### PR TITLE
Codex-P1-Fix: einseitige Erledigung ist Urteil, nicht Beschluss (beschluss-bauen-zpo)

### DIFF
--- a/urteilsbauer-relationsmacher/skills/beschluss-bauen-zpo/SKILL.md
+++ b/urteilsbauer-relationsmacher/skills/beschluss-bauen-zpo/SKILL.md
@@ -122,19 +122,22 @@ Die vom Beklagten an den Klaeger zu erstattenden Kosten werden auf
 Basiszinssatz seit Rechtshaengigkeit (Paragraf 104 I 2 ZPO) zu zahlen.
 ```
 
-### Erledigungsbeschluss Paragraf 91a ZPO
+### Erledigungsbeschluss Paragraf 91a ZPO — **nur bei uebereinstimmender Erledigungserklaerung**
+
+Der Erledigungsbeschluss nach Paragraf 91a ZPO ergeht **nur**, wenn **beide Parteien** den Rechtsstreit uebereinstimmend fuer erledigt erklaert haben. Er enthaelt **nur die Kostenentscheidung**.
 
 ```
 Die Kosten des Rechtsstreits werden gegeneinander aufgehoben
 (Paragraf 91a I 1 ZPO).
 ```
 
-oder bei einseitiger Erledigungserklaerung mit folgender Klageabweisung:
+oder z.B.
 
 ```
-Es wird festgestellt, dass die Hauptsache erledigt ist.
-Die Kosten des Rechtsstreits traegt der Beklagte.
+Die Kosten des Rechtsstreits traegt der Beklagte (Paragraf 91a I 1 ZPO).
 ```
+
+> **Achtung — abgrenzende Konstellation**: Bei **einseitiger** Erledigungserklaerung, der die Gegenseite **widerspricht**, ist der Streitgegenstand gewandelt zur Feststellung der Erledigung. Darueber wird **durch Urteil** entschieden (nicht durch Beschluss nach Paragraf 91a ZPO), mit Tenor „Es wird festgestellt, dass die Hauptsache erledigt ist" und voller Kostenentscheidung nach Paragraf 91 ZPO. Tenor und Urteilsbegruendung gehoeren dann nicht in diesen Beschluss-Skill, sondern in `tenor-bauen-zivil` und `entscheidungsgruende-zivil-schreiben`.
 
 ## 4) Begruendungsmuster
 


### PR DESCRIPTION
## Codex-P1-Bug adressiert

Codex hatte in der Review zu PR #15 (P1, also Hauptbug) zu Recht angemerkt, dass im Skill `beschluss-bauen-zpo` ein **juristisch falscher Tenor-Block** unter der Erledigungsbeschluss-Sektion stand:

```
Es wird festgestellt, dass die Hauptsache erledigt ist.
Die Kosten des Rechtsstreits traegt der Beklagte.
```

Diese Konstellation (einseitige Erledigungserklaerung mit Bestreiten der Gegenseite) wird **durch Urteil** entschieden, nicht durch Beschluss nach Paragraf 91a ZPO. Ein Plugin-Nutzer, der dem Skill verbatim folgt, haette die falsche Entscheidungsform gewaehlt.

## Korrekt

| Konstellation | Entscheidungsform | Rechtsgrundlage |
|---|---|---|
| **Beidseitige** Erledigungserklaerung | **Beschluss** | Paragraf 91a ZPO, nur Kostenentscheidung |
| **Einseitige** Erledigungserklaerung + Bestreiten Gegenseite | **Urteil** | Paragraf 91 ZPO, Feststellung + Kosten |

## Korrektur in `beschluss-bauen-zpo`

1. Falsche Tenor-Variante aus dem Erledigungsbeschluss-Abschnitt entfernt.
2. Ueberschrift praezisiert: „Erledigungsbeschluss Paragraf 91a ZPO — **nur bei uebereinstimmender Erledigungserklaerung**".
3. **Abgrenzungs-Box** ergaenzt mit Hinweis auf die Urteils-Konstellation und Verweis auf die korrekten Folge-Skills:
   - `tenor-bauen-zivil` (fuer den „Es wird festgestellt..."-Tenor im Urteil)
   - `entscheidungsgruende-zivil-schreiben` (fuer die Urteilsbegruendung)

## Verifikation

- `scripts/validate-plugin-structure.mjs`: gruen
- Verweise auf `tenor-bauen-zivil` und `entscheidungsgruende-zivil-schreiben` existieren im Plugin-Verzeichnis

## Test-Plan

- [ ] Skill aufrufen, Tenor-Bausteine fuer Erledigungsbeschluss enthalten nur reine Kostenentscheidung
- [ ] Abgrenzungs-Box weist klar auf die Urteils-Konstellation hin
- [ ] Bei einseitiger Erledigung: Nutzer wird zu `tenor-bauen-zivil` und `entscheidungsgruende-zivil-schreiben` geleitet

---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_