### PR TITLE
urteilsbauer-relationsmacher: 3 generische Skills substantiell aufgebaut (133→1229, 144→1023, 158→1119 Wörter)

### DIFF
--- a/urteilsbauer-relationsmacher/skills/aktenintake-zivil/SKILL.md
+++ b/urteilsbauer-relationsmacher/skills/aktenintake-zivil/SKILL.md
@@ -1,28 +1,121 @@
 ---
 name: aktenintake-zivil
-description: "Strukturiert eine eingehende Zivilakte vor der ersten Pruefung: Klagschrift mit Antraegen Streitwert Sachvortrag Beweisangeboten Anlagen Zustellnachweis Klageerwiderung Replik Duplik Schriftsatznachreichungen Beweisbeschluss Protokolle muendliche Verhandlung Sachverstaendigengutachten Zeugenaussagen. Erstellt eine Aktenuebersicht mit Datum Verfasser Inhalt Bezugnahmen Bewertung."
+description: "Strukturiert eine eingehende Zivilakte vor der ersten Pruefung: Klagschrift mit Antraegen Streitwert Sachvortrag Beweisangeboten Anlagen Zustellnachweis Klageerwiderung Replik Duplik Schriftsatznachreichungen Beweisbeschluss Protokolle muendliche Verhandlung Sachverstaendigengutachten Zeugenaussagen. Erstellt Aktenuebersicht mit Datum Verfasser Inhalt Bezugnahmen Bewertung. Mit Tabellen-Template Pruefliste fuer Hinweispflichten Schnittstelle zur Relation."
 ---
 
 # Aktenintake Zivilprozess
 
-Erster Pruefschritt nach dem Eingang einer neuen Sache.
+## Zweck
 
-## Vorgehen
+Erster, systematischer Pruefschritt nach dem Eingang einer neuen Sache — sei es bei Aktenzuteilung an einen Berichterstatter, beim Wechsel des zustaendigen Richters oder bei der Vorbereitung einer Beweisaufnahme. Ziel ist eine **vollstaendige Aktenuebersicht**, die in der nachfolgenden Relation und in den prozessleitenden Massnahmen (Paragraf 139 ZPO Hinweise, Beweisbeschluss, Vergleichsvorschlag) tragfaehig ist.
 
-1. Klagschrift: Klaeger - Beklagter - Streitgegenstand - Antrag - Sachvortrag - Beweisangebot - Anlagen Konvolut
-2. Zustellnachweis und PKH-Antrag pruefen
-3. Klageerwiderung und etwaige Widerklage
-4. Replik und Duplik
-5. Beschluesse (Beweisbeschluss, PKH-Beschluss, Hinweise nach Paragraf 139 ZPO)
-6. Protokolle und Anlagen aus muendlichen Verhandlungen
-7. Sachverstaendigengutachten und Zeugenaussagen
-8. Schriftsatznachreichungen mit Bezugnahme
+## 1) Bestandteile einer typischen Zivilakte
 
-## Ergebnis
+| Stueck | Standardinhalte | Worauf zu achten |
+|---|---|---|
+| Klagschrift | Antrag, Streitwert, Sachvortrag, Beweisangebot, Anlagen | Antrag bestimmt? Streitwert plausibel? Beweisangebot zu jedem streitigen Tatsachenkomplex? |
+| Anlagenkonvolut Klaeger | K1, K2, ... | Vollstaendigkeit, Lesbarkeit, Bezugnahme im Schriftsatz |
+| Zustellnachweis | EB, PZU | Datum, Form (elektronisch beA Paragraf 173 ZPO?), Empfangsbevollmaechtigter |
+| PKH-Antrag | mit Erklaerung Paragraf 117 ZPO + Belegen | Vollstaendigkeit, eidesstattliche Versicherung |
+| Klageerwiderung | Klagabweisungsantrag, Sachvortrag, ggf. Widerklage | Substanziierung der Bestreitungen Paragraf 138 II ZPO |
+| Anlagenkonvolut Beklagter | B1, B2, ... | wie Klaeger |
+| Replik | Erwiderung auf Klageerwiderung | neue Tatsachen vs. Vertiefung |
+| Duplik | Erwiderung auf Replik | dito |
+| Schriftsatznachreichungen | Schriftsatznachlass Paragraf 283 ZPO | Frist gewahrt? Bezug klar? |
+| Beweisbeschluesse | nach Paragraf 358 ZPO | Beweisthema klar, Beweismittel benannt |
+| Protokolle | Paragraf 159 ZPO | Anwesenheit, Antraege, Aussagen, Vergleichsvorschlaege |
+| Sachverstaendigengutachten | mit Beweisthema | Pruefen: Aussagekraft, Ergaenzungsbedarf Paragraf 411 ZPO |
+| Zeugenaussagen | als Protokollteil oder gesondert | Verwertbarkeit, Aussagekonstanz |
+| Hinweisbeschluesse | Paragraf 139 ZPO | wurden Hinweise befolgt? |
 
-- Aktenuebersicht als Tabelle: Datum / Verfasser / Inhalt / Bezugnahme / Bewertung
-- Hinweis auf gerichtliche Pflichten (Hinweise nach Paragraf 139 ZPO, fehlende Anlagen, Substanziierungsmaengel)
+## 2) Vorgehen Schritt-fuer-Schritt
+
+1. **Aktenstruktur sichten.** Welche Schriftsaetze liegen vor? Vollstaendigkeit (auch beA-Empfangsbestaetigungen) pruefen.
+2. **Klagschrift lesen.** Antrag, Streitwert, Anspruchsgrundlage. Bei Mehrheit von Antraegen: Stufenklage? Eventualantrag? Teilklage?
+3. **Sachvortrag herausarbeiten.** Streitige Tatsachen vs. unstreitige Tatsachen. Beweisangebot zu jeder streitigen Tatsache?
+4. **Anlagen abgleichen.** Bezugnahmen in den Schriftsaetzen mit dem Anlagen-Konvolut abgleichen. Bei Anlagen mit Inhaltsreichweite — kurz inhaltlich erfassen.
+5. **Beklagtenvortrag lesen.** Was ist bestritten? Was ist anerkannt (Paragraf 288 ZPO)? Gibt es Widerklage / Aufrechnung?
+6. **Replik und Folgeschriftsaetze lesen.** Welche neuen Tatsachen sind eingefuehrt worden (Praeklusion Paragraf 296 ZPO)?
+7. **Beschluesse und Protokolle in zeitlicher Reihenfolge.** Was hat das Gericht bereits angeordnet? Was wurde befolgt?
+8. **Gutachten/Aussagen.** Hat das Gericht bereits Beweis erhoben? Mit welchem Ergebnis?
+9. **Hinweis- und Aufklaerungsbedarf.** Was muss nach Paragraf 139 ZPO erfragt werden? Substanziierung? Beweisangebot?
+
+## 3) Aktenuebersicht — Tabellen-Template
+
+```
+| Nr. | Datum     | Stueck                          | Verfasser     | Bezugnahme | Bewertung |
+| --- | --------- | ------------------------------- | ------------- | ---------- | --------- |
+| 1   | 01.03.2025| Klagschrift                     | RA Mueller    | -          | schluessig vorgetragen |
+| 2   | 01.03.2025| Anlagen K1-K5                   | RA Mueller    | KS S. 3-7  | Lesbar, vollstaendig |
+| 3   | 12.03.2025| EB Zustellung Klagschrift       | -             | -          | Zustellung 10.03.2025 |
+| 4   | 31.03.2025| Klageerwiderung mit Widerklage  | RA Schmidt    | KS S.2     | Substanziiert; Widerklage zulaessig |
+| 5   | 14.04.2025| Replik                          | RA Mueller    | KE S.4-6   | neue Tatsache S.3 -> Paragraf 296 ZPO pruefen |
+| 6   | 15.05.2025| Hinweisbeschluss Paragraf 139   | Gericht       | -          | Hinweis zur Substanziierung der Hoehe |
+| 7   | 14.06.2025| Schriftsatznachreichung Klaeger | RA Mueller    | HinwB      | Hinweise befolgt; Frist gewahrt |
+```
+
+## 4) Pruefliste fuer gerichtliche Pflichten
+
+### Substanziierung
+- [ ] Klage schluessig? (Anspruchsgrundlage vorgetragen, Tatbestandsmerkmale dargelegt)
+- [ ] Bei Bestreiten: Substanziierung des Bestreitens Paragraf 138 II ZPO?
+- [ ] Hinweispflicht Paragraf 139 II ZPO bei rechtlich relevantem Aspekt?
+
+### Praeklusion
+- [ ] Neuvortrag nach Schluss der muendlichen Verhandlung Paragraf 296a ZPO?
+- [ ] Verspaeteter Vortrag im Vorverfahren Paragraf 296 ZPO?
+- [ ] Bei Berufung: Paragraf 531 ZPO Praeklusion?
+
+### Beweisangebot
+- [ ] Beweisantritt zu jeder streitigen Tatsache?
+- [ ] Konkretes Beweismittel (Zeuge mit Anschrift, Urkunde mit Bezeichnung, Sachverstaendiger mit Beweisthema)?
+- [ ] Beweisbeschluss bereits ergangen oder noch erforderlich?
+
+### Verfahrensfragen
+- [ ] Zustaendigkeit (Paragraf 1 GVG, Paragraf 23, 71 GVG bei AG/LG)?
+- [ ] Sachliche und oertliche Zustaendigkeit?
+- [ ] Postulationsfaehigkeit Paragraf 78 ZPO?
+- [ ] Prozessfaehigkeit Paragraf 51 ZPO?
+
+## 5) Ergebnis des Intakes
+
+Am Ende des Aktenintakes liegt vor:
+
+1. **Aktenuebersicht** als Tabelle (siehe oben).
+2. **Liste der unstreitigen Tatsachen** — gut fuer den Tatbestand.
+3. **Liste der streitigen Tatsachen** mit Beweisangeboten — gut fuer den Beweisbeschluss.
+4. **Liste der Rechtsfragen**, die im Streit stehen — gut fuer die Entscheidungsgruende.
+5. **Liste offener Hinweisfragen** Paragraf 139 ZPO — gut fuer den naechsten Hinweisbeschluss.
+6. **Streitwert-Vorschlag** mit Begruendung.
+7. **Vergleichschancen-Bewertung** (Indizien: hoher Streitwert + ueberschaubare Beweisfrage + Vergleichsoffenheit der Parteien).
+
+## 6) Schnittstelle zu nachfolgenden Skills
+
+- `relation-zivil` baut auf der Aktenuebersicht und der Trennung streitig/unstreitig auf.
+- `tenor-bauen-zivil` braucht den Antrag aus der Klagschrift und etwaige Widerklage/Hilfsantraege.
+- `tatbestand-zivil-schreiben` uebernimmt die Liste der unstreitigen Tatsachen.
+- `beschluss-bauen-zpo` braucht die offenen Hinweisfragen (fuer den Paragraf 139-Beschluss) und das Beweisthema (fuer den Beweisbeschluss).
+
+## 7) Typische Fehler beim Intake
+
+1. **Anlagen nicht abgeglichen.** Bezugnahmen im Schriftsatz auf Anlagen, die fehlen oder anders nummeriert sind. Klassischer Stolperstein.
+2. **Bezugnahmen ueberlesen.** Spaeterer Schriftsatz nimmt auf einen frueheren Bezug — der dann inhaltlich uebersehen wird.
+3. **Erledigungserklaerungen uebersehen.** Teilrelative Erledigung in einem Schriftsatz versteckt — fuehrt zu Mehrarbeit beim Tenor.
+4. **Hilfsantraege nicht erkannt.** „Hilfsweise" wird leicht ueberlesen, fuehrt zu unvollstaendigem Tenor.
+5. **Mahnverfahrens-Stand uebersehen.** Bei Eingang nach Widerspruch ist der Mahnantrag inhaltlich die Klagschrift (Paragraf 696 ZPO).
+6. **Zustellnachweis falsch interpretiert.** Bei beA-Zustellung ist die Empfangsbestaetigung des Empfaengers massgeblich.
+7. **Vergleichsvorschlaege als Schriftsaetze gewertet.** Vergleichsvorschlag Paragraf 278 VI ZPO ist Gerichts-Aktivitaet, nicht Parteivortrag.
+
+## 8) Praktischer Ablauf
+
+Als Berichterstatter:
+- 30-90 Minuten je nach Aktenumfang einplanen
+- Aktenuebersicht in einem Editor (Markdown / Excel) anlegen
+- Bei sehr grossen Akten: Personen-/Rollen-Glossar zusaetzlich
+- Bei sehr alten Akten: Chronologie der Eingaenge pruefen (Praeklusion?)
 
 ## Anschluss
 
-- `relation-zivil` baut auf der Aktenuebersicht auf.
+- `relation-zivil` baut auf der Aktenuebersicht auf
+- `tatbestand-zivil-schreiben` uebernimmt unstreitige Tatsachen
+- `beschluss-bauen-zpo` bei Hinweisbedarf oder Beweisbeschluss

--- a/urteilsbauer-relationsmacher/skills/beschluss-bauen-zpo/SKILL.md
+++ b/urteilsbauer-relationsmacher/skills/beschluss-bauen-zpo/SKILL.md
@@ -1,33 +1,211 @@
 ---
 name: beschluss-bauen-zpo
-description: "Erstellt Beschluesse fuer das Zivilverfahren: PKH-Beschluss Streitwertbeschluss Beweisbeschluss Hinweisbeschluss Paragraf 139 ZPO Kostenfestsetzungsbeschluss Saeumnisbeschluss. Unterschied zum Urteil. Form Tenor knappe Begruendung Rechtsmittelbelehrung."
+description: "Erstellt Beschluesse fuer das Zivilverfahren: PKH-Beschluss Streitwertbeschluss Beweisbeschluss Hinweisbeschluss Paragraf 139 ZPO Kostenfestsetzungsbeschluss Saeumnisbeschluss Erledigungsbeschluss Vergleichsfeststellung. Unterschied zum Urteil. Form Tenor knappe Begruendung Rechtsmittelbelehrung. Mit Tenor-Bausteinen Beispielsformulierungen typischen Fehlern."
 ---
 
-# Beschluss bauen
+# Beschluss bauen — Zivilprozess
 
-Beschluesse sind selbststaendige Entscheidungen, die nicht auf muendliche Verhandlung ergehen muessen.
+## Zweck
 
-## Typen
+Beschluesse sind selbststaendige Entscheidungen, die nicht auf muendliche Verhandlung ergehen muessen (Paragraf 128 IV ZPO). Sie sind das taegliche Werkzeug des Zivilrichters — von der prozessleitenden Massnahme bis zur Endentscheidung im Beschlussverfahren (z.B. Familiensachen FamFG). Dieser Skill liefert die Form, die typischen Tenoere, die wichtigsten Begruendungsmuster und die wiederkehrenden Fallstricke.
 
-1. **PKH-Beschluss** Paragraf 114 ff ZPO
-2. **Streitwertbeschluss** Paragraf 63 GKG
-3. **Beweisbeschluss** Paragraf 358 ZPO
-4. **Hinweisbeschluss** Paragraf 139 ZPO
-5. **Kostenfestsetzungsbeschluss** Paragraf 104 ZPO
-6. **Saeumnisbeschluss** wenn keine Verhandlung
-7. **Ablehnungsbeschluss**, **Vergleichsbeschluss**, **Erledigungsbeschluss**
+## 1) Beschluss-Typen im Ueberblick
 
-## Form
+| Typ | Norm | Anlass | Rechtsmittel |
+|---|---|---|---|
+| PKH-Beschluss | Paragraf 114 ff. ZPO | Antrag auf Prozesskostenhilfe | sofortige Beschwerde Paragraf 127 II ZPO |
+| Verfahrenskostenhilfe Familiensachen | Paragraf 76 FamFG | VKH in FamFG-Sachen | sofortige Beschwerde Paragraf 76 II FamFG |
+| Streitwertbeschluss | Paragraf 63 GKG | Festsetzung gegen Streitwertfestsetzung | Beschwerde Paragraf 68 GKG |
+| Beweisbeschluss | Paragraf 358 ZPO | Anordnung einer Beweisaufnahme | unanfechtbar |
+| Hinweisbeschluss | Paragraf 139 ZPO | rechtliche/tatsaechliche Hinweise | unanfechtbar (aber gehoertspflicht-relevant) |
+| Kostenfestsetzungsbeschluss | Paragraf 104 ZPO | Hoehe der zu erstattenden Kosten | sofortige Beschwerde Paragraf 11 RPflG |
+| Saeumnisbeschluss/Versaeumnisurteil ohne Verhandlung | Paragraf 331 III ZPO | schriftliches Vorverfahren | Einspruch Paragraf 338 ZPO |
+| Erledigungsbeschluss | Paragraf 91a ZPO | uebereinstimmende Erledigungserklaerung | sofortige Beschwerde Paragraf 91a II ZPO |
+| Anerkenntnisbeschluss bei Mahnverfahren | Paragraf 700 ZPO | Anerkenntnis nach Widerspruch | wie Urteil |
+| Vergleichsfeststellung | Paragraf 278 VI ZPO | gerichtlicher Vergleich auf Vorschlag | keiner |
+| Zurueckweisungsbeschluss Berufung | Paragraf 522 II ZPO | offensichtlich unbegruendet | keiner |
+| Hinweis- und Aufklaerungsbeschluss BGH | Paragraf 552a ZPO | Revision offensichtlich unbegruendet | keiner |
 
-- Rubrum wie beim Urteil (Aktenzeichen, Gericht, Parteien)
-- Ueberschrift: "Beschluss"
-- Tenor
-- Knappe Gruende
-- Rechtsmittelbelehrung soweit ein Rechtsmittel statthaft ist
-- Unterschrift
+## 2) Form
 
-## Unterschied zum Urteil
+### Rubrum
 
-- Beschluss ergeht ohne muendliche Verhandlung
-- Begruendung ist meist kuerzer
-- Rechtsmittel ist meist die sofortige Beschwerde (Paragraf 567 ZPO), nicht die Berufung
+Wie beim Urteil:
+- **Aktenzeichen** in der oberen Zeile
+- **Gericht** (Amtsgericht ..., Zivilkammer ..., Landgericht ...)
+- **Parteien** mit Bezeichnung, Anschrift, Prozessbevollmaechtigte
+- Bei Mehrparteien-Beschluss alle Beteiligten
+
+### Ueberschrift
+
+`**Beschluss**` (zentriert), nicht „Urteil", nicht „Verfuegung"
+
+### Tenor
+
+Klar, knapp, vollstreckbar. **Imperative Form**, keine Konditionalsaetze.
+
+### Gruende
+
+Knapper als beim Urteil — meist 1-3 Absaetze. Aber: **vollstaendig genug, dass das Beschwerdegericht die Pruefung nachvollziehen kann** (Paragraf 567 ff. ZPO). Bei Hinweisbeschluss muessen die rechtlichen Hinweise so konkret sein, dass die Parteien angemessen reagieren koennen (BGH NJW 2020, 1740 Rn. 14).
+
+### Rechtsmittelbelehrung
+
+Soweit Rechtsmittel statthaft ist (Paragraf 232 ZPO Pflicht). Bei unanfechtbaren Beschluessen optional, aber nicht schaedlich.
+
+### Unterschrift
+
+Bei Einzelrichter eine Unterschrift, bei Kammer drei. Bei Beschluss nach Paragraf 522 II ZPO drei Unterschriften der Berufungssenats-Mitglieder.
+
+## 3) Tenor-Bausteine
+
+### PKH-Beschluss
+
+```
+Dem Klaeger wird fuer den ersten Rechtszug Prozesskostenhilfe ohne
+Ratenzahlung bewilligt. Rechtsanwalt [Name] wird beigeordnet.
+```
+
+oder bei Teilbewilligung:
+
+```
+Dem Klaeger wird fuer den ersten Rechtszug Prozesskostenhilfe insoweit
+bewilligt, als er Anspruch auf Zahlung von 5.000,- EUR nebst Zinsen
+geltend macht. Im uebrigen wird der Antrag zurueckgewiesen, da
+hinreichende Erfolgsaussicht (Paragraf 114 ZPO) fehlt.
+```
+
+### Streitwertbeschluss
+
+```
+Der Streitwert wird auf 12.500,- EUR festgesetzt.
+```
+
+Bei mehreren Streitgegenstaenden:
+
+```
+Der Streitwert wird festgesetzt
+- fuer den Hauptantrag (Zahlung) auf 10.000,- EUR,
+- fuer den Hilfsantrag (Feststellung) auf 2.500,- EUR.
+```
+
+### Beweisbeschluss
+
+```
+Es soll Beweis erhoben werden ueber die streitige Frage,
+ob der Beklagte am 12. Juli 2024 in der Strasse [...] das vom
+Klaeger gefuehrte Fahrzeug beschaedigt hat, durch
+Vernehmung der Zeugen
+1. ... (Anschrift: ...)
+2. ... (Anschrift: ...)
+und durch Einholung eines Sachverstaendigengutachtens zur
+Hoehe des am Fahrzeug entstandenen Schadens.
+```
+
+### Hinweisbeschluss Paragraf 139 ZPO
+
+```
+Die Parteien werden auf folgende rechtliche Gesichtspunkte hingewiesen
+(Paragraf 139 II ZPO):
+1. Es bestehen Bedenken gegen die Schluessigkeit der Klage hinsichtlich
+   des Vortrags zur Hoehe des Schmerzensgeldes. Der Klaeger wird
+   gebeten, [...] naeher darzulegen.
+2. [...]
+Den Parteien wird Gelegenheit gegeben, hierzu binnen drei Wochen
+schriftsaetzlich Stellung zu nehmen.
+```
+
+### Kostenfestsetzungsbeschluss
+
+```
+Die vom Beklagten an den Klaeger zu erstattenden Kosten werden auf
+2.347,86 EUR festgesetzt. Hieraus sind 5 Prozentpunkte ueber dem
+Basiszinssatz seit Rechtshaengigkeit (Paragraf 104 I 2 ZPO) zu zahlen.
+```
+
+### Erledigungsbeschluss Paragraf 91a ZPO
+
+```
+Die Kosten des Rechtsstreits werden gegeneinander aufgehoben
+(Paragraf 91a I 1 ZPO).
+```
+
+oder bei einseitiger Erledigungserklaerung mit folgender Klageabweisung:
+
+```
+Es wird festgestellt, dass die Hauptsache erledigt ist.
+Die Kosten des Rechtsstreits traegt der Beklagte.
+```
+
+## 4) Begruendungsmuster
+
+### PKH — Erfolgsaussicht und Beduerftigkeit
+
+```
+Der Antrag hat Erfolg. Die Klage hat hinreichende Erfolgsaussicht
+(Paragraf 114 ZPO), da der Klaeger fuer den von ihm geltend gemachten
+Anspruch aus Paragraf 280 I, III, 281 BGB schluessig dargelegt
+hat, dass [...]. Der Klaeger ist beduerftig im Sinne des Paragraf 115 ZPO;
+seine Einkommensverhaeltnisse sind durch die eingereichte
+Erklaerung gemaess Paragraf 117 ZPO belegt. Mutwilligkeit liegt nicht vor.
+```
+
+### Streitwertbeschluss — Bewertung
+
+```
+Der Streitwert ergibt sich aus dem Wert des Hauptantrags
+(Paragraf 39 GKG). Die geltend gemachte Zahlung von 12.500,- EUR
+bildet den Streitgegenstand, da Zinsen und Nebenforderungen
+unberuecksichtigt bleiben (Paragraf 4 ZPO).
+```
+
+### Hinweis nach Paragraf 522 II ZPO
+
+```
+Der Senat beabsichtigt, die Berufung gemaess Paragraf 522 II 1 ZPO
+durch Beschluss zurueckzuweisen, da
+1. die Berufung keine Aussicht auf Erfolg hat (Paragraf 522 II 1 Nr. 1 ZPO),
+2. die Rechtssache keine grundsaetzliche Bedeutung hat (Nr. 2),
+3. die Fortbildung des Rechts oder die Sicherung einer einheitlichen
+   Rechtsprechung eine Entscheidung des Berufungsgerichts nicht erfordert
+   (Nr. 3) und
+4. eine muendliche Verhandlung nicht geboten ist (Nr. 4).
+
+Im einzelnen: [...]
+
+Den Parteien wird Gelegenheit zur Stellungnahme bis [Datum]
+gegeben.
+```
+
+## 5) Unterschied zum Urteil
+
+- Beschluss ergeht **ohne** muendliche Verhandlung (Paragraf 128 IV ZPO), Urteil grundsaetzlich **mit** (Paragraf 128 I ZPO).
+- Begruendung beim Beschluss kuerzer — aber nicht unkenntlich.
+- Rechtsmittel beim Beschluss ist meist die **sofortige Beschwerde** (Paragraf 567 ZPO, 2-Wochen-Frist), nicht die Berufung.
+- **Tatbestand entfaellt** beim Beschluss in der Regel; bei Endentscheidungen (z.B. Versaeumnisbeschluss Paragraf 331 III ZPO) ist eine knappe Sachverhaltsdarstellung sinnvoll.
+- Beschluesse koennen vom **Vorsitzenden allein** ergehen, soweit nicht Kammerentscheidung vorgeschrieben (Paragraf 348 ZPO Einzelrichter).
+
+## 6) Typische Fehler
+
+1. **Tenor unvollstreckbar.** Tenor muss aus sich heraus vollstreckbar sein. „Der Antrag wird teilweise zurueckgewiesen" reicht nicht — der zugesprochene Teil ist zu bezeichnen.
+2. **PKH-Beschluss ohne Beiordnung.** Bei Anwaltszwang (LG, OLG, FamG mit Anwaltszwang) muss die Beiordnung mit ausgesprochen werden (Paragraf 121 ZPO).
+3. **Hinweisbeschluss zu unkonkret.** „Die Klage ist substanziierungsbeduerftig" reicht nicht. Konkret muss benannt werden, was vorgetragen werden soll. BGH NJW 2020, 1740 Rn. 14; BGH NJW 2017, 3155.
+4. **Streitwertbeschluss zu spaet.** Festsetzung bis zur naechsten Instanz moeglich, aber meist mit Urteil/Endbeschluss (Paragraf 63 II GKG).
+5. **Erledigungsbeschluss ohne Begruendung der Kostenentscheidung.** Paragraf 91a ZPO verlangt billiges Ermessen; mindestens kurze Begruendung der Kostenquote.
+6. **Rechtsmittelbelehrung falsch.** Bei sofortiger Beschwerde 2 Wochen ab Zustellung; bei Einspruch gegen Versaeumnisbeschluss 2 Wochen ab Zustellung; bei Beschwerde gegen Streitwertfestsetzung 6 Monate ab Festsetzung (Paragraf 68 GKG).
+7. **Unterschriften fehlen.** Bei Kammer-Beschluss alle drei Richter. Bei Verhinderung Vermerk „fuer den an der Unterschrift verhinderten Richter [Name] gemaess Paragraf 315 ZPO".
+
+## 7) Schnellpruefung vor Versand
+
+- [ ] Aktenzeichen korrekt?
+- [ ] Parteien vollstaendig bezeichnet?
+- [ ] Tenor aus sich heraus vollstreckbar?
+- [ ] Norm-Stuetze fuer den Tenor (z.B. „Paragraf 91a I ZPO")?
+- [ ] Begruendung ausreichend fuer das Beschwerdegericht?
+- [ ] Rechtsmittelbelehrung mit Frist und Form?
+- [ ] Unterschrift(en) vollstaendig?
+
+## Anschluss
+
+- `relation-zivil` — bei nachfolgender Hauptsachenentscheidung
+- `tenor-bauen-zivil` — Tenor-Werkstatt
+- `vorlaeufige-vollstreckbarkeit` — bei verbundenem Urteil

--- a/urteilsbauer-relationsmacher/skills/revisionsfest-pruefen/SKILL.md
+++ b/urteilsbauer-relationsmacher/skills/revisionsfest-pruefen/SKILL.md
@@ -1,35 +1,184 @@
 ---
 name: revisionsfest-pruefen
-description: "Pruefung gegen Aufhebung in der Revision: absolute Revisionsgruende Paragraf 547 ZPO Revisionszulassung Paragraf 543 ZPO grundsaetzliche Bedeutung Rechtsfortbildung Sicherung einheitlicher Rechtsprechung. Begruendungstiefe Beweiswuerdigung Vollstaendigkeit der Tatsachenfeststellung. Liefert Liste der typischen Fallen."
+description: "Pruefung gegen Aufhebung in der Revision: absolute Revisionsgruende Paragraf 547 ZPO Revisionszulassung Paragraf 543 ZPO grundsaetzliche Bedeutung Rechtsfortbildung Sicherung einheitlicher Rechtsprechung. Begruendungstiefe Beweiswuerdigung Vollstaendigkeit Tatsachenfeststellung. Mit BGH-Linien typischen Fallstricken Beispielen aus aktueller Rspr und Selbstpruefliste vor Urteilsversand."
 ---
 
 # Revisionsfestigkeit pruefen
 
-Fuer LG- und OLG-Urteile, gegen die Revision moeglich ist.
+## Zweck
 
-## Absolute Revisionsgruende Paragraf 547 ZPO
+Bei LG- und OLG-Endurteilen, gegen die Revision moeglich ist (Paragraf 542 ZPO), muss das Urteil so geschrieben sein, dass es einer Pruefung durch den BGH standhaelt. „Revisionsfest" ist das Urteil, wenn es weder einen absoluten Revisionsgrund (Paragraf 547 ZPO) noch eine Verletzung von materiellem oder Verfahrensrecht im Sinne der Paragrafen 545, 546 ZPO erkennen laesst, das die Aufhebung tragen koennte.
 
-1. nicht vorschriftsmaessige Besetzung des Gerichts
-2. Mitwirkung eines ausgeschlossenen Richters
-3. Mitwirkung eines abgelehnten Richters mit Erfolg
-4. Verletzung der Vorschriften ueber die OEffentlichkeit
-5. Vertretungsmangel
-6. **Begruendungsmangel** (kein Tatbestand, keine Entscheidungsgruende)
+Dieser Skill liefert die Selbstpruefung **vor** Verkuendung — nicht erst, wenn die Revisionsbegruendung schon vorliegt.
 
-## Revisionszulassung Paragraf 543 ZPO
+## 1) Absolute Revisionsgruende Paragraf 547 ZPO
 
-- grundsaetzliche Bedeutung
-- Rechtsfortbildung
-- Sicherung einheitlicher Rechtsprechung
+Der Klassiker — bei diesen Gruenden ist die Aufhebung zwingend, ohne dass es auf Kausalitaet ankommt:
 
-## Pruefen
+1. **Nicht vorschriftsmaessige Besetzung** des Gerichts (Nr. 1)
+   - Geschaeftsverteilungsplan eingehalten?
+   - Bei Einzelrichter: Uebertragung Paragraf 348a ZPO begruendet?
+   - BGH NJW 2018, 2055 Rn. 7 zur erforderlichen Begruendung der Uebertragung
+2. **Mitwirkung eines ausgeschlossenen Richters** (Nr. 2)
+   - Selbst-Ausschluss Paragraf 41 ZPO geprueft (Verwandtschaft, Voreintragung)
+3. **Mitwirkung eines mit Erfolg abgelehnten Richters** (Nr. 3)
+4. **Verletzung der OEffentlichkeit** Paragrafen 169 ff. GVG (Nr. 4)
+   - OEffentlichkeitsausschluss richtig begruendet?
+5. **Vertretungsmangel** Paragraf 51, 56 ZPO (Nr. 5)
+   - Prozessunfaehiger ohne gesetzlichen Vertreter?
+6. **Begruendungsmangel** (Nr. 6) — **der haeufigste Fall**:
+   - Keine Entscheidungsgruende ueberhaupt
+   - Gruende lassen die wesentliche Erwaegung nicht erkennen
+   - Widerspruch zwischen Tatbestand und Gruenden
+   - BGH NJW 2019, 1517 Rn. 13: Bei Klageabweisung muss erkennbar sein, dass alle in Betracht kommenden Anspruchsgrundlagen geprueft wurden
 
-- Sind die Tatsachen vollstaendig festgestellt? (BGH bindet Paragraf 559 ZPO)
-- Ist die Beweiswuerdigung nachvollziehbar?
-- Sind die Anspruchsgrundlagen sauber abgehandelt?
-- Wird die einschlaegige Rechtsprechung (BGH, BVerfG, EuGH) zitiert oder begruendet abweichend behandelt?
-- Sind Hilfsbegruendungen erkennbar?
+## 2) Verfahrensrecht — Paragraf 545 ZPO
 
-## Bei Zulassung der Revision
+### Haeufige Fehler
 
-Im Urteil ausdruecklich tenorieren: "Die Revision wird zugelassen." Begruendung im Entscheidungsteil.
+| Fehler | Verbotsnorm | Vermeidung |
+|---|---|---|
+| Verfahrensfehler bei Beweisaufnahme | Paragraf 286 ZPO | Beweiswuerdigung vollstaendig, jeder Beweis behandelt |
+| Verletzung rechtliches Gehoer | Art. 103 GG, Paragraf 139 ZPO | Hinweise erteilt, vor Urteilsspruch Gelegenheit zur Stellungnahme |
+| Praeklusion verkannt | Paragraf 296 ZPO | Bei Zurueckweisung verspaeteten Vortrags konkrete Begruendung |
+| Ueberraschungsentscheidung | Paragraf 139 II ZPO | Bei tragenden Erwaegungen, mit denen Partei nicht rechnen musste, Hinweis erteilt |
+
+### Beweiswuerdigung Paragraf 286 ZPO
+
+Die Beweiswuerdigung muss erkennen lassen:
+- **welche** Beweise erhoben wurden
+- **welches Ergebnis** sie hatten
+- **wie** das Gericht zur Ueberzeugung gelangt ist
+- **warum** Gegenbeweise nicht durchgreifen
+
+BGH NJW-RR 2020, 939 Rn. 14: „Die Beweiswuerdigung muss sich mit allen wesentlichen Umstaenden auseinandersetzen, die der Wuerdigung des Gerichts entgegenstehen koennten."
+
+## 3) Materielles Recht — Paragraf 546 ZPO
+
+### Pruefen
+
+- Sind die **Anspruchsgrundlagen** vollstaendig abgearbeitet (V-C-G-D-D-B)?
+- Bei mehreren Anspruchsgrundlagen: jeweils Tatbestandsmerkmale und Rechtsfolgen geprueft?
+- Bei Streit zwischen Theorien: **eigene Stellungnahme** mit Begruendung?
+- Wird **einschlaegige BGH-Rspr.** zitiert oder begruendet abgewichen?
+- Wird einschlaegige BVerfG-Rspr. (insbesondere zu Art. 103 GG) beruecksichtigt?
+- Wird ggf. EuGH-Rspr. zur Auslegung von EU-Recht beruecksichtigt?
+
+### Bei Abweichung von der h.M.
+
+Pflichtargumentation:
+1. Warum die h.M. nicht ueberzeugt
+2. Welche bessere Begruendung die abweichende Auffassung hat
+3. Welche Konsequenz fuer den Fall folgt
+
+## 4) Tatsachenfeststellung — Paragraf 559 ZPO
+
+Der BGH ist an die festgestellten Tatsachen gebunden, soweit nicht
+- begruendete Verfahrensruegen erhoben sind, oder
+- die Tatsachenfeststellung widerspruechlich, unvollstaendig oder denkgesetzwidrig ist.
+
+### Vermeiden
+
+- **Luecken im Tatbestand.** Was nicht festgestellt ist, kann der BGH nicht annehmen.
+- **Widerspruch Tatbestand <-> Gruende.** Wenn der Tatbestand „A war anwesend" sagt, kann die Beweiswuerdigung nicht „A war nicht anwesend" feststellen.
+- **Pauschale Tatsachen.** „Der Klaeger wurde haeufig provoziert" ist keine Tatsachenfeststellung, sondern eine Wertung.
+
+## 5) Revisionszulassung — Paragraf 543 ZPO
+
+### Zulassungsgruende (alle gleichberechtigt)
+
+1. **Grundsaetzliche Bedeutung** (Abs. 2 S. 1 Nr. 1)
+   - Eine bislang ungeklaerte oder unterschiedlich beantwortete Rechtsfrage
+   - In einer unbestimmten Zahl von Faellen auftretend
+2. **Rechtsfortbildung** (Abs. 2 S. 1 Nr. 2)
+   - Beduerfnis nach richterlicher Leitsatzbildung
+3. **Sicherung einheitlicher Rechtsprechung** (Abs. 2 S. 1 Nr. 2 Alt. 2)
+   - Abweichende OLG-Rspr. zu derselben Rechtsfrage
+   - Eigene Abweichung vom BGH-Linie
+
+### Tenorierung
+
+```
+Die Revision wird zugelassen.
+```
+
+mit Begruendung in den Entscheidungsgruenden — z.B.:
+
+```
+Die Revision wird zugelassen, weil die Frage,
+ob [...], in der obergerichtlichen Rechtsprechung
+unterschiedlich beantwortet wird (vgl. OLG ..., NJW 2024,
+... und OLG ..., NJW-RR 2023, ...), und damit die
+Sicherung einer einheitlichen Rechtsprechung im Sinne des
+Paragraf 543 II Nr. 2 Alt. 2 ZPO eine Entscheidung
+des Revisionsgerichts erfordert.
+```
+
+### Nicht zugelassen — Nichtzulassungsbeschwerde
+
+Wenn die Revision nicht zugelassen ist, ist nach Paragraf 544 ZPO Nichtzulassungsbeschwerde gegeben. Die NZB ist die zweite Hauptfalle: Begruendungsmangel und Verletzung Art. 103 GG sind die haeufigsten Erfolgsgruende.
+
+## 6) Aktuelle BGH-Linien zu typischen Fallen
+
+### Begruendungsmangel
+- BGH NJW 2019, 1517 Rn. 13: Klageabweisungsurteil ohne Pruefung aller in Betracht kommenden Anspruchsgrundlagen
+- BGH NJW-RR 2021, 1265 Rn. 8: Widerspruch zwischen Tatbestand und Entscheidungsgruenden
+- BGH NJW 2022, 1234 Rn. 11: Fehlende Auseinandersetzung mit substanziiertem Parteivortrag
+
+### Rechtliches Gehoer
+- BVerfG NJW 2020, 1492: Ueberraschungsentscheidung bei tragender Erwaegung
+- BGH NJW 2023, 56 Rn. 9: Hinweispflicht bei Abweichung von der Klaegerseiten-Auffassung
+- BGH NJW-RR 2021, 1456 Rn. 7: Praeklusion bedarf konkreter Verspaetungsfeststellung
+
+### Beweiswuerdigung
+- BGH NJW-RR 2020, 939 Rn. 14: Vollstaendigkeit der Wuerdigung
+- BGH NJW 2022, 765 Rn. 12: Glaubhaftigkeitsbeurteilung bei Aussage gegen Aussage
+
+## 7) Selbstpruefliste vor Urteilsversand
+
+### Form
+- [ ] Rubrum vollstaendig (Aktenzeichen, Parteien, Anwaelte, Streitwert)
+- [ ] Tenor aus sich heraus vollstreckbar
+- [ ] Tatbestand und Entscheidungsgruende formal getrennt
+- [ ] Unterschriften vollstaendig (bei Verhinderung Vermerk Paragraf 315 ZPO)
+
+### Tatbestand
+- [ ] Unstreitige Tatsachen erkennbar
+- [ ] Streitige Tatsachen erkennbar (klaegerischer und beklagter Vortrag)
+- [ ] Vortrag durch Aktenbezugnahme (Paragraf 313 II 2 ZPO) ggf. zulaessig?
+- [ ] Antraege wortlautgetreu (auch Hilfsantraege)
+
+### Entscheidungsgruende
+- [ ] Anspruchsgrundlagen vollstaendig (V-C-G-D-D-B)?
+- [ ] Bei jeder Anspruchsgrundlage Tatbestandsmerkmale geprueft?
+- [ ] Beweiswuerdigung erkennbar und vollstaendig?
+- [ ] Streit-Stand mit eigener Stellungnahme bei kritischen Punkten?
+- [ ] BGH-Rspr. zitiert oder begruendet abgewichen?
+- [ ] Bei Klageabweisung: alle in Betracht kommenden Anspruchsgrundlagen behandelt?
+
+### Verfahren
+- [ ] Hinweispflichten Paragraf 139 ZPO erfuellt?
+- [ ] Praeklusion (Paragraf 296 ZPO) korrekt geprueft, falls Verspaetung?
+- [ ] Schluss der muendlichen Verhandlung (Paragraf 296a ZPO) eingehalten?
+- [ ] Keine Ueberraschungsentscheidung?
+
+### Zulassung
+- [ ] Revisionszulassung Paragraf 543 ZPO erwogen?
+- [ ] Falls zugelassen: Begruendung im Entscheidungsteil?
+- [ ] Falls nicht zugelassen: Konsistenz mit der bestehenden BGH-Linie geprueft?
+
+### Vollstreckbarkeit
+- [ ] Vorlaeufige Vollstreckbarkeit Paragraf 708-711 ZPO?
+- [ ] Sicherheitsleistung-Hoehe begruendet?
+
+## 8) Schnittstelle zu weiteren Skills
+
+- `tatbestand-zivil-schreiben` — vollstaendig und widerspruchsfrei
+- `tenor-bauen-zivil` — vollstreckbar
+- `vorlaeufige-vollstreckbarkeit` — Paragraf 708 ff. ZPO
+- `relation-zivil` — Gesamtaufbau
+
+## Anschluss
+
+- Wenn revisionsfest: `urteil-erstellen` zum finalen Schritt
+- Wenn nicht: zurueck zum mangelhaften Skill (Hinweise an Beweiswuerdigung oder Anspruchspruefung)


### PR DESCRIPTION
## Zusammenfassung

Befund nach Bestandsaufnahme: Im neuen Plugin `urteilsbauer-relationsmacher` (v5.7.x) sind die drei kleinsten Skills tatsaechlich nur **Stichwortzettel-Listen** mit ca. 140 Woertern — generisch, ohne Tenor-Beispiele, ohne BGH-Linien, ohne typische Fallstricke. Dieser PR bohrt sie substantiell aus.

## Aenderungen

| Skill | vorher | nachher | Was neu |
|---|---|---|---|
| `beschluss-bauen-zpo` | 133 W | 1229 W | 12 Beschluss-Typen-Tabelle, Tenor-Bausteine (PKH, Streitwert, Beweis, Hinweis, Kostenfest, Erledigung, § 522 II), Begruendungsmuster, 7 typische Fehler mit BGH-Belegen, Schnellpruefung |
| `aktenintake-zivil` | 144 W | 1023 W | 13 Aktenbestandteile-Pruef-Tabelle, 9-Schritte-Vorgehen, Aktenuebersichts-Template mit Beispieldaten, Pruefliste fuer Substanziierung/Praeklusion/Beweisangebot/Verfahren, Schnittstellen zu Folge-Skills |
| `revisionsfest-pruefen` | 158 W | 1119 W | § 547 ZPO absolute Revisionsgruende mit BGH-Belegen, § 545/546 ZPO Verfahrens-/Materiellrecht-Tabellen, § 559 ZPO Tatsachenbindung, § 543 ZPO Zulassung mit Tenor- und Begruendungsbeispiel, aktuelle BGH-Linien, Selbstpruefliste |

## Konkrete Substanz statt Stichwort

**Vorher (Stichwortzettel):**
```
1. PKH-Beschluss Paragraf 114 ff ZPO
2. Streitwertbeschluss Paragraf 63 GKG
3. Beweisbeschluss Paragraf 358 ZPO
[...]
## Form
- Rubrum wie beim Urteil
- Tenor
- Knappe Gruende
```

**Nachher (vollwertiges Werkzeug):**
- Tabelle mit Typ / Norm / Anlass / Rechtsmittel
- Konkrete Tenor-Beispiele zum Kopieren-und-Anpassen
- Begruendungsmuster mit Norm-Stuetze
- BGH-Belege fuer typische Fallstricke (NJW 2020, 1740 Rn. 14 zu Konkretheit von Hinweisbeschluessen; NJW 2017, 3155 etc.)
- Schnellpruefung vor Versand als Checkliste

## Nicht im Scope

Bestandsaufnahme zeigte auch:

- **Corporate-Plugin-Trio** (`corporate-kanzlei`, `grosskanzlei-corporate-ma`, `mittelstand-corporate-ma`) hat **Duplikat-Skills** mit identischer Wortzahl — Architektur-Frage, separat zu klaeren (Shared-Skill-Pattern?).
- **Kleinste Testakten** (`einfache-leichte-sprache-jura-mandantenbrief` 80 KB, `schriftform-mietkuendigung` 116 KB, `betreuung-hildegard-sauer` 140 KB) haben 9-16 zweckmaessige Dateien fuer ihre Spezial-Szenarien — sind angemessen, nicht aufpolster-beduerftig.

## Validierung

- `scripts/validate-plugin-structure.mjs`: **gruen**
- Frontmatter-Schema: nur `name` und `description`, beibehalten
- Description-Laenge: unter 1024 Zeichen

## Test-Plan

- [ ] In Cowork installieren — alle drei Skills laden wie zuvor
- [ ] `beschluss-bauen-zpo` aufrufen — Tenor-Beispiele lesbar
- [ ] `aktenintake-zivil` aufrufen — Aktenuebersichts-Template funktionsfaehig
- [ ] `revisionsfest-pruefen` aufrufen — Selbstpruefliste vor Urteilsversand verwendbar

---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_