### PR TITLE
Codex-Audit-Anfrage A: Drei Werkstatt-Skills (beschluss-bauen-zpo, aktenintake-zivil, revisionsfest-pruefen)

### DIFF
--- a/audits/2026-05-23-werkstatt-skills-codex-review.md
+++ b/audits/2026-05-23-werkstatt-skills-codex-review.md
@@ -1,0 +1,54 @@
+# Codex-Audit-Anfrage 2026-05-23: Werkstatt-Skills aus PR #13
+
+@codex review
+
+## Kontext
+
+PR #13 (Commit `54bd016d`) hat drei Stub-Skills im Plugin
+`urteilsbauer-relationsmacher` substantiell ausgebaut. Codex hatte
+bei der ursprünglichen Review zwei juristische Bugs gefunden, die
+in PR #15 und PR #16 bereits adressiert wurden.
+
+Jetzt: vollständiger juristischer Zweit-Review der drei Skills.
+
+## Bitte-an-Codex
+
+Bitte prüfe die folgenden drei Skill-Dateien gezielt auf:
+
+1. **Juristische Korrektheit der BGH-/BVerfG-Zitate**
+   — existieren die zitierten Aktenzeichen?
+   — passen Aktenzeichen, Jahrgang, Fundstelle und Randnummer zusammen?
+   — sind die Aussagen, die ihnen zugeschrieben werden, im Beleg-Urteil
+     tatsächlich enthalten?
+
+2. **Paragrafen-Verweise**
+   — sind alle ZPO-, BGB-, GVG-Paragrafen tatbestandsmäßig richtig
+     verortet?
+   — gibt es Verweise auf Paragrafen, die so nicht (mehr) existieren?
+   — sind Absatz-Verweise korrekt?
+
+3. **Tenor-Bausteine und Begründungsmuster**
+   — sind die vorgeschlagenen Tenor-Formulierungen juristisch korrekt?
+   — passen Entscheidungsform (Urteil/Versäumnisurteil/Beschluss) und
+     Rechtsgrundlage zusammen (vgl. PR #16 zum einseitige-Erledigung-Bug)?
+   — sind die typischen Fehler-Listen vollständig oder fehlen wichtige
+     Klassiker?
+
+4. **Workflow-Handoffs zu anderen Skills**
+   — referenzieren die Skills nur Skill-IDs, die im Repo tatsächlich
+     existieren? (vgl. PR #15)
+
+## Zu prüfende Dateien
+
+- `urteilsbauer-relationsmacher/skills/beschluss-bauen-zpo/SKILL.md`
+- `urteilsbauer-relationsmacher/skills/aktenintake-zivil/SKILL.md`
+- `urteilsbauer-relationsmacher/skills/revisionsfest-pruefen/SKILL.md`
+
+## Schweregrad-Bitte
+
+Bitte als P1 (juristischer Fehler, der zu falscher Entscheidung führen
+würde), P2 (handwerklicher Mangel, formal falsch aber nicht ergebnis-
+verfälschend) oder P3 (Stil, kosmetisch) klassifizieren.
+
+Findings werden nicht in diesem PR adressiert — dieser PR ist eine
+reine Review-Anforderung. Etwaige Fixes folgen in eigenen Hotfix-PRs.


### PR DESCRIPTION
@codex review

## Was

Bitte um vollstaendigen juristischen Zweit-Review der drei in PR #13 ausgebauten Werkstatt-Skills im Plugin `urteilsbauer-relationsmacher`:

- `urteilsbauer-relationsmacher/skills/beschluss-bauen-zpo/SKILL.md`
- `urteilsbauer-relationsmacher/skills/aktenintake-zivil/SKILL.md`
- `urteilsbauer-relationsmacher/skills/revisionsfest-pruefen/SKILL.md`

## Warum

Codex hat in PR #14 und PR #13 bereits **zwei juristische Bugs** in genau diesen Skills gefangen (nicht-existente Skill-IDs P2, einseitige Erledigung als Beschluss statt Urteil P1). Bevor diese drei Skills in Schulungen eingesetzt werden, soll Codex eine vollstaendige Pruefung machen.

## Pruef-Punkte

1. **BGH-/BVerfG-Zitate** — Aktenzeichen, Jahrgang, Fundstelle, Randnummer und die zugeschriebene Aussage gegenpruefen.
2. **Paragrafen-Verweise** ZPO/BGB/GVG — tatbestandsmaessig korrekt, Absatz-Verweise stimmig.
3. **Tenor-Bausteine und Begruendungsmuster** — Entscheidungsform passt zur Rechtsgrundlage.
4. **Workflow-Handoffs** — alle referenzierten Skill-IDs existieren im Repo.

## Schweregrade

Bitte als **P1** (juristischer Fehler mit Ergebnis-Risiko), **P2** (handwerklicher Mangel ohne Ergebnis-Verfaelschung) oder **P3** (Stil, kosmetisch) klassifizieren.

## Was passiert mit Findings

Findings werden **nicht** in diesem PR adressiert. Etwaige Fixes folgen als separate Hotfix-PRs (Pattern wie PR #15 + #16). Dieser PR ist eine reine Review-Anforderung und wird nach Codex-Review wieder geschlossen oder als Konsens-Stand gemerged.

Volltext der Bitte siehe `audits/2026-05-23-werkstatt-skills-codex-review.md`.