### PR TITLE
Make release ZIPs clean for Cowork upload

### DIFF
--- a/.github/workflows/release-plugin-zips.yml
+++ b/.github/workflows/release-plugin-zips.yml
@@ -46,7 +46,7 @@ jobs:
           mkdir -p dist
           for plugin in ${{ steps.plugins.outputs.names }}; do
             echo "Baue $plugin.zip"
-            (cd "$plugin" && zip -rq "../dist/${plugin}.zip" . -x '*.DS_Store' '__pycache__/*' '*.pyc')
+            (cd "$plugin" && zip -rq "../dist/${plugin}.zip" . -x '*.DS_Store' '__pycache__/*' '*.pyc' 'CLAUDE.md')
             ls -la "dist/${plugin}.zip"
           done
           # Manifest fuer Marketplace-Komfort

--- a/betreuungsrecht/.claude-plugin/plugin.json
+++ b/betreuungsrecht/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "betreuungsrecht",
   "version": "0.1.1",
-  "description": "Skills für berufliche Betreuer nach BtOG und §§ 1814 ff. BGB: Jahresbericht ans Betreuungsgericht (§ 1863 BGB), Vermögensverzeichnis und Rechnungslegung (§§ 1835 ff. BGB), Genehmigungspflicht-Prüfung (§§ 1848 ff. BGB). Praxis für Berufsbetreuer, Vereinsbetreuer und Betreuungsbehörden. Maßgeblich Reform 2023, einschlägige BGH-Rechtsprechung sowie Kommentarliteratur (Grüneberg, MünchKomm).",
+  "description": "Betreuungsrechtliche Skills für Jahresbericht, Vermögensverzeichnis und Genehmigungspflichten nach BtOG und BGB.",
   "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"

--- a/forderungsmanagement-klagewerkstatt/.claude-plugin/plugin.json
+++ b/forderungsmanagement-klagewerkstatt/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "forderungsmanagement-klagewerkstatt",
   "version": "0.1.0",
-  "description": "Generalisierter Klage-Assistent für Forderungsmanagement-Klagen mit eigenem Plugin-Generator. Aus eigenen Klagemustern, Urteilen, Kommentaren, Aufsätzen und Formatvorlagen destilliert der Skill eine hauseigene Standardklage-Vorlage, sammelt den Sachverhalt, prüft online die örtliche und sachliche Zuständigkeit (justizadressen.nrw.de, justiz.de Gerichtssuche; §§ 12, 13, 29, 29c ZPO; §§ 23, 71 GVG) und liefert die fertige Klage als DOCX und Markdown. Zusätzlich erzeugt der Skill ein eigenes, sofort in Claude Code installierbares Mini-Plugin (ZIP), mit dem die nächste Klage ohne Extraktionsschritt direkt in der hauseigenen Vorlage entsteht. Eigenständig nutzbar; ergänzt sich mit prozessrecht, vertragsrecht und liquiditaetsplanung, hängt aber nicht davon ab.",
+  "description": "Klagewerkstatt für Forderungsmanagement mit Zuständigkeitsprüfung, Standardklage und optionalem Kanzlei-Mini-Plugin.",
   "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"

--- a/insolvenzrecht/.claude-plugin/plugin.json
+++ b/insolvenzrecht/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "insolvenzrecht",
   "version": "0.1.1",
-  "description": "Insolvenzrechtliche Skills: Liquiditätsvorschau zur Prüfung der Zahlungsunfähigkeit (§ 17 InsO), Überschuldungsstatus (§ 19 InsO) mit Fortbestehensprognose, Antragspflicht des Geschäftsleiters (§ 15a InsO), Gläubigerantrag-Prüfung. Praxis für Insolvenzverwalter, beratende Anwälte, Geschäftsführer, Sanierungsberater (StaRUG) und Wirtschaftsprüfer. Maßgeblich BGH-Rechtsprechung sowie IDW S 11/S 9/S 6.",
+  "description": "Insolvenzrechtliche Skills zu Zahlungsunfähigkeit, Überschuldung, Antragspflicht und Gläubigerantrag.",
   "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"

--- a/liquiditaetsplanung/.claude-plugin/plugin.json
+++ b/liquiditaetsplanung/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "liquiditaetsplanung",
   "version": "0.2.1",
-  "description": "Eigenständiges Power-Plugin Liquiditätsvorschau nach deutschem Recht. Wochenaktuelle 3-Wochen-Vorschau (§ 17 InsO), rollierende 13/26/52-Wochen-Planung und gerichtsfeste Liquiditätsbilanz nach BGH-Schema (BGHZ 217, 129 Passiva II; BGHZ 163, 134 10-%-Schwelle/3-Wochen-Horizont; BGH 28.06.2022 II ZR 112/21; BGH 28.04.2022 IX ZR 48/21; BGH 23.01.2025 IX ZR 229/22; BGH 11.03.2025 II ZR 139/23). Erzeugt zwingend eine Excel-Tabelle nach hinterlegter Vorlage und auf Wunsch ein interaktives HTML-Padlet oder Markdown-Artefakt. Banking optional (manuell, Datei-Import CAMT.053/MT940/CSV/DATEV-OPOS, Connector). Memo nur auf Anfrage. Voll autark; ergänzt sich mit den Plugins insolvenzrecht und steuerberater-werkzeuge, hängt aber nicht davon ab.",
+  "description": "Autarke Liquiditätsplanung nach deutschem Recht mit 3-Wochen-Vorschau, 13/26/52-Wochen-Planung und Excel-Export.",
   "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"

--- a/prozessrecht/.claude-plugin/plugin.json
+++ b/prozessrecht/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prozessrecht",
   "version": "1.0.0",
-  "description": "Prozessrecht – Zivil-, Straf-, Verwaltungs- und Arbeitsgerichtsverfahren: Mandatsportfolio, Fristen, Mahnbescheid §§ 688 ff. ZPO, einstweilige Verfügung und Schutzschrift, Zwangsvollstreckung, Verkehrsunfall, Schriftsatzentwürfe, Anhörungsrüge, Beweismittel ohne Discovery.",
+  "description": "Prozessrechtliche Skills für Mandate, Fristen, Mahnbescheid, Eilverfahren, Vollstreckung und Schriftsätze.",
   "author": {
     "name": "Klotzkette"
   }

--- a/scripts/validate-release-zips.py
+++ b/scripts/validate-release-zips.py
@@ -47,6 +47,8 @@ def validate_plugin_zip(dist_dir: Path, plugin_name: str) -> None:
         fail(f"{zip_path}: ZIP is nested under {plugin_name}/; upload ZIPs must be flat")
     if any(name.startswith(f"{plugin_name}/") for name in names):
         fail(f"{zip_path}: contains nested {plugin_name}/ root")
+    if "CLAUDE.md" in names:
+        fail(f"{zip_path}: root CLAUDE.md must not be shipped; Claude Code treats it as a warning and Cowork upload may reject it")
     if any("__pycache__/" in name or name.endswith(".pyc") for name in names):
         fail(f"{zip_path}: contains Python cache files")
 

--- a/steuerberater-werkzeuge/.claude-plugin/plugin.json
+++ b/steuerberater-werkzeuge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "steuerberater-werkzeuge",
-  "description": "Werkzeugbox für Steuerberater und Geschäftsleitung kleiner GmbHs/UGs: BWA-, SuSa- und Belegprüfung, Krisenfrüherkennung (§§ 17, 19 InsO, § 1 StaRUG, § 102 StaRUG-Warnpflicht). Für die rollierende Liquiditätsplanung siehe das eigene Plugin `liquiditaetsplanung`.",
+  "description": "Werkzeugbox für Steuerberater mit BWA-, SuSa- und Belegprüfung sowie Krisenfrüherkennung.",
   "version": "0.1.1",
   "author": {
     "name": "Klotzkette"


### PR DESCRIPTION
## Ursache

Das lokale `main.log` zeigt keine konkrete Validator-Fehlermeldung, aber ein klares Muster: mehrere vollständige `liquiditaetsplanung`-ZIPs wurden hochgeladen, danach erschien kein `Installed plugin`; erst ein minimales Test-ZIP wurde installiert. Die vollständigen Release-ZIPs enthielten noch `CLAUDE.md` im Plugin-Root. Claude Code validiert das lokal nur mit Warnung, Cowork/Remote-Upload kann solche Warnungen aber als `plugin validation failed` behandeln.

## Änderung

- Release-Workflow schließt Root-`CLAUDE.md` aus Plugin-ZIPs aus.
- Release-ZIP-Validator blockt künftig Root-`CLAUDE.md` im ZIP.
- Lange Manifestbeschreibungen werden gekürzt, besonders `liquiditaetsplanung`, damit der Remote-Uploader nur knappe Plugin-Metadaten bekommt.

## Validierung

- `node scripts/validate-plugin-structure.mjs`
- `npx --yes @anthropic-ai/claude-code@latest plugin validate .`
- Release-ZIP-Simulation für alle 17 Plugins
- `scripts/validate-release-zips.py` gegen die simulierten ZIPs
- Alle 17 simulierten Plugin-ZIPs entpackt und einzeln mit `npx --yes @anthropic-ai/claude-code@latest plugin validate <extract>` validiert; alle ohne Root-`CLAUDE.md`-Warnung