### PR TITLE
Package release ZIPs for Cowork upload

### DIFF
--- a/.github/workflows/release-plugin-zips.yml
+++ b/.github/workflows/release-plugin-zips.yml
@@ -3,7 +3,7 @@ name: Release Plugin ZIPs
 # Baut bei jedem Tag oder bei manueller Ausloesung pro Plugin eine ZIP-Datei
 # und haengt sie an den GitHub Release. Damit ergeben sich stabile Download-URLs:
 #   https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/<plugin>.zip
-# Direkt einzeln in Claude Code (Customize Plugins) installierbar.
+# Direkt einzeln in Claude Code/Cowork (Customize Plugins) installierbar.
 
 on:
   push:
@@ -46,7 +46,7 @@ jobs:
           mkdir -p dist
           for plugin in ${{ steps.plugins.outputs.names }}; do
             echo "Baue $plugin.zip"
-            (cd "$plugin" && zip -rq "../dist/${plugin}.zip" . -x '*.DS_Store' '__pycache__/*' '*.pyc' 'CLAUDE.md')
+            zip -rq "dist/${plugin}.zip" "$plugin" -x '*.DS_Store' '*/__pycache__/*' '*.pyc' "${plugin}/CLAUDE.md"
             ls -la "dist/${plugin}.zip"
           done
           # Manifest fuer Marketplace-Komfort

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Wenn kein Marketplace-Manifest verwendet werden soll oder eine bestimmte Version
 2. In Cowork **Customize → Plugin** öffnen und über **+ → Create → Upload plugin** dieses einzelne Plugin-ZIP hochladen.
 3. Nach dem Upload erscheint das Plugin in der Plugin-Liste und kann aktiviert werden.
 
-**Wichtig:** Nicht das komplette Repository-ZIP aus **Code → Download ZIP** hochladen. Ein Upload-ZIP muss direkt `.claude-plugin/plugin.json`, `skills/`, `assets/` usw. im ZIP-Root enthalten.
+**Wichtig:** Nicht das komplette Repository-ZIP aus **Code → Download ZIP** hochladen. Das Release-ZIP enthält genau einen Plugin-Ordner, z. B. `liquiditaetsplanung/.claude-plugin/plugin.json`, und ist so für Cowork-Upload gebaut.
 
 ### Weg 3 — Marketplace-Kommando (Claude Code im Terminal)
 

--- a/liquiditaetsplanung/README.md
+++ b/liquiditaetsplanung/README.md
@@ -20,7 +20,7 @@ Die URLs sind **stabil** und zeigen immer auf die neueste Version. Alle weiteren
 2. Claude Code → **Customize Plugins** → **Install from .zip** → Datei wählen.
 3. Fertig. Skills sind sofort verfügbar.
 
-Hinweis: Für den ZIP-Upload muss das Archiv direkt `.claude-plugin/plugin.json`, `skills/`, `assets/` und `references/` im ZIP-Root enthalten. Nicht das komplette Repository-ZIP aus **Code → Download ZIP** verwenden.
+Hinweis: Für den ZIP-Upload muss das Release-Archiv genau einen Plugin-Ordner enthalten, z. B. `liquiditaetsplanung/.claude-plugin/plugin.json`. Nicht das komplette Repository-ZIP aus **Code → Download ZIP** verwenden.
 
 ### Zum Ausprobieren: Beispielakte (separat)
 

--- a/scripts/validate-release-zips.py
+++ b/scripts/validate-release-zips.py
@@ -41,24 +41,29 @@ def validate_plugin_zip(dist_dir: Path, plugin_name: str) -> None:
         )
 
     names = zip_names(zip_path)
-    if ".claude-plugin/plugin.json" not in names:
-        fail(f"{zip_path}: .claude-plugin/plugin.json must be at ZIP root")
-    if f"{plugin_name}/.claude-plugin/plugin.json" in names:
-        fail(f"{zip_path}: ZIP is nested under {plugin_name}/; upload ZIPs must be flat")
-    if any(name.startswith(f"{plugin_name}/") for name in names):
-        fail(f"{zip_path}: contains nested {plugin_name}/ root")
-    if "CLAUDE.md" in names:
+    root = f"{plugin_name}/"
+    manifest_path = f"{root}.claude-plugin/plugin.json"
+    if manifest_path not in names:
+        fail(f"{zip_path}: {manifest_path} must exist")
+    if ".claude-plugin/plugin.json" in names:
+        fail(f"{zip_path}: ZIP is flat; Cowork upload expects a single {plugin_name}/ root folder")
+    outside_root = sorted(name for name in names if name and not name.startswith(root))
+    if outside_root:
+        fail(f"{zip_path}: contains entries outside {plugin_name}/ root: {outside_root[:3]}")
+    if f"{root}CLAUDE.md" in names:
         fail(f"{zip_path}: root CLAUDE.md must not be shipped; Claude Code treats it as a warning and Cowork upload may reject it")
     if any("__pycache__/" in name or name.endswith(".pyc") for name in names):
         fail(f"{zip_path}: contains Python cache files")
 
     with zipfile.ZipFile(zip_path) as archive:
-        manifest = json.loads(archive.read(".claude-plugin/plugin.json"))
+        manifest = json.loads(archive.read(manifest_path))
     if manifest.get("name") != plugin_name:
         fail(f"{zip_path}: manifest name {manifest.get('name')!r} does not match {plugin_name!r}")
+    if len(manifest.get("description", "")) > 300:
+        fail(f"{zip_path}: manifest description is too long for Cowork upload")
 
     if plugin_name == "liquiditaetsplanung":
-        generator = "skills/liquiditaetsvorschau-3-6-12-monate/werkzeuge/build_liquiditaetsplan.py"
+        generator = f"{root}skills/liquiditaetsvorschau-3-6-12-monate/werkzeuge/build_liquiditaetsplan.py"
         if generator not in names:
             fail(f"{zip_path}: missing standalone Liquiditätsplan generator {generator}")
 


### PR DESCRIPTION
## Ursache

Das lokale Claude-Log zeigt, dass frühere von Cowork akzeptierte ZIPs als Ordner-Archiv aufgebaut waren, z. B. `steuerberater-werkzeuge/.claude-plugin/plugin.json`. Die aktuellen Release-ZIPs waren dagegen flach (`.claude-plugin/plugin.json` im ZIP-Root). Lokale Claude-Code-Validierung akzeptiert diese flache Form, aber Cowork-Upload verhält sich anders und meldet nur `plugin validation failed`.

## Änderung

- Release-ZIPs werden wieder als einzelner Plugin-Ordner gebaut, z. B. `liquiditaetsplanung/.claude-plugin/plugin.json`.
- Root-`CLAUDE.md` bleibt aus ZIPs ausgeschlossen, damit keine Claude-Code-Warnung im Upload-Pfad entsteht.
- Release-ZIP-Validator prüft jetzt explizit die Cowork-Ordnerstruktur, kurze Manifest-Descriptions und den Liquiditätsplan-Generator.
- README-Hinweise korrigiert: Release-ZIP hochladen, nicht Repository-ZIP.

## Validierung

- `node scripts/validate-plugin-structure.mjs`
- `npx --yes @anthropic-ai/claude-code@latest plugin validate .`
- Manifest-Descriptions <= 300 Zeichen geprüft
- Cowork-Release-ZIP-Simulation für 17 Plugins
- `scripts/validate-release-zips.py` gegen die simulierten ZIPs
- `liquiditaetsplanung.zip` entpackt und den verschachtelten Plugin-Root mit Claude Code validiert