### PR TITLE
Fix plugin ZIP packaging for desktop upload

### DIFF
--- a/.github/workflows/release-plugin-zips.yml
+++ b/.github/workflows/release-plugin-zips.yml
@@ -46,7 +46,7 @@ jobs:
           mkdir -p dist
           for plugin in ${{ steps.plugins.outputs.names }}; do
             echo "Baue $plugin.zip"
-            zip -rq "dist/${plugin}.zip" "$plugin" -x '*.DS_Store'
+            (cd "$plugin" && zip -rq "../dist/${plugin}.zip" . -x '*.DS_Store' '__pycache__/*' '*.pyc')
             ls -la "dist/${plugin}.zip"
           done
           # Manifest fuer Marketplace-Komfort

--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ Einfachster Weg in Claude Desktop oder der Cowork-Oberfläche:
 
 Wenn kein Marketplace-Manifest verwendet werden soll oder eine bestimmte Version festgehalten werden muss:
 
-1. Auf https://github.com/Klotzkette/claude-fuer-deutsches-recht das Release **v1.0** öffnen (oder **Code → Download ZIP** vom `main`-Branch).
-2. In Cowork **Customize → Plugin** öffnen und über **+ → Create → Upload plugin** das ZIP hochladen.
+1. Das gewünschte einzelne Plugin-ZIP aus dem neuesten Release herunterladen, z. B. `liquiditaetsplanung.zip` von https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest.
+2. In Cowork **Customize → Plugin** öffnen und über **+ → Create → Upload plugin** dieses einzelne Plugin-ZIP hochladen.
 3. Nach dem Upload erscheint das Plugin in der Plugin-Liste und kann aktiviert werden.
 
-**Wichtig:** Das ZIP muss die korrekte Verzeichnisstruktur enthalten — `SKILL.md` auf der jeweils obersten Skill-Ebene (z. B. `arbeitsrecht/skills/<skill-name>/SKILL.md`). Andernfalls vor dem Upload neu komprimieren.
+**Wichtig:** Nicht das komplette Repository-ZIP aus **Code → Download ZIP** hochladen. Ein Upload-ZIP muss direkt `.claude-plugin/plugin.json`, `skills/`, `assets/` usw. im ZIP-Root enthalten.
 
 ### Weg 3 — Marketplace-Kommando (Claude Code im Terminal)
 

--- a/liquiditaetsplanung/README.md
+++ b/liquiditaetsplanung/README.md
@@ -20,6 +20,8 @@ Die URLs sind **stabil** und zeigen immer auf die neueste Version. Alle weiteren
 2. Claude Code → **Customize Plugins** → **Install from .zip** → Datei wählen.
 3. Fertig. Skills sind sofort verfügbar.
 
+Hinweis: Für den ZIP-Upload muss das Archiv direkt `.claude-plugin/plugin.json`, `skills/`, `assets/` und `references/` im ZIP-Root enthalten. Nicht das komplette Repository-ZIP aus **Code → Download ZIP** verwenden.
+
 ### Zum Ausprobieren: Beispielakte (separat)
 
 Fiktive Mandatsakte zum sofortigen Testen — **kein Teil des Plugins**, separater Download:


### PR DESCRIPTION
## Änderungen
- Release-Workflow baut einzelne Plugin-ZIPs jetzt flach aus dem Plugin-Root statt mit verschachteltem Top-Level-Ordner.
- README korrigiert den manuellen ZIP-Upload: kein komplettes Repository-ZIP hochladen, sondern einzelne Release-ZIPs verwenden.
- Liquiditätsplanung-README ergänzt den Hinweis, dass `.claude-plugin/plugin.json` direkt im ZIP-Root liegen muss.

## Ursache
Desktop-/Cowork-Upload-Validatoren können ZIPs ablehnen, wenn `.claude-plugin/plugin.json` nicht direkt im ZIP-Root liegt. Die bisherigen Release-ZIPs enthielten stattdessen `liquiditaetsplanung/.claude-plugin/plugin.json`.

## Validierung
- `node scripts/validate-plugin-structure.mjs`
- `npx --yes @anthropic-ai/claude-code@latest plugin validate .`
- Lokales Flat-ZIP simuliert und geprüft: `.claude-plugin/plugin.json` direkt im Root, Generator enthalten, kein verschachtelter `liquiditaetsplanung/`-Root
- Entpacktes Flat-ZIP mit Claude Plugin Validator geprüft