### PR TITLE
Erbrecht-Audit-Fixes: BGH-AZ korrigiert IV ZR 232/12 + IV ZR 169/89 + Niederstwertprinzip

### DIFF
--- a/fachanwalt-erbrecht/skills/fachanwalt-erbrecht-pflichtteilsberechnung/SKILL.md
+++ b/fachanwalt-erbrecht/skills/fachanwalt-erbrecht-pflichtteilsberechnung/SKILL.md
@@ -26,7 +26,7 @@ description: "Pflichtteilsanspruch nach §§ 2303 ff. BGB pruefen und beziffern.
 
 - Pflichtteilsberechtigter trägt die Beweislast für seine Berechtigung und für die anspruchserhöhenden Tatsachen (Schenkungen).
 - Erbe trägt die Beweislast für anspruchsmindernde Tatsachen (Anrechnung, Erfüllung).
-- Verjährung drei Jahre nach § 195 BGB; Beginn nach § 199 Abs. 1 BGB mit Schluss des Jahres in dem der Pflichtteilsberechtigte Kenntnis vom Erbfall und von der ihn beeinträchtigenden Verfügung erlangt hat (st. Rspr., siehe BGH IV ZR 30/14, Urt. v. 16.01.2013, Rn. 11).
+- Verjährung drei Jahre nach § 195 BGB; Beginn nach § 199 Abs. 1 BGB mit Schluss des Jahres in dem der Pflichtteilsberechtigte Kenntnis vom Erbfall und von der ihn beeinträchtigenden Verfügung erlangt hat (BGH, Urt. v. 16.01.2013 – IV ZR 232/12, NJW 2013, 1086: einheitlicher unaufspaltbarer Pflichtteilsanspruch, keine erneute Verjährung bei später bekanntwerdenden Nachlassgegenständen).
 - Höchstfrist 30 Jahre ab Erbfall (§ 199 Abs. 3a BGB).
 
 ## Berechnungsschema

--- a/fachanwalt-erbrecht/skills/fachanwalt-erbrecht-testamentsentwurf/SKILL.md
+++ b/fachanwalt-erbrecht/skills/fachanwalt-erbrecht-testamentsentwurf/SKILL.md
@@ -35,7 +35,7 @@ Standardliteratur: Grüneberg BGB § 2247 ff.; MüKo-BGB / Leipold zu §§ 2247�
 | Teilungsanordnung § 2048 BGB | Verteilung unter Erben | Berührt nicht die Quote |
 | Pflichtteilsstrafklausel | Wer Pflichtteil verlangt verliert Schlusserbenstellung | Üblich im Berliner Testament |
 | Wiederverheiratungsklausel | Bedingte Verfügung bei Wiederheirat | Vorsicht — keine sittenwidrige Behinderung |
-| Behindertentestament Vor- und Nacherbschaft mit Dauer-TV | Schutz vor Sozialregress § 102 SGB XII | Anerkannt BGH IV ZR 7/89, Urt. v. 21.03.1990, Rn. 18 ff. |
+| Behindertentestament Vor- und Nacherbschaft mit Dauer-TV | Schutz vor Zugriff Sozialhilfeträger §§ 93 102 SGB XII | Grundsatzentscheidung BGH IV ZR 169/89, Urt. v. 21.03.1990, NJW 1990, 2055; bestätigt BGH IV ZR 231/92, Urt. v. 20.10.1993; Pflichtteilsverzicht BGH IV ZR 7/10, Urt. v. 19.01.2011. |
 
 ## Schreibvorlage eigenhändiges Berliner Testament
 
@@ -70,5 +70,5 @@ Saemtliche Verfuegungen sind wechselbezueglich § 2270 BGB.
 
 - Bei Vermögen über Freibeträgen (Ehegatte 500 TEUR Kinder 400 TEUR § 16 ErbStG) Hinweis auf Schenkungs-/Erbschaftsteuerberatung.
 - Bei Unternehmensvermögen Nachfolgeregelung gesondert prüfen (Begünstigungen §§ 13a, 13b ErbStG).
-- Empfehlung Hinterlegung beim Amtsgericht (§ 2248 BGB) — Hinterlegungsgebühr nach KostO/GNotKG.
+- Empfehlung Hinterlegung beim Amtsgericht (§ 2248 BGB) — Hinterlegungsgebühr nach GNotKG (KostO ist mit Wirkung zum 01.08.2013 außer Kraft getreten, Art. 9 2. KostRMoG).
 - Anschluss-Skill bei späterem Erbfall: `fachanwalt-erbrecht-erbschein-antrag`.

--- a/fachanwalt-erbrecht/skills/nachlassinsolvenz-erbenhaftung-begrenzen/SKILL.md
+++ b/fachanwalt-erbrecht/skills/nachlassinsolvenz-erbenhaftung-begrenzen/SKILL.md
@@ -46,8 +46,9 @@ Bei vermutlich überschuldetem Nachlass die Erbenhaftung begrenzen — vom Aussc
 
 ### Frist
 
-- **Nachlassgericht setzt Frist** § 1994 BGB
+- **Nachlassgericht setzt Frist auf Antrag eines Nachlassgläubigers** § 1994 Abs. 1 Satz 1 BGB (Glaubhaftmachung der Forderung erforderlich)
 - Bei Versäumnis unbeschränkte Haftung § 1994 Abs. 1 Satz 2 BGB
+- Freiwillige Inventarerrichtung ohne Antrag jederzeit möglich (§ 1993 BGB)
 
 ### Schutzwirkung
 
@@ -158,7 +159,7 @@ Bei vermutlich überschuldetem Nachlass die Erbenhaftung begrenzen — vom Aussc
 
 - Ungültige Letztwillige Verfügung — Anfechtung § 2082 BGB
 - Erb-Vertrag-Aufhebung
-- Pflichtteilsverzicht nichtig § 138 BGB
+- Pflichtteilsverzicht grundsätzlich wirksam bei notarieller Form § 2346 Abs. 2 iVm § 2348 BGB; Nichtigkeit nach § 138 BGB nur in besonderen Einzelfällen (z. B. Sittenwidrigkeit gegenüber behindertem Sozialhilfeempfänger ist nach BGH IV ZR 7/10 vom 19.01.2011 gerade nicht gegeben)
 
 ## Praktische Checkliste
 

--- a/fachanwalt-erbrecht/skills/pflichtteil-berechnen/SKILL.md
+++ b/fachanwalt-erbrecht/skills/pflichtteil-berechnen/SKILL.md
@@ -98,8 +98,8 @@ Schenkungen des Erblassers in den letzten zehn Jahren werden in einer abschmelze
 
 ### Bewertung der Schenkungen
 
-- Bei Geldschenkungen Nominalwert
-- Bei Sachzuwendungen Verkehrswert zum Stichtag der Schenkung — bei Wertsteigerung Stichtag des Erbfalls (Niedrigwerttheorie BGH IV ZR 263/95)
+- Verbrauchbare Sachen (Geld Wertpapiere) Wert zum Zeitpunkt der Schenkung (§ 2325 Abs. 2 Satz 1 BGB)
+- Nicht verbrauchbare Sachen (insb. Immobilien) Niederstwertprinzip § 2325 Abs. 2 Satz 2 BGB: Vergleich inflationsbereinigter Schenkungswert mit Wert zum Erbfall, der **niedrigere** Wert ist anzusetzen (st. Rspr. BGH IVa ZR 85/88, Urt. v. 19.04.1989; BGH IV ZR 259/92, Urt. v. 02.06.1993)
 
 ## Schritt 6 — Pflichtteilsquote x Berechnungsbasis
 


### PR DESCRIPTION
@codex review

Bitte juristisch zweitpruefen — 4 konkrete Fixes nach manuellem Audit der Erbrecht-Skills:

## Fix 1 (P1): BGH-Aktenzeichen fuer Pflichtteils-Verjaehrung korrigiert
**Datei:** `fachanwalt-erbrecht/skills/fachanwalt-erbrecht-pflichtteilsberechnung/SKILL.md`
- **Vorher:** "st. Rspr., siehe BGH IV ZR 30/14, Urt. v. 16.01.2013, Rn. 11"
- **Nachher:** "BGH, Urt. v. 16.01.2013 – IV ZR 232/12, NJW 2013, 1086: einheitlicher unaufspaltbarer Pflichtteilsanspruch, keine erneute Verjaehrung bei spaeter bekanntwerdenden Nachlassgegenstaenden"
- **Grund:** Das Aktenzeichen IV ZR 30/14 existiert nicht (IV ZR 30/14 ist ein anderer Fall vom 30.04.2014). Die zitierte Entscheidung zum Pflichtteil als einheitlichem Anspruch ist BGH IV ZR 232/12 vom 16.01.2013, NJW 2013, 1086 (verifiziert ueber dejure.org und erbrecht-lahn.de).

## Fix 2 (P1): Behindertentestament Leitentscheidung korrigiert
**Datei:** `fachanwalt-erbrecht/skills/fachanwalt-erbrecht-testamentsentwurf/SKILL.md`
- **Vorher:** "Anerkannt BGH IV ZR 7/89, Urt. v. 21.03.1990, Rn. 18 ff."
- **Nachher:** "Grundsatzentscheidung BGH IV ZR 169/89, Urt. v. 21.03.1990, NJW 1990, 2055; bestaetigt BGH IV ZR 231/92, Urt. v. 20.10.1993; Pflichtteilsverzicht BGH IV ZR 7/10, Urt. v. 19.01.2011."
- **Grund:** Das Behindertentestament-Grundsatzurteil ist BGH IV ZR 169/89 vom 21.03.1990 (NJW 1990, 2055), nicht IV ZR 7/89. Verifiziert ueber dejure.org, erbrecht-dav.de Aufsatz Hamann, OLG Hamm 10 U 13/16. Zusaetzlich Folgeentscheidungen aufgenommen und Geltungsbereich SGB XII auf §§ 93 (Anspruchsueberleitung) und 102 (Kostenersatz durch Erben) praezisiert.

## Fix 3 (P2): KostO ausser Kraft seit 01.08.2013
**Datei:** `fachanwalt-erbrecht/skills/fachanwalt-erbrecht-testamentsentwurf/SKILL.md`
- **Vorher:** "Hinterlegungsgebuehr nach KostO/GNotKG"
- **Nachher:** "Hinterlegungsgebuehr nach GNotKG (KostO ist mit Wirkung zum 01.08.2013 ausser Kraft getreten, Art. 9 2. KostRMoG)"
- **Grund:** Die KostO ist seit dem 01.08.2013 ausser Kraft (2. Kostenrechtsmodernisierungsgesetz). Gleicher Fehler wie im Arbeitsrecht-PR #21 behoben.

## Fix 4 (P1): Pflichtteilsverzicht-Beschreibung korrigiert und Niederstwertprinzip praezisiert
**Datei A:** `fachanwalt-erbrecht/skills/nachlassinsolvenz-erbenhaftung-begrenzen/SKILL.md`
- **Vorher:** "Pflichtteilsverzicht nichtig § 138 BGB"
- **Nachher:** "Pflichtteilsverzicht grundsaetzlich wirksam bei notarieller Form § 2346 Abs. 2 iVm § 2348 BGB; Nichtigkeit nach § 138 BGB nur in besonderen Einzelfaellen (z. B. Sittenwidrigkeit gegenueber behindertem Sozialhilfeempfaenger ist nach BGH IV ZR 7/10 vom 19.01.2011 gerade nicht gegeben)"
- **Grund:** Pauschale Aussage Pflichtteilsverzicht sei nichtig nach § 138 BGB ist falsch — § 2346 Abs. 2 BGB sieht ihn gerade vor. BGH IV ZR 7/10 hat ausdruecklich klargestellt, dass auch der Pflichtteilsverzicht eines Sozialhilfeempfaengers grundsaetzlich nicht sittenwidrig ist. Zusaetzlich: Inventarfrist § 1994 BGB praezisiert (nur auf Antrag eines Nachlassglaeubigers mit Glaubhaftmachung der Forderung, nicht von Amts wegen) sowie Hinweis auf freiwillige Inventarerrichtung § 1993 BGB ergaenzt.

**Datei B:** `fachanwalt-erbrecht/skills/pflichtteil-berechnen/SKILL.md`
- **Vorher:** "Bei Sachzuwendungen Verkehrswert zum Stichtag der Schenkung — bei Wertsteigerung Stichtag des Erbfalls (Niedrigwerttheorie BGH IV ZR 263/95)"
- **Nachher:** "Verbrauchbare Sachen (Geld Wertpapiere) Wert zum Zeitpunkt der Schenkung (§ 2325 Abs. 2 Satz 1 BGB); Nicht verbrauchbare Sachen (insb. Immobilien) Niederstwertprinzip § 2325 Abs. 2 Satz 2 BGB: Vergleich inflationsbereinigter Schenkungswert mit Wert zum Erbfall, der niedrigere Wert ist anzusetzen (st. Rspr. BGH IVa ZR 85/88, Urt. v. 19.04.1989; BGH IV ZR 259/92, Urt. v. 02.06.1993)"
- **Grund:** Korrekter Terminus ist Niederstwertprinzip (nicht Niedrigwerttheorie); gesetzliche Grundlage § 2325 Abs. 2 Satz 2 BGB; Leitentscheidung ist BGH IVa ZR 85/88 vom 19.04.1989, nicht IV ZR 263/95. Logik in der Vorgaengerformulierung war auch verdreht — das Niederstwertprinzip greift gerade nicht bei Wertsteigerung zugunsten des Pflichtteilsberechtigten, sondern schuetzt im Gegenteil davor.

## Bitte an Codex
- Pruefe die uebrigen Erbrecht-Skills (`fachanwalt-erbrecht-erbschein-antrag`, `fachanwalt-erbrecht-orientierung`, `mandat-triage-erbrecht`) auf weitere Paragrafen- und BGH-AZ-Fehler.
- Insbesondere in `pflichtteil-berechnen` Zeile 97 die Aktenzeichen BGH IV ZR 132/13 (Schenkung an Ehegatten, Fristbeginn) und BGH IV ZR 138/14 (Niessbrauch, Fristbeginn) gegen die tatsaechliche Rechtsprechung gegenpruefen — Standard-Entscheidungen sind eher BGH IV ZR 91/87 (Ehegatten) und BGH IV ZR 13/12 (Niessbrauch).
- Pruefe in `pflichtteil-berechnen` Zeile 80 das Aktenzeichen BGH IV ZR 132/76 (Erbschaftsteuer nicht abziehbar).
- Konkrete Patches mit Datei + Zeile + Vorher + Nachher willkommen.
