### PR TITLE
Arbeitsrecht-Audit-Fixes: Streitwert GKG (KostO ausser Kraft), § 102 BetrVG Zustimmungsfiktion praezisiert, § 14 Abs. 3 TzBfG Voraussetzungen vollstaendigt

### DIFF
--- a/fachanwalt-arbeitsrecht/skills/fachanwalt-arbeitsrecht-befristung-tzbfg/SKILL.md
+++ b/fachanwalt-arbeitsrecht/skills/fachanwalt-arbeitsrecht-befristung-tzbfg/SKILL.md
@@ -20,7 +20,7 @@ description: Befristung nach TzBfG. Schriftform vor Beschaeftigungsbeginn § 14 
 - **Sachgrundlos:** § 14 Abs. 2 TzBfG — bis zu zwei Jahre, höchstens dreimalige Verlängerung in dieser Zeit.
 - **Vorbeschäftigungsverbot:** § 14 Abs. 2 S. 2 TzBfG — keine sachgrundlose Befristung, wenn bereits zuvor ein Arbeitsverhältnis mit demselben Arbeitgeber bestanden hat. Sehr lange zurückliegende Vorbeschäftigungen können nach BVerfG, Beschl. v. 06.06.2018 – Az. 1 BvL 7/14, BVerfGE 149, 126 Rn. 63 ff. in eng begrenzten Fällen unbeachtlich sein.
 - **Befristungskontrollklage:** § 17 TzBfG — drei Wochen nach vereinbartem Ende; Versäumung führt zur Fiktion der Wirksamkeit (§ 17 S. 2 iVm § 7 KSchG).
-- **Neueinstellung Älterer:** § 14 Abs. 3 TzBfG — sachgrundlose Befristung bis fünf Jahre bei vorheriger Arbeitslosigkeit ab Vollendung 52. Lebensjahr.
+- **Neueinstellung Älterer:** § 14 Abs. 3 TzBfG — sachgrundlose Befristung bis fünf Jahre, wenn der Arbeitnehmer bei Beginn des befristeten Arbeitsverhältnisses das 52. Lebensjahr vollendet hat **und** unmittelbar vor Beginn des Arbeitsverhältnisses **mindestens vier Monate** beschäftigungslos war (§ 138 SGB III), Transferkurzarbeitergeld bezog oder an einer Massnahme nach SGB II/III teilgenommen hat. Mehrfachverlaengerung innerhalb der Gesamtdauer von fünf Jahren zulaessig.
 - **Wissenschaftszeitvertragsgesetz (WissZeitVG):** Sondergesetz für Wissenschaft.
 
 ## Sachgründe (§ 14 Abs. 1 S. 2 TzBfG)

--- a/fachanwalt-arbeitsrecht/skills/fachanwalt-arbeitsrecht-betriebsratsanhoerung/SKILL.md
+++ b/fachanwalt-arbeitsrecht/skills/fachanwalt-arbeitsrecht-betriebsratsanhoerung/SKILL.md
@@ -19,8 +19,8 @@ description: Anhoerung des Betriebsrats nach § 102 BetrVG vor jeder Kuendigung.
 - **Stellungnahmefristen § 102 Abs. 2 BetrVG:**
   - ordentliche Kündigung: eine Woche
   - außerordentliche Kündigung: drei Tage
-- **Widerspruchsgründe § 102 Abs. 3 BetrVG** (z. B. unzureichende Sozialauswahl, andere Beschäftigungsmöglichkeiten).
-- **Weiterbeschäftigungsanspruch § 102 Abs. 5 BetrVG** bei Widerspruch und Klage.
+- **Widerspruchsgründe § 102 Abs. 3 BetrVG** — nur gegen **ordentliche** Kündigungen (z. B. unzureichende Sozialauswahl, andere Beschäftigungsmöglichkeiten); ein Widerspruch des Betriebsrats gegen eine ausserordentliche Kündigung ist gesetzlich nicht vorgesehen.
+- **Weiterbeschäftigungsanspruch § 102 Abs. 5 BetrVG** bei Widerspruch und Klage gegen eine ordentliche Kündigung.
 - **§ 79 BetrVG** Verschwiegenheitspflicht; bei sensiblen Daten Schwärzung.
 
 ## Mindestinhalt der Anhörung
@@ -46,9 +46,8 @@ Eine unvollständige Anhörung ist regelmäßig nicht ordnungsgemäß (BAG, Urt.
 4. Anhörung vor Ausspruch der Kündigung.
 5. Fristbeginn mit Zugang bei Vorsitz BR (§ 26 Abs. 2 BetrVG).
 6. Stellungnahme abwarten oder Schweigen der Frist
-   - ordentlich: 1 Woche
-   - außerordentlich: 3 Tage
-   Bei Schweigen Zustimmungsfiktion (§ 102 Abs. 2 S. 2 BetrVG).
+   - ordentlich: 1 Woche — Schweigen = Zustimmungsfiktion § 102 Abs. 2 S. 2 BetrVG.
+   - ausserordentlich: 3 Tage — keine Zustimmungsfiktion im Gesetz; bei Schweigen oder Stellungnahme gilt die Anhoerung als abgeschlossen, die Kuendigung kann ausgesprochen werden (BAG, st. Rspr.).
 7. Bei Widerspruch § 102 Abs. 3 BetrVG: Weiterbeschäftigungsanspruch § 102 Abs. 5 BetrVG.
 8. Dokumentation für späteren Prozess.
 ```

--- a/fachanwalt-arbeitsrecht/skills/fachanwalt-arbeitsrecht-kuendigungsschutzklage/SKILL.md
+++ b/fachanwalt-arbeitsrecht/skills/fachanwalt-arbeitsrecht-kuendigungsschutzklage/SKILL.md
@@ -86,7 +86,7 @@ und beantragen, das Gericht möge nach mündlicher Verhandlung wie folgt erkenne
 3. Hilfsweise: Das Arbeitsverhältnis wird gegen Zahlung einer angemessenen Abfindung gemäß § 9 KSchG aufgelöst.
 4. Die Beklagte trägt die Kosten des Rechtsstreits.
 
-Streitwert: drei Bruttomonatsgehälter (§ 42 Abs. 2 GKG iVm § 2 KostO).
+Streitwert: drei Bruttomonatsverdienste (§ 42 Abs. 2 S. 1 GKG — Vierteljahresverdienst, Hoechstgrenze).
 
 Sachverhalt:
 [Anstellungsdaten, Tätigkeit, Lohn, Kündigung, Anhörung Betriebsrat, Sonderkündigungsschutz]


### PR DESCRIPTION
@codex review

Bitte juristisch zweitpruefen — drei konkrete Fixes nach manuellem Audit:

## Fix 1 (P1): Kuendigungsschutzklage — Streitwert-Norm korrigiert

**Datei:** `fachanwalt-arbeitsrecht/skills/fachanwalt-arbeitsrecht-kuendigungsschutzklage/SKILL.md`

- **Vorher:** `Streitwert: drei Bruttomonatsgehälter (§ 42 Abs. 2 GKG iVm § 2 KostO).`
- **Nachher:** `Streitwert: drei Bruttomonatsverdienste (§ 42 Abs. 2 S. 1 GKG — Vierteljahresverdienst, Hoechstgrenze).`
- **Grund:** Die **Kostenordnung (KostO) ist seit 01.08.2013 ausser Kraft** und durch das GNotKG ersetzt. Der bisherige Verweis "iVm § 2 KostO" ist tot. Streitwert fuer Bestandsschutzstreitigkeiten ist allein § 42 Abs. 2 S. 1 GKG (Vierteljahresverdienst als Hoechstgrenze).

## Fix 2 (P2): Betriebsratsanhoerung — Zustimmungsfiktion und Widerspruchsrecht praezisiert

**Datei:** `fachanwalt-arbeitsrecht/skills/fachanwalt-arbeitsrecht-betriebsratsanhoerung/SKILL.md`

- **Vorher Pruefschema-Punkt 6:** "Bei Schweigen Zustimmungsfiktion (§ 102 Abs. 2 S. 2 BetrVG)." — pauschal fuer ordentlich und ausserordentlich
- **Nachher:** Differenzierung — ordentliche Kuendigung: Schweigen = Zustimmungsfiktion § 102 Abs. 2 S. 2 BetrVG. Ausserordentliche Kuendigung: keine Zustimmungsfiktion im Gesetz; Anhoerung gilt nach Ablauf der 3-Tage-Frist als abgeschlossen.
- **Grund:** Der Gesetzeswortlaut von § 102 Abs. 2 S. 2 BetrVG sieht die Zustimmungsfiktion **nur** fuer die ordentliche Kuendigung vor (Bedenken-Frist 1 Woche). Fuer die ausserordentliche Kuendigung sagt § 102 Abs. 2 S. 3 BetrVG nur, dass Bedenken "unverzueglich, spaetestens innerhalb von drei Tagen" mitzuteilen sind — ohne Fiktionswirkung. Die pauschale Aussage war juristisch ungenau.
- **Zusatz:** Auch der Hinweis auf das Widerspruchsrecht § 102 Abs. 3 BetrVG wurde dahingehend praezisiert, dass dieses **nur gegen ordentliche** Kuendigungen besteht.

## Fix 3 (P2): Befristung — § 14 Abs. 3 TzBfG Voraussetzungen vollstaendigt

**Datei:** `fachanwalt-arbeitsrecht/skills/fachanwalt-arbeitsrecht-befristung-tzbfg/SKILL.md`

- **Vorher:** "sachgrundlose Befristung bis fuenf Jahre bei vorheriger Arbeitslosigkeit ab Vollendung 52. Lebensjahr."
- **Nachher:** Volltext der Voraussetzungen: Vollendung 52. Lebensjahr UND unmittelbar zuvor mindestens 4 Monate beschaeftigungslos (§ 138 SGB III) oder Transferkurzarbeitergeld oder Massnahme nach SGB II/III. Mehrfachverlaengerung innerhalb der 5 Jahre zulaessig.
- **Grund:** Die 4-Monats-Mindestdauer der Beschaeftigungslosigkeit ist tatbestandliche Voraussetzung von § 14 Abs. 3 TzBfG. Ohne Erwaehnung dieser Mindestdauer waere die Vorschrift faelschlich auch auf kurzfristig Arbeitslose anwendbar.

## Bitte an Codex

- Verifiziere die drei Korrekturen gegen aktuelle Gesetzeslage und BAG-Rechtsprechung.
- Bitte ergaenzend: Findest du in den drei verbleibenden Skills (orientierung, kuendigungsschutzklage, betriebsratsanhoerung, befristung-tzbfg) **weitere** P1/P2-Findings, die ich nicht erfasst habe? Insbesondere:
  - Stimmen alle BAG-Aktenzeichen?
  - Fehlen typische Mandate (AGG-Entschaedigung, Aufhebungsvertrag, Arbeitszeugnis)?
  - Stimmen die Schreibvorlagen prozessual?

Bei P1-Findings: bitte konkrete Patches vorschlagen (Datei + Zeile + Vorher + Nachher).
