### PR TITLE
Codex-Fix: nicht-existente Schnittstellen-IDs in 4 Skills durch echte ersetzt

### DIFF
--- a/kanzlei-allgemein/skills/kanzlei-allgemein-abwesenheiten-urlaub/SKILL.md
+++ b/kanzlei-allgemein/skills/kanzlei-allgemein-abwesenheiten-urlaub/SKILL.md
@@ -151,6 +151,9 @@ Vorlage unter `assets/templates/abwesenheiten-register.md`.
 ## 9) Schnittstellen
 
 - `kanzlei-allgemein-lohn-sv` — bei Krankheit > 6 Wochen, Mutterschutz, Elternzeit
-- `kanzlei-allgemein-fristen-kalender` — Fristen-Vertretung
-- `kanzlei-allgemein-bea-postfach` — beA-Vertretung Paragraf 31a III BRAO
-- `kanzlei-allgemein-mandanten-kommunikation` — Vertretungsanzeige
+- `kanzlei-allgemein-hr-personal` — Personalakte, Resturlaubs-Konto, Vertragsfragen
+- `kanzlei-allgemein-fristen-monitor` — Fristen-Vertretung waehrend Abwesenheit
+- `kanzlei-allgemein-kanzleikalender` — Termin-Vertretung und Kalender-Synchronisation
+- `kanzlei-allgemein-bea-journal` — beA-Vertretung Paragraf 31a III BRAO
+- `kanzlei-allgemein-postlauf` — Postzustellung und -bearbeitung waehrend Abwesenheit
+- `kanzlei-allgemein-output-versand` — Vertretungsanzeige in der Mandanten-Korrespondenz

--- a/legistik-werkstatt/skills/lesefassung-konsolidiert/SKILL.md
+++ b/legistik-werkstatt/skills/lesefassung-konsolidiert/SKILL.md
@@ -117,5 +117,7 @@ Die Lesefassung ist **kein** amtliches Dokument. Die amtliche Konsolidierung erf
 ## 6) Anschluss
 
 - `xml-paralleldarstellung` — bei XML-pflichtigen Veroeffentlichungen
-- `synopse-erstellen` — fuer den Aenderungs-Diff
-- `bgbl-veroeffentlichung-vorbereiten` — fuer die amtliche Verkuendung
+- `synopse-erstellen` — fuer den Aenderungs-Diff alt vs. neu
+- `dokumente-rendern-docx-pdf` — fuer den DOCX-/PDF-Export der Lesefassung
+- `referentenentwurf-bauen` — bei aenderbarem Entwurfsstand
+- `inkrafttreten-uebergangsrecht` — bei stufenweisem Inkrafttreten oder Uebergangsregelungen

--- a/urteilsbauer-relationsmacher/skills/revisionsfest-pruefen/SKILL.md
+++ b/urteilsbauer-relationsmacher/skills/revisionsfest-pruefen/SKILL.md
@@ -180,5 +180,5 @@ Wenn die Revision nicht zugelassen ist, ist nach Paragraf 544 ZPO Nichtzulassung
 
 ## Anschluss
 
-- Wenn revisionsfest: `urteil-erstellen` zum finalen Schritt
-- Wenn nicht: zurueck zum mangelhaften Skill (Hinweise an Beweiswuerdigung oder Anspruchspruefung)
+- Wenn revisionsfest: `dokumente-rendern-urteil-docx` zum finalen DOCX-/PDF-Export
+- Wenn nicht: zurueck zum mangelhaften Skill (`tatbestand-zivil-schreiben`, `entscheidungsgruende-zivil-schreiben`, `beweiswuerdigung-mit-richter-input` oder `anspruchsgrundlagen-pruefen`, je nach Mangel)

--- a/vertragsausfueller/skills/vaf-quality-gate/SKILL.md
+++ b/vertragsausfueller/skills/vaf-quality-gate/SKILL.md
@@ -168,7 +168,10 @@ Empfehlung: Go / Go mit Warnungen / No-go
 
 ## 8) Schnittstellen
 
-- `vaf-vertragsdatenmatrix` — liefert die Eingabedaten
-- `vaf-rueckfragen` — fuettert die ungeklaerten Punkte
-- `vaf-ausfuellprotokoll` — protokolliert die Entscheidungen
-- `vaf-track-changes` — nach GRUEN-Ampel und Bestaetigung
+- `vaf-feldinventar` — extrahiert das Pflichtfeld-Inventar aus der Vorlage
+- `vaf-termsheet-mapping` — mappt Term-Sheet-Werte auf die Feldliste
+- `vaf-rueckfrageninterview` — klaert offene Punkte mit dem Mandanten
+- `vaf-plausibilitaetscheck` — pre-Quality-Gate-Pruefung der Zahlenlogik
+- `vaf-redline-qa` — Review von Track-Changes-Fassungen
+- `vaf-clean-output` — finaler Clean-Entwurf nach GRUEN-Ampel
+- `vaf-track-changes-nur-nach-frage` — Track Changes nur nach Bestaetigung


### PR DESCRIPTION
## Codex-Feedback adressiert

Codex hatte in der Review zu PR #14 (P2-Bug) zu Recht angemerkt, dass der neue Skill `kanzlei-allgemein-abwesenheiten-urlaub` Schnittstellen-IDs referenziert, die als Skills **nicht existieren**. Workflow-Handoffs wuerden so in tote Targets routen.

Sweep ueber **alle vier** in den letzten beiden PRs (#13, #14) aufgebauten Skills durchgefuehrt — jede referenzierte Skill-ID gegen die Verzeichnis-Realitaet abgeglichen.

## Korrekturen

### `kanzlei-allgemein-abwesenheiten-urlaub`

| nicht-existent | -> echte Skills |
|---|---|
| `kanzlei-allgemein-fristen-kalender` | `kanzlei-allgemein-fristen-monitor` + `kanzlei-allgemein-kanzleikalender` |
| `kanzlei-allgemein-bea-postfach` | `kanzlei-allgemein-bea-journal` |
| `kanzlei-allgemein-mandanten-kommunikation` | `kanzlei-allgemein-output-versand` |
| (neu ergaenzt) | `kanzlei-allgemein-hr-personal`, `kanzlei-allgemein-postlauf` |

### `vaf-quality-gate`

| nicht-existent | -> echte Skills |
|---|---|
| `vaf-vertragsdatenmatrix` | `vaf-feldinventar` + `vaf-termsheet-mapping` |
| `vaf-rueckfragen` | `vaf-rueckfrageninterview` |
| `vaf-ausfuellprotokoll` | `vaf-plausibilitaetscheck` + `vaf-clean-output` |
| `vaf-track-changes` | `vaf-track-changes-nur-nach-frage` |
| (neu ergaenzt) | `vaf-redline-qa` |

### `lesefassung-konsolidiert`

| nicht-existent | -> echte Skills |
|---|---|
| `bgbl-veroeffentlichung-vorbereiten` | `dokumente-rendern-docx-pdf` |
| (neu ergaenzt) | `referentenentwurf-bauen`, `inkrafttreten-uebergangsrecht` |

### `revisionsfest-pruefen`

| nicht-existent | -> echte Skills |
|---|---|
| `urteil-erstellen` | `dokumente-rendern-urteil-docx` |
| (konkretisiert) | „zurueck zum mangelhaften Skill" -> namentliche Liste: `tatbestand-zivil-schreiben`, `entscheidungsgruende-zivil-schreiben`, `beweiswuerdigung-mit-richter-input`, `anspruchsgrundlagen-pruefen` |

## Verifikation

Alle 24 jetzt referenzierten Skill-IDs durch `[ -d <plugin>/skills/<id> ]` gegengeprueft — alle OK. Workflow-Handoffs routen jetzt zu echten Folge-Skills.

`scripts/validate-plugin-structure.mjs`: gruen.

## Test-Plan

- [ ] In Cowork installieren — alle vier Skills laden, Schnittstellen-Links funktionieren
- [ ] `grep -rn "kanzlei-allgemein-fristen-kalender\|kanzlei-allgemein-bea-postfach\|kanzlei-allgemein-mandanten-kommunikation\|vaf-vertragsdatenmatrix\|vaf-ausfuellprotokoll\|bgbl-veroeffentlichung-vorbereiten\|urteil-erstellen" .` ausserhalb von dist/ und protokolle/: keine Treffer mehr

---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_