### PR TITLE
Fix Liquiditätsplan YAML fallback

### DIFF
--- a/forderungsmanagement-klagewerkstatt/CLAUDE.md
+++ b/forderungsmanagement-klagewerkstatt/CLAUDE.md
@@ -30,6 +30,6 @@ Verbindliche Regeln für jeden Lauf in diesem Plugin. Gilt für beide Skills.
 
 ## Übergabe
 
-- Bei drohender Zahlungsunfähigkeit der Beklagten an `liquiditaetsplanung`.
+- Bei drohender Zahlungsunfähigkeit der Beklagten an Liquiditätsplanung (`liquiditaetsplanung`).
 - Bei einstweiligem Rechtsschutz / Mahnverfahren an `prozessrecht`.
 - Wiederverwendung beim nächsten Mal über den Laufzeit-Skill `klage-aus-eigenem-skill`.

--- a/forderungsmanagement-klagewerkstatt/README.md
+++ b/forderungsmanagement-klagewerkstatt/README.md
@@ -10,7 +10,7 @@
 | --- | --- |
 | **forderungsmanagement-klagewerkstatt** (dieses Plugin) | [forderungsmanagement-klagewerkstatt.zip](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/forderungsmanagement-klagewerkstatt.zip) |
 | prozessrecht (sinnvolle Ergänzung) | [prozessrecht.zip](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/prozessrecht.zip) |
-| liquiditaetsplanung (Folgeprüfung) | [liquiditaetsplanung.zip](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/liquiditaetsplanung.zip) |
+| Liquiditätsplanung (`liquiditaetsplanung`, Folgeprüfung) | [liquiditaetsplanung.zip](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/liquiditaetsplanung.zip) |
 
 Die URLs sind **stabil** und zeigen immer auf die neueste Version. Alle weiteren Plugins (Vertragsrecht, Arbeitsrecht, Datenschutz, …) liegen unter [Releases · latest](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest).
 

--- a/forderungsmanagement-klagewerkstatt/scripts/plugin_aus_hausregeln.py
+++ b/forderungsmanagement-klagewerkstatt/scripts/plugin_aus_hausregeln.py
@@ -212,7 +212,7 @@ Felder automatisch belegen.
 
 ## Übergabe
 
-- Bei drohender Zahlungsunfähigkeit der Beklagten an `liquiditaetsplanung`.
+- Bei drohender Zahlungsunfähigkeit der Beklagten an Liquiditätsplanung (`liquiditaetsplanung`).
 - Bei einstweiligem Rechtsschutz / Mahnverfahren an `prozessrecht`.
 - Wenn die Hausvorlage veraltet wirkt, zurück an den Schwester-Skill
   `klagevorlage-aus-eigenen-mustern` im Plugin `forderungsmanagement-klagewerkstatt`

--- a/forderungsmanagement-klagewerkstatt/skills/klagevorlage-aus-eigenen-mustern/SKILL.md
+++ b/forderungsmanagement-klagewerkstatt/skills/klagevorlage-aus-eigenen-mustern/SKILL.md
@@ -165,6 +165,6 @@ Mindestens zwei BGH-Belege (jüngere zuerst) und zwei Kommentarbelege im Bearbei
 
 ## Übergabe
 
-- Bei drohender Zahlungsunfähigkeit der Beklagten an `liquiditaetsplanung` (Plugin) zur Schnellprüfung.
+- Bei drohender Zahlungsunfähigkeit der Beklagten an Liquiditätsplanung (`liquiditaetsplanung`) zur Schnellprüfung.
 - Bei einstweiligem Rechtsschutz/Mahnverfahren an `prozessrecht` (Plugin) verweisen.
 - Wenn der Nutzer beim nächsten Mal nur den Sachverhalt einreichen will: Schwester-Skill `klage-aus-eigenem-skill` mit dem im Schritt 8 erzeugten Plugin verwenden.

--- a/insolvenzrecht/skills/liquiditaetsvorschau-insolvenzrechtlich/SKILL.md
+++ b/insolvenzrecht/skills/liquiditaetsvorschau-insolvenzrechtlich/SKILL.md
@@ -25,7 +25,7 @@ when_to_use: |
 
 ## Powerplugin-Hinweis
 
-**Die fachlich aktualisierte und autarke Version dieses Skills lebt im Plugin `liquiditaetsplanung`** (Power-Plugin Liquiditätsvorschau) — mit dem strikten BGH-Schema (Passiva II zwingend, BGHZ 217, 129; 10-%-Schwelle BGHZ 163, 134; Bugwellenrspr. BGH II ZR 112/21; titulierte Forderungen BGH IX ZR 229/22; objektive Beurteilung BGH II ZR 139/23), Excel-Vorlage, optionalem HTML-Padlet oder Markdown-Artefakt und Banking-Wahl. PDFs liegen im Plugin unter `references/rechtsprechung/`. Wenn `liquiditaetsplanung` installiert ist, dorthin übergeben oder dessen Belege beim Erstellen der gerichtsfesten Liquiditätsbilanz beiziehen.
+**Die fachlich aktualisierte und autarke Version dieses Skills lebt im Plugin Liquiditätsplanung (`liquiditaetsplanung`)** (Power-Plugin Liquiditätsvorschau) — mit dem strikten BGH-Schema (Passiva II zwingend, BGHZ 217, 129; 10-%-Schwelle BGHZ 163, 134; Bugwellenrspr. BGH II ZR 112/21; titulierte Forderungen BGH IX ZR 229/22; objektive Beurteilung BGH II ZR 139/23), Excel-Vorlage, optionalem HTML-Padlet oder Markdown-Artefakt und Banking-Wahl. PDFs liegen im Plugin unter `references/rechtsprechung/`. Wenn `liquiditaetsplanung` installiert ist, dorthin übergeben oder dessen Belege beim Erstellen der gerichtsfesten Liquiditätsbilanz beiziehen.
 
 ## Zweck
 

--- a/liquiditaetsplanung/CLAUDE.md
+++ b/liquiditaetsplanung/CLAUDE.md
@@ -1,4 +1,4 @@
-# Plugin liquiditaetsplanung – Modellhinweise
+# Plugin Liquiditätsplanung (`liquiditaetsplanung`) – Modellhinweise
 
 Dieses Plugin ist **autark**. Es funktioniert als **eigenständiges Power-Plugin Liquiditätsvorschau**. Wenn `insolvenzrecht` und/oder `steuerberater-werkzeuge` ebenfalls installiert sind, werden Übergaben angeboten — sie sind aber keine Voraussetzung.
 

--- a/liquiditaetsplanung/README.md
+++ b/liquiditaetsplanung/README.md
@@ -8,7 +8,7 @@
 
 | Plugin | Direkt-Download |
 | --- | --- |
-| **liquiditaetsplanung** (dieses Plugin) | [liquiditaetsplanung.zip](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/liquiditaetsplanung.zip) |
+| **Liquiditätsplanung** (`liquiditaetsplanung`, dieses Plugin) | [liquiditaetsplanung.zip](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/liquiditaetsplanung.zip) |
 | insolvenzrecht | [insolvenzrecht.zip](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/insolvenzrecht.zip) |
 | steuerberater-werkzeuge | [steuerberater-werkzeuge.zip](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/steuerberater-werkzeuge.zip) |
 

--- a/scripts/agentenrezept-ausliefern.sh
+++ b/scripts/agentenrezept-ausliefern.sh
@@ -12,7 +12,7 @@
 # so their JSON is schema-checked before the orchestrator consumes it.
 #
 # Usage: scripts/agentenrezept-ausliefern.sh <slug>
-#   e.g. scripts/agentenrezept-ausliefern.sh reg-monitor
+#   e.g. scripts/agentenrezept-ausliefern.sh aufsichts-monitor
 
 set -euo pipefail
 

--- a/scripts/validate-plugin-structure.mjs
+++ b/scripts/validate-plugin-structure.mjs
@@ -106,12 +106,12 @@ function checkMarketplace() {
       }
     }
     if (plugin.name === 'liquiditaetsplanung') {
-      // liquiditaetsplanung is the standalone Power-Plugin Liquiditaetsvorschau.
+      // liquiditaetsplanung is the standalone Power-Plugin Liquiditätsvorschau.
       // It MUST work without insolvenzrecht/steuerberater-werkzeuge. Dependencies are
       // therefore optional (recommended companions, not required), but its own skills
       // must exist and be self-contained.
       const skills = walk(path.join(pluginRoot, 'skills'), f => path.basename(f) === 'SKILL.md');
-      if (skills.length === 0) errors.push(`${plugin.name}: expected autark Liquiditaetsvorschau skills`);
+      if (skills.length === 0) errors.push(`${plugin.name}: expected autark Liquiditätsvorschau skills`);
       for (const required of ['liquiditaetsvorschau-3wochen', 'liquiditaetsvorschau-3-6-12-monate', 'liquiditaetsvorschau-insolvenzrechtlich']) {
         const sp = path.join(pluginRoot, 'skills', required, 'SKILL.md');
         if (!exists(sp)) errors.push(`${plugin.name}: missing required standalone skill ${required}`);

--- a/steuerberater-werkzeuge/skills/liquiditaetsvorschau-3-6-12-monate/SKILL.md
+++ b/steuerberater-werkzeuge/skills/liquiditaetsvorschau-3-6-12-monate/SKILL.md
@@ -23,7 +23,7 @@ when_to_use: |
 
 ## Powerplugin-Hinweis
 
-**Die vollständige, fachlich autarke Version dieses Skills lebt im Plugin `liquiditaetsplanung`** (Power-Plugin Liquiditätsvorschau) — mit BGH-Schema Passiva II (BGHZ 217, 129), Volumeneffekt der Quote, Bugwellenrspr. (BGH II ZR 112/21), 10-%-Schwelle (BGH IX ZR 48/21), titulierten Forderungen mit Nennwert (BGH IX ZR 229/22), objektiver Beurteilung (BGH II ZR 139/23), Excel-Vorlage, optionalem HTML-Padlet oder Markdown-Artefakt, Banking-Wahl und Memo-nur-auf-Anfrage. Wenn `liquiditaetsplanung` installiert ist, dorthin übergeben.
+**Die vollständige, fachlich autarke Version dieses Skills lebt im Plugin Liquiditätsplanung (`liquiditaetsplanung`)** (Power-Plugin Liquiditätsvorschau) — mit BGH-Schema Passiva II (BGHZ 217, 129), Volumeneffekt der Quote, Bugwellenrspr. (BGH II ZR 112/21), 10-%-Schwelle (BGH IX ZR 48/21), titulierten Forderungen mit Nennwert (BGH IX ZR 229/22), objektiver Beurteilung (BGH II ZR 139/23), Excel-Vorlage, optionalem HTML-Padlet oder Markdown-Artefakt, Banking-Wahl und Memo-nur-auf-Anfrage. Wenn `liquiditaetsplanung` installiert ist, dorthin übergeben.
 
 Wenn nicht installiert, hier nach dem Steuerberater-spezifischen Schema arbeiten und am Ende die Hinweispflicht nach § 102 StaRUG dokumentieren.
 

--- a/steuerberater-werkzeuge/skills/liquiditaetsvorschau-3-6-12-monate/werkzeuge/build_liquiditaetsplan.py
+++ b/steuerberater-werkzeuge/skills/liquiditaetsvorschau-3-6-12-monate/werkzeuge/build_liquiditaetsplan.py
@@ -84,11 +84,175 @@ def load_input(path: Path) -> dict[str, Any]:
     text = path.read_text(encoding="utf-8")
     if path.suffix.lower() in {".yaml", ".yml"}:
         if yaml is None:
-            raise SystemExit("PyYAML nicht installiert – bitte `pip install pyyaml`.")
-        return yaml.safe_load(text)
+            return load_simple_yaml(text, path)
+        return yaml.safe_load(text) or {}
     if path.suffix.lower() == ".json":
         return json.loads(text)
     raise SystemExit(f"Unbekanntes Eingabeformat: {path.suffix}")
+
+
+def load_simple_yaml(text: str, path: Path) -> dict[str, Any]:
+    """Kleiner YAML-Fallback für die mitgelieferten Akten, falls PyYAML fehlt."""
+    root: dict[Any, Any] = {}
+    stack: list[tuple[int, dict[Any, Any] | list[Any]]] = [(-1, root)]
+    lines: list[tuple[int, int, str]] = []
+
+    for lineno, raw_line in enumerate(text.splitlines(), start=1):
+        if "\t" in raw_line[: len(raw_line) - len(raw_line.lstrip())]:
+            raise SystemExit(f"{path}:{lineno}: Tabs in Einrückungen werden nicht unterstützt.")
+
+        line = strip_yaml_comment(raw_line).rstrip()
+        if not line.strip():
+            continue
+
+        indent = len(line) - len(line.lstrip(" "))
+        content = line[indent:]
+        lines.append((lineno, indent, content))
+
+    for index, (lineno, indent, content) in enumerate(lines):
+        while indent <= stack[-1][0]:
+            stack.pop()
+        parent = stack[-1][1]
+
+        if content.startswith("- "):
+            if not isinstance(parent, list):
+                raise SystemExit(f"{path}:{lineno}: YAML-Liste ohne Listenkontext.")
+
+            item_text = content[2:].strip()
+            split_at = find_yaml_key_separator(item_text)
+            if item_text and split_at is not None:
+                item: dict[Any, Any] = {}
+                parent.append(item)
+                stack.append((indent, item))
+
+                key_text = item_text[:split_at].strip()
+                value_text = item_text[split_at + 1:].strip()
+                if not key_text:
+                    raise SystemExit(f"{path}:{lineno}: Leerer YAML-Schlüssel.")
+                key = parse_yaml_scalar(key_text)
+                if value_text == "":
+                    child: dict[Any, Any] | list[Any]
+                    child = [] if next_yaml_child_is_list(lines, index, indent) else {}
+                    item[key] = child
+                    stack.append((next_yaml_child_stack_indent(lines, index, indent), child))
+                else:
+                    item[key] = parse_yaml_scalar(value_text)
+            elif item_text:
+                parent.append(parse_yaml_scalar(item_text))
+            else:
+                item = {}
+                parent.append(item)
+                stack.append((next_yaml_child_stack_indent(lines, index, indent), item))
+            continue
+
+        if not isinstance(parent, dict):
+            raise SystemExit(f"{path}:{lineno}: YAML-Schlüssel ohne Mapping-Kontext.")
+
+        split_at = find_yaml_key_separator(content)
+        if split_at is None:
+            raise SystemExit(f"{path}:{lineno}: YAML-Zeile nicht verstanden: {content!r}")
+
+        key_text = content[:split_at].strip()
+        value_text = content[split_at + 1:].strip()
+        if not key_text:
+            raise SystemExit(f"{path}:{lineno}: Leerer YAML-Schlüssel.")
+
+        key = parse_yaml_scalar(key_text)
+
+        if value_text == "":
+            child: dict[Any, Any] | list[Any]
+            child = [] if next_yaml_child_is_list(lines, index, indent) else {}
+            parent[key] = child
+            stack.append((next_yaml_child_stack_indent(lines, index, indent), child))
+        else:
+            parent[key] = parse_yaml_scalar(value_text)
+
+    return root
+
+
+def next_yaml_child_is_list(lines: list[tuple[int, int, str]], index: int, indent: int) -> bool:
+    for _, next_indent, content in lines[index + 1:]:
+        if next_indent <= indent:
+            return False
+        if next_indent > indent:
+            return content.startswith("- ")
+    return False
+
+
+def next_yaml_child_stack_indent(lines: list[tuple[int, int, str]], index: int, indent: int) -> int:
+    for _, next_indent, _ in lines[index + 1:]:
+        if next_indent > indent:
+            return next_indent - 1
+    return indent
+
+
+def strip_yaml_comment(line: str) -> str:
+    quote: str | None = None
+    escaped = False
+    for i, ch in enumerate(line):
+        if quote == '"':
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
+                quote = None
+        elif quote == "'":
+            if ch == quote:
+                quote = None
+        else:
+            if ch in {"'", '"'}:
+                quote = ch
+            elif ch == "#":
+                return line[:i]
+    return line
+
+
+def find_yaml_key_separator(content: str) -> int | None:
+    quote: str | None = None
+    escaped = False
+    for i, ch in enumerate(content):
+        if quote == '"':
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
+                quote = None
+        elif quote == "'":
+            if ch == quote:
+                quote = None
+        else:
+            if ch in {"'", '"'}:
+                quote = ch
+            elif ch == ":":
+                return i
+    return None
+
+
+def parse_yaml_scalar(value: str) -> Any:
+    if value.startswith('"') and value.endswith('"'):
+        return json.loads(value)
+    if value.startswith("'") and value.endswith("'"):
+        return value[1:-1].replace("''", "'")
+
+    lower = value.lower()
+    if lower in {"null", "~"}:
+        return None
+    if lower == "true":
+        return True
+    if lower == "false":
+        return False
+
+    normalized = value.replace("_", "")
+    try:
+        return int(normalized)
+    except ValueError:
+        pass
+    try:
+        return float(normalized)
+    except ValueError:
+        return value
 
 
 # ----------------------------------------------------------------------------

--- a/steuerberater-werkzeuge/skills/liquiditaetsvorschau-3wochen/SKILL.md
+++ b/steuerberater-werkzeuge/skills/liquiditaetsvorschau-3wochen/SKILL.md
@@ -18,7 +18,7 @@ when_to_use: |
 
 ## Powerplugin-Hinweis
 
-**Die vollständige, fachlich autarke Version dieses Skills lebt im Plugin `liquiditaetsplanung`** (Power-Plugin Liquiditätsvorschau) — mit BGH-Schema Passiva II (BGHZ 217, 129), Volumeneffekt der Quote, titulierten Forderungen mit Nennwert (BGH IX ZR 229/22), objektiver Beurteilung (BGH II ZR 139/23), Excel-Vorlage, optionalem HTML-Padlet oder Markdown-Artefakt und Banking-Wahl. Wenn `liquiditaetsplanung` installiert ist, dorthin übergeben.
+**Die vollständige, fachlich autarke Version dieses Skills lebt im Plugin Liquiditätsplanung (`liquiditaetsplanung`)** (Power-Plugin Liquiditätsvorschau) — mit BGH-Schema Passiva II (BGHZ 217, 129), Volumeneffekt der Quote, titulierten Forderungen mit Nennwert (BGH IX ZR 229/22), objektiver Beurteilung (BGH II ZR 139/23), Excel-Vorlage, optionalem HTML-Padlet oder Markdown-Artefakt und Banking-Wahl. Wenn `liquiditaetsplanung` installiert ist, dorthin übergeben.
 
 Wenn nicht installiert, hier nach dem Steuerberater-spezifischen Schema arbeiten und am Ende ausdrücklich die Hinweispflicht nach § 102 StaRUG dokumentieren.
 


### PR DESCRIPTION
## Änderungen
- Liquiditätsplan-Generator liest YAML-Beispielakten jetzt auch ohne installierte PyYAML-Abhängigkeit.
- Fallback-Parser unterstützt einfache YAML-Mappings, verschachtelte Mappings, einfache Listen und skalare Werte.
- Sichtbare Nutzertexte nennen sauber „Liquiditätsplanung“; technische Slugs und Download-URLs bleiben stabil.
- Stale Beispiel im Agentenrezept-Auslieferungsskript korrigiert.

## Ursache
Der mitgelieferte Generator akzeptierte YAML-Dateien laut Skill-Dokumentation, brach in der Codex-Runtime aber ab, wenn PyYAML nicht installiert war.

## Validierung
- `node scripts/validate-plugin-structure.mjs`
- `npx --yes @anthropic-ai/claude-code@latest plugin validate .`
- Einzelvalidierung der betroffenen Plugins: `steuerberater-werkzeuge`, `liquiditaetsplanung`, `insolvenzrecht`, `forderungsmanagement-klagewerkstatt`
- `git diff --check origin/main..HEAD`
- Python-Compile für betroffene Skripte
- XLSX-Erzeugung aus `examples/beispielakte-edelholz-berlin/mandant.yaml` mit `openpyxl`-Load-Check
- ZIP-Erzeugung des Klagewerkstatt-Generators