### PR TITLE
Strafrecht-Audit-Fixes: § 147 StPO Reform 2017 + § 25 GVG + § 32f StPO

### DIFF
--- a/fachanwalt-strafrecht/skills/fachanwalt-strafrecht-akteneinsicht-beantragen/SKILL.md
+++ b/fachanwalt-strafrecht/skills/fachanwalt-strafrecht-akteneinsicht-beantragen/SKILL.md
@@ -17,11 +17,11 @@ description: "Akteneinsicht § 147 StPO durch Verteidiger jederzeit waehrend Erm
 
 - Recht auf Akteneinsicht nach § 147 Abs. 1 StPO: Verteidiger darf die dem Gericht vorliegenden oder im Falle der Erhebung der Anklage vorzulegenden Akten einsehen und amtlich verwahrte Beweisstücke besichtigen.
 - Versagungsgrund § 147 Abs. 2 StPO: solange die Akten dem Gericht nicht vorliegen können einzelne Aktenteile bis zum Abschluss der Ermittlungen versagt werden, wenn der Untersuchungszweck gefährdet würde.
-- Aber: Bei Untersuchungshaft Akteneinsicht in haftbegründende Tatsachen unabhängig vom Untersuchungszweck (BVerfG 2 BvR 1487/11).
-- Beschuldigter selbst hat eingeschränktes Recht (§ 147 Abs. 4 StPO) — Auskünfte und Abschriften.
+- Aber: Bei Untersuchungshaft (oder beantragter U-Haft) müssen dem Verteidiger die für die Beurteilung der Rechtmäßigkeit der Freiheitsentziehung wesentlichen Informationen zugänglich gemacht werden (§ 147 Abs. 2 Satz 2 StPO; verfassungsrechtliche Verankerung BVerfG, Beschl. v. 11.07.1994, 2 BvR 777/94, NStZ 1994, 551; BVerfG, Beschl. v. 19.01.2006, 2 BvR 1075/05, NJW 2006, 1048).
+- Nicht verteidigter Beschuldigter: Seit dem 1.1.2018 (Gesetz vom 5.7.2017, BGBl I S. 2208) eigenes Akteneinsichtsrecht in entsprechender Anwendung der Abs. 1–3 (§ 147 Abs. 4 Satz 1 StPO); bei Papierakten Bereitstellung von Kopien möglich (§ 147 Abs. 4 Satz 2 StPO). Die alte Regelung (nur Auskünfte oder Abschriften nach § 147 Abs. 7 StPO a.F.) ist mit dieser Reform weggefallen.
 - Nebenkläger und Verletzte: § 406e StPO — eingeschränkt bei berechtigtem Interesse.
 - Elektronische Akteneinsicht nach § 32f StPO in Verbindung mit eAkte StPO.
-- Beschwerde gegen Versagung § 147 Abs. 5 StPO an das nächsthöhere Gericht.
+- Rechtsbehelf gegen Versagung: Antrag auf gerichtliche Entscheidung nach § 147 Abs. 5 Satz 2 StPO (zuständig das Gericht nach § 162 StPO), wenn die Staatsanwaltschaft nach Abschlussvermerk versagt, oder bei Versagung in den Fällen des § 147 Abs. 3 StPO oder wenn der Beschuldigte sich nicht auf freiem Fuß befindet.
 - Anwaltliche Schweigepflicht § 43a Abs. 2 BRAO — Akteninhalte vertraulich; bei Untersuchungshaft besonderer Schutz nach BVerfG.
 
 Standardliteratur: Meyer-Goßner/Schmitt StPO § 147; LR-StPO / Lüderssen/Jahn § 147; Beck'sches Strafverteidigerhandbuch.
@@ -30,7 +30,7 @@ Standardliteratur: Meyer-Goßner/Schmitt StPO § 147; LR-StPO / Lüderssen/Jahn 
 
 - Recht des Verteidigers ist umfassend, Begründung für Antrag nicht erforderlich — nur Identifikation des Aktenzeichens.
 - Versagungsentscheidung muss begründet werden (§ 147 Abs. 5 StPO).
-- Mitnahme der Akten zur Kanzlei möglich (§ 147 Abs. 4 Satz 2 StPO) bei Erfordernis sachgemäßer Verteidigung.
+- Mitnahme der Papierakten in die Kanzlei: auf besonderen Antrag, § 32f Abs. 2 Satz 3 StPO; Akten **werden** dem Verteidiger mitgegeben, sofern keine wichtigen Gründe entgegenstehen (kein Rechtsanspruch, Meyer-Goßner/Schmitt § 32f Rn. 10). Einsicht in elektronisch geführte Akten durch Bereitstellung zum Abruf, § 32f Abs. 1 StPO.
 - Dauer: keine gesetzliche Frist — bei Verzögerung Erinnerung und Beschwerde.
 
 ## Schreibvorlage Akteneinsichtsgesuch
@@ -72,6 +72,6 @@ Mit kollegialen Gruessen
 ## Übergabe
 
 - Nach Eingang der Akten: vollständige Sichtung, Aktenspiegel anlegen, Beweismittelübersicht erstellen.
-- Bei Versagung: Beschwerde nach § 147 Abs. 5 StPO an Oberlandesgericht / Amtsgericht.
+- Bei Versagung: Antrag auf gerichtliche Entscheidung nach § 147 Abs. 5 Satz 2 StPO bei dem nach § 162 StPO zuständigen Ermittlungsrichter.
 - Anschluss-Skill nach Aktenkenntnis: `fachanwalt-strafrecht-einlassung-vorbereiten` — Entscheidung Schweigen oder Einlassung mit Mandant abstimmen.
 - Bei Untersuchungshaft zusätzlich Haftprüfungsantrag (§ 117 StPO) und Haftbeschwerde (§ 304 StPO) prüfen.

--- a/fachanwalt-strafrecht/skills/fachanwalt-strafrecht-orientierung/SKILL.md
+++ b/fachanwalt-strafrecht/skills/fachanwalt-strafrecht-orientierung/SKILL.md
@@ -45,7 +45,7 @@ description: Orientierung im Strafrecht — FAO-Voraussetzungen Normen typische 
 
 ## Hauptgerichte
 
-- **Amtsgericht** Strafrichter (bis ein Jahr) Schöffengericht (bis vier Jahre).
+- **Amtsgericht** Strafrichter § 25 GVG (Vergehen Privatklage oder keine höhere Strafe als zwei Jahre zu erwarten) Schöffengericht § 28 GVG (bis vier Jahre Straferwartung).
 - **Landgericht** Grosse Strafkammer Wirtschaftsstrafkammer Schwurgericht.
 - **OLG** Berufungs- und Revisionsinstanz; Anklage erstinstanzlich bei Staatsschutzdelikten.
 - **BGH 1.–5. Strafsenat** Revisionsinstanz.


### PR DESCRIPTION
@codex review

Bitte juristisch zweitpruefen — 5 konkrete Fixes nach manuellem Audit der Strafrecht-Skills:

## Fix 1 (P1): Akteneinsichtsrecht des unverteidigten Beschuldigten aktualisiert
**Datei:** `fachanwalt-strafrecht/skills/fachanwalt-strafrecht-akteneinsicht-beantragen/SKILL.md`
- **Vorher:** "Beschuldigter selbst hat eingeschraenktes Recht (§ 147 Abs. 4 StPO) — Auskuenfte und Abschriften."
- **Nachher:** "Nicht verteidigter Beschuldigter: Seit dem 1.1.2018 (Gesetz vom 5.7.2017, BGBl I S. 2208) eigenes Akteneinsichtsrecht in entsprechender Anwendung der Abs. 1–3 (§ 147 Abs. 4 Satz 1 StPO); bei Papierakten Bereitstellung von Kopien moeglich (§ 147 Abs. 4 Satz 2 StPO). Die alte Regelung (nur Auskuenfte oder Abschriften nach § 147 Abs. 7 StPO a.F.) ist mit dieser Reform weggefallen."
- **Grund:** Die Aussage beschrieb die Rechtslage vor der StPO-Reform vom 5.7.2017 (in Kraft 1.1.2018). Seitdem hat der nicht verteidigte Beschuldigte ein eigenes Akteneinsichtsrecht in entsprechender Anwendung von Abs. 1 bis 3 (§ 147 Abs. 4 Satz 1 StPO), nicht nur Auskuenfte/Abschriften. Verifiziert ueber gesetze-im-internet.de, anwaltspraxis-magazin.de.

## Fix 2 (P1): Mitnahme der Akten falsch verortet
**Datei:** `fachanwalt-strafrecht/skills/fachanwalt-strafrecht-akteneinsicht-beantragen/SKILL.md`
- **Vorher:** "Mitnahme der Akten zur Kanzlei moeglich (§ 147 Abs. 4 Satz 2 StPO) bei Erfordernis sachgemaesser Verteidigung."
- **Nachher:** "Mitnahme der Papierakten in die Kanzlei: auf besonderen Antrag, § 32f Abs. 2 Satz 3 StPO; Akten werden dem Verteidiger mitgegeben, sofern keine wichtigen Gruende entgegenstehen (kein Rechtsanspruch, Meyer-Gossner/Schmitt § 32f Rn. 10). Einsicht in elektronisch gefuehrte Akten durch Bereitstellung zum Abruf, § 32f Abs. 1 StPO."
- **Grund:** § 147 Abs. 4 Satz 2 StPO regelt die Bereitstellung von Kopien fuer den unverteidigten Beschuldigten, nicht die Mitnahme durch den Verteidiger. Die Mitnahme von Papierakten ist seit dem 1.1.2018 in § 32f Abs. 2 Satz 3 StPO geregelt.

## Fix 3 (P1): Rechtsbehelf gegen Versagung praezisiert
**Datei:** `fachanwalt-strafrecht/skills/fachanwalt-strafrecht-akteneinsicht-beantragen/SKILL.md`
- **Vorher:** "Beschwerde gegen Versagung § 147 Abs. 5 StPO an das naechsthoehere Gericht."
- **Nachher:** "Rechtsbehelf gegen Versagung: Antrag auf gerichtliche Entscheidung nach § 147 Abs. 5 Satz 2 StPO (zustaendig das Gericht nach § 162 StPO), wenn die Staatsanwaltschaft nach Abschlussvermerk versagt, oder bei Versagung in den Faellen des § 147 Abs. 3 StPO oder wenn der Beschuldigte sich nicht auf freiem Fuss befindet."
- **Grund:** § 147 Abs. 5 StPO sieht keinen Rechtszug an das naechsthoehere Gericht vor, sondern einen Antrag auf gerichtliche Entscheidung beim nach § 162 StPO zustaendigen Ermittlungsrichter — und das nur unter den engen Voraussetzungen des § 147 Abs. 5 Satz 2 StPO. Verifiziert ueber gesetze-im-internet.de, anwaltspraxis-magazin.de Oktober 2021.

## Fix 4 (P2): U-Haft-Akteneinsicht mit aktueller gesetzlicher Verankerung
**Datei:** `fachanwalt-strafrecht/skills/fachanwalt-strafrecht-akteneinsicht-beantragen/SKILL.md`
- **Vorher:** "Bei Untersuchungshaft Akteneinsicht in haftbegruendende Tatsachen unabhaengig vom Untersuchungszweck (BVerfG 2 BvR 1487/11)."
- **Nachher:** "Bei Untersuchungshaft (oder beantragter U-Haft) muessen dem Verteidiger die fuer die Beurteilung der Rechtmaessigkeit der Freiheitsentziehung wesentlichen Informationen zugaenglich gemacht werden (§ 147 Abs. 2 Satz 2 StPO; verfassungsrechtliche Verankerung BVerfG, Beschl. v. 11.07.1994, 2 BvR 777/94, NStZ 1994, 551; BVerfG, Beschl. v. 19.01.2006, 2 BvR 1075/05, NJW 2006, 1048)."
- **Grund:** Seit der StPO-Reform vom 5.7.2017 ist die Akteneinsicht in haftrelevante Aktenbestandteile einfachgesetzlich in § 147 Abs. 2 Satz 2 StPO normiert. Das in der alten Fassung zitierte BVerfG-Aktenzeichen 2 BvR 1487/11 vom 19.01.2015 konnte ich nicht eindeutig verifizieren — habe deshalb die etablierten Leitentscheidungen 2 BvR 777/94 und 2 BvR 1075/05 aufgenommen.

## Fix 5 (P2): Strafrichter-Zustaendigkeit § 25 GVG korrigiert
**Datei:** `fachanwalt-strafrecht/skills/fachanwalt-strafrecht-orientierung/SKILL.md`
- **Vorher:** "**Amtsgericht** Strafrichter (bis ein Jahr) Schoeffengericht (bis vier Jahre)."
- **Nachher:** "**Amtsgericht** Strafrichter § 25 GVG (Vergehen Privatklage oder keine hoehere Strafe als zwei Jahre zu erwarten) Schoeffengericht § 28 GVG (bis vier Jahre Straferwartung)."
- **Grund:** § 25 GVG: Strafrichter ist zustaendig bei Vergehen, wenn keine hoehere Strafe als **zwei Jahre** Freiheitsstrafe zu erwarten ist — nicht ein Jahr. Verifiziert ueber gesetze-im-internet.de.

## Bitte an Codex
- Pruefe die uebrigen Strafrecht-Skills (`akteneinsicht-strafrecht-auswerten`, `fachanwalt-strafrecht-einlassung-vorbereiten`, `fachanwalt-strafrecht-hauptverhandlung-vorbereiten`, `mandat-triage-strafrecht`, `plaedoyer-vorbereitung-strafverteidigung`) auf Paragrafen- und BGH-AZ-Fehler.
- Insbesondere relevant: § 257c StPO Verstaendigung, § 273 StPO Hauptverhandlungsprotokoll, § 263 StGB Betrug, § 113/§ 114 StGB Widerstand, § 244 StPO Beweisantrag, BtMG-Verteidigung, JGG-Verfahren.
- Konkrete Patches mit Datei + Zeile + Vorher + Nachher willkommen.
