### PR TITLE
Familienrecht-Audit-Fixes: § 232 FamFG bei Zugewinn falsch → § 261/262 FamFG (Gueterrechtssache); Unterhalt FamFG-Zustaendigkeit vollstaendigt

### DIFF
--- a/fachanwalt-familienrecht/skills/fachanwalt-familienrecht-unterhaltsberechnung/SKILL.md
+++ b/fachanwalt-familienrecht/skills/fachanwalt-familienrecht-unterhaltsberechnung/SKILL.md
@@ -27,7 +27,7 @@ description: "Kindesunterhalt nach Duesseldorfer Tabelle § 1601 ff. BGB. Trennu
 - Bereinigtes Nettoeinkommen: Brutto − Steuern − Sozialabgaben − berufsbedingte Aufwendungen (5 % pauschal, mindestens 50 EUR höchstens 150 EUR — st. Rspr.) − Vorsorgeaufwendungen (bis 4 % Bruttoeinkommen Altersvorsorge).
 - Halbteilungsgrundsatz: Nach Abzug Kindesunterhalt bleibt der Rest 50/50 unter Ehegatten verteilt (BGH XII ZR 25/06, Urt. v. 30.07.2008, Rn. 25 ff.).
 - Erwerbsobliegenheit § 1574 BGB — fiktives Einkommen bei vorwerfbarer Untätigkeit.
-- Selbstbehalt nach Düsseldorfer Tabelle Anmerkung A — angemessener Selbstbehalt 1.450 EUR (Erwerbstätige), notwendiger Selbstbehalt 1.200 EUR (gegenüber minderjährigen Kindern) — Stand 2025 jeweils prüfen.
+- Selbstbehalt nach Duesseldorfer Tabelle Anmerkung A — die konkreten Saetze (notwendiger Selbstbehalt gegenueber minderjaehrigen Kindern, angemessener Selbstbehalt gegenueber Ehegatten und volljaehrigen Kindern) werden in der Duesseldorfer Tabelle jaehrlich neu festgelegt; immer aktuelle Fassung des laufenden Jahres heranziehen, z.B. ueber OLG Duesseldorf Pressestelle oder unterhalt.net.
 - Rangfolge § 1609 BGB: 1. minderjährige unverheiratete Kinder + privilegierte Volljährige, 2. Elternteile betreuender Kinder, 3. Ehegatten ab Ehe über kurze Zeit, 4. nicht privilegierte Volljährige, 5. andere Verwandte.
 - Bei Mangelfall (Einkommen reicht nicht für alle Berechtigten): Mangelverteilung nach Quoten innerhalb desselben Rangs.
 
@@ -72,7 +72,7 @@ Mit kollegialen Gruessen
 
 ## Übergabe
 
-- Bei Verweigerung Auskunft: Stufenklage Familiengericht § 232 FamFG.
+- Bei Verweigerung Auskunft: Stufenklage Familiengericht; Unterhaltssache § 231 FamFG; oertliche Zustaendigkeit § 232 FamFG; sachliche Zustaendigkeit §§ 23a Abs. 1 Nr. 1, 23b GVG.
 - Bei einstweiligem Regelungsbedarf einstweilige Anordnung § 246 FamFG (Trennungsunterhalt).
 - Bei Verfahrenskostenhilfe Anlage § 117 ZPO ausfüllen.
 - Anschluss bei Trennung: Skill `fachanwalt-familienrecht-scheidungsantrag-stellen`.

--- a/fachanwalt-familienrecht/skills/fachanwalt-familienrecht-zugewinnausgleich-berechnen/SKILL.md
+++ b/fachanwalt-familienrecht/skills/fachanwalt-familienrecht-zugewinnausgleich-berechnen/SKILL.md
@@ -77,7 +77,7 @@ Mit kollegialen Gruessen
 
 ## Übergabe
 
-- Bei Verweigerung: Stufenklage Auskunft + eidesstattliche Versicherung + Zahlung beim Familiengericht (§ 232 FamFG).
+- Bei Verweigerung: Stufenklage Auskunft + eidesstattliche Versicherung + Zahlung beim Familiengericht (Gueterrechtssache § 261 FamFG; Zustaendigkeit § 262 FamFG i.V.m. §§ 23a, 23b GVG).
 - Bei Auslandsvermögen Auskunftsanspruch erstreckt sich auch auf ausländisches Vermögen.
 - Bei Unternehmenswerten Sachverständigengutachten zur Bewertung notwendig — Kosten regelmäßig vorzustrecken.
 - Anschluss: Skill `fachanwalt-familienrecht-scheidungsantrag-stellen` bei Verbund nach § 137 FamFG.


### PR DESCRIPTION
@codex review

Bitte juristisch zweitpruefen — zwei FamFG-Zustaendigkeitskorrekturen:

## Fix 1 (P1): Zugewinnausgleich — falsche FamFG-Norm korrigiert

**Datei:** `fachanwalt-familienrecht/skills/fachanwalt-familienrecht-zugewinnausgleich-berechnen/SKILL.md`

- **Vorher:** "Stufenklage Auskunft + eidesstattliche Versicherung + Zahlung beim Familiengericht (§ 232 FamFG)."
- **Nachher:** "... Familiengericht (Gueterrechtssache § 261 FamFG; Zustaendigkeit § 262 FamFG i.V.m. §§ 23a, 23b GVG)."
- **Grund:** Der Zugewinnausgleich ist eine **Gueterrechtssache** und in § 261 FamFG (Definition) sowie § 262 FamFG (Zustaendigkeit) geregelt. § 232 FamFG ist die oertliche Zustaendigkeit fuer **Unterhaltssachen** — ein voellig anderer Verfahrensgegenstand. Die alte Norm war juristisch falsch zugeordnet.

## Fix 2 (P2): Unterhalt — FamFG-Zustaendigkeit vollstaendig dargestellt

**Datei:** `fachanwalt-familienrecht/skills/fachanwalt-familienrecht-unterhaltsberechnung/SKILL.md`

- **Vorher:** "Stufenklage Familiengericht § 232 FamFG."
- **Nachher:** "Unterhaltssache § 231 FamFG; oertliche Zustaendigkeit § 232 FamFG; sachliche Zustaendigkeit §§ 23a Abs. 1 Nr. 1, 23b GVG."
- **Grund:** § 232 FamFG ist hier zwar nicht falsch (oertliche Zustaendigkeit fuer Unterhaltssachen), aber unvollstaendig. Praesizion erfordert auch die sachliche Zustaendigkeit (GVG) und die definitionsnorm § 231 FamFG.

## Fix 3 (P3): Unterhalt — veraltete Selbstbehalts-Konkretzahlen entfernt

- **Vorher:** "angemessener Selbstbehalt 1.450 EUR (Erwerbstaetige), notwendiger Selbstbehalt 1.200 EUR (gegenueber minderjaehrigen Kindern) — Stand 2025 jeweils pruefen."
- **Nachher:** Keine Konkretzahlen mehr im Skill — Hinweis auf jaehrliche Neufestlegung in der Duesseldorfer Tabelle, immer aktuelle Fassung heranziehen.
- **Grund:** Konkrete EUR-Saetze veralten jaehrlich; im Skill stehende Zahlen werden in der Praxis fehlinterpretiert. Bei Bedarf jaehrlich von OLG Duesseldorf Pressestelle / Duesseldorfer Tabelle aktualisieren.

## Bitte an Codex

- Pruefe die anderen vier Familienrecht-Skills (orientierung, scheidungsantrag-stellen, mandat-triage, umgangsregelung, unterhalt-duesseldorfer-tabelle) auf Praezision.
- Beim Scheidungsantrag-Skill: Zustaendigkeit § 122 FamFG, Versorgungsausgleichs-Verbund § 137 FamFG.
- Beim Umgangs-Skill: § 1684 BGB, einstweilige Anordnung § 49 FamFG.
