### PR TITLE
Handle BOM input in liquidity generator

### DIFF
--- a/liquiditaetsplanung/skills/liquiditaetsvorschau-3-6-12-monate/werkzeuge/build_liquiditaetsplan.py
+++ b/liquiditaetsplanung/skills/liquiditaetsvorschau-3-6-12-monate/werkzeuge/build_liquiditaetsplan.py
@@ -81,7 +81,7 @@ except ImportError:
 # ----------------------------------------------------------------------------
 
 def load_input(path: Path) -> dict[str, Any]:
-    text = path.read_text(encoding="utf-8")
+    text = path.read_text(encoding="utf-8-sig")
     if path.suffix.lower() in {".yaml", ".yml"}:
         if yaml is None:
             return load_simple_yaml(text, path)

--- a/steuerberater-werkzeuge/skills/liquiditaetsvorschau-3-6-12-monate/werkzeuge/build_liquiditaetsplan.py
+++ b/steuerberater-werkzeuge/skills/liquiditaetsvorschau-3-6-12-monate/werkzeuge/build_liquiditaetsplan.py
@@ -81,7 +81,7 @@ except ImportError:
 # ----------------------------------------------------------------------------
 
 def load_input(path: Path) -> dict[str, Any]:
-    text = path.read_text(encoding="utf-8")
+    text = path.read_text(encoding="utf-8-sig")
     if path.suffix.lower() in {".yaml", ".yml"}:
         if yaml is None:
             return load_simple_yaml(text, path)


### PR DESCRIPTION
## Ursache

Beim Test des öffentlichen `liquiditaetsplanung.zip` lief die Plugin-Validierung durch, aber der Standalone-Generator scheiterte an JSON/YAML-Dateien mit UTF-8-BOM. Das passiert auf Windows leicht, z. B. bei PowerShell/Editor-Ausgaben.

## Änderung

- Der Liquiditätsplan-Generator liest Eingaben mit `utf-8-sig`.
- Die Änderung ist in beiden Generator-Kopien enthalten: `liquiditaetsplanung` und `steuerberater-werkzeuge`.

## Validierung

- BOM-JSON-Testdaten erzeugt
- Beide Generatoren ausgeführt
- Beide XLSX-Ausgaben mit `openpyxl` geladen und erwartete Sheets geprüft
- `node scripts/validate-plugin-structure.mjs`
- `npx --yes @anthropic-ai/claude-code@latest plugin validate liquiditaetsplanung`
- `npx --yes @anthropic-ai/claude-code@latest plugin validate steuerberater-werkzeuge`
- Release-ZIP-Simulation mit `scripts/validate-release-zips.py` für 17 Plugin-ZIPs