### PR TITLE
Sozialrecht-Audit-Fixes: § 12 III SGB II Karenzzeit + § 86b I Nr. 2 SGG

### DIFF
--- a/fachanwalt-sozialrecht/skills/fachanwalt-sozialrecht-sgb-ii-bescheid/SKILL.md
+++ b/fachanwalt-sozialrecht/skills/fachanwalt-sozialrecht-sgb-ii-bescheid/SKILL.md
@@ -38,7 +38,7 @@ description: SGB II Buergergeld-Bescheid. Bedarfsberechnung Regelbedarf § 20 Me
 5. Einkommensanrechnung
    - Bereinigung § 11b SGB II (Versicherungspauschale, Werbungskosten, Erwerbstätigenfreibetrag).
 6. Vermögen
-   - Freibeträge, Schonvermögen, Karenzzeit nach § 12 Abs. 4 SGB II.
+   - Freibeträge (§ 12 Abs. 2 SGB II: 15.000 EUR pro Person), Karenzzeit ein Jahr ab Erstbezug § 12 Abs. 3 SGB II (Vermögen nur bei Erheblichkeit berücksichtigt), Definition erhebliches Vermögen § 12 Abs. 4 SGB II (40.000 EUR / 15.000 EUR), Schonvermögen § 12 Abs. 1 SGB II.
 7. Sanktionen
    - Ist die Pflichtverletzung tatbestandlich? Rechtsfolgenbelehrung erfolgt?
 8. Verfahrensfehler

--- a/fachanwalt-sozialrecht/skills/fachanwalt-sozialrecht-widerspruch-sozialleistung/SKILL.md
+++ b/fachanwalt-sozialrecht/skills/fachanwalt-sozialrecht-widerspruch-sozialleistung/SKILL.md
@@ -73,7 +73,7 @@ ein.
 Begründung folgt binnen vier Wochen nach Akteneinsicht. Wir bitten um Übersendung der vollständigen Verwaltungsakte (§ 25 SGB X) sowie um Mitteilung des Sachbearbeiters.
 
 [Bei Wegfall der aufschiebenden Wirkung zusätzlich:]
-Zugleich wird beim zuständigen Sozialgericht parallel ein Antrag nach § 86b Abs. 2 SGG auf Wiederherstellung / Anordnung der aufschiebenden Wirkung gestellt.
+Zugleich wird beim zuständigen Sozialgericht parallel ein Antrag nach § 86b Abs. 1 Satz 1 Nr. 2 SGG auf Anordnung der aufschiebenden Wirkung gestellt (Anfechtungssituation, etwa bei § 39 SGB II); bei Verpflichtungs- bzw. Leistungsbegehren stattdessen einstweilige Anordnung nach § 86b Abs. 2 SGG.
 
 Anlagen:
 - Vollmacht


### PR DESCRIPTION
@codex review

Bitte juristisch zweitpruefen — 2 konkrete Fixes nach manuellem Audit der Sozialrecht-Skills:

## Fix 1 (P1): Karenzzeit § 12 SGB II in falschem Absatz verortet
**Datei:** `fachanwalt-sozialrecht/skills/fachanwalt-sozialrecht-sgb-ii-bescheid/SKILL.md`
- **Vorher:** "Freibetraege, Schonvermoegen, Karenzzeit nach § 12 Abs. 4 SGB II."
- **Nachher:** "Freibetraege (§ 12 Abs. 2 SGB II: 15.000 EUR pro Person), Karenzzeit ein Jahr ab Erstbezug § 12 Abs. 3 SGB II (Vermoegen nur bei Erheblichkeit beruecksichtigt), Definition erhebliches Vermoegen § 12 Abs. 4 SGB II (40.000 EUR / 15.000 EUR), Schonvermoegen § 12 Abs. 1 SGB II."
- **Grund:** Die Karenzzeit ist in § 12 Abs. 3 SGB II geregelt — nicht in Abs. 4. § 12 Abs. 4 SGB II definiert lediglich, was als erhebliches Vermoegen waehrend der Karenzzeit gilt (40.000 EUR / 15.000 EUR). Verifiziert ueber gesetze-im-internet.de § 12 SGB II.

## Fix 2 (P1): § 86b Abs. 2 SGG falsch verwiesen fuer Wiederherstellung aufschiebender Wirkung
**Datei:** `fachanwalt-sozialrecht/skills/fachanwalt-sozialrecht-widerspruch-sozialleistung/SKILL.md`
- **Vorher:** "Zugleich wird beim zustaendigen Sozialgericht parallel ein Antrag nach § 86b Abs. 2 SGG auf Wiederherstellung / Anordnung der aufschiebenden Wirkung gestellt."
- **Nachher:** "Zugleich wird beim zustaendigen Sozialgericht parallel ein Antrag nach § 86b Abs. 1 Satz 1 Nr. 2 SGG auf Anordnung der aufschiebenden Wirkung gestellt (Anfechtungssituation, etwa bei § 39 SGB II); bei Verpflichtungs- bzw. Leistungsbegehren stattdessen einstweilige Anordnung nach § 86b Abs. 2 SGG."
- **Grund:** § 86b Abs. 1 SGG regelt Wiederherstellung/Anordnung der aufschiebenden Wirkung in der Anfechtungssituation; § 86b Abs. 2 SGG ist die einstweilige Anordnung fuer Verpflichtungs-/Leistungsbegehren. Bei einem Aufhebungs-/Erstattungsbescheid SGB II (Widerspruch ohne aufschiebende Wirkung wegen § 39 SGB II) ist § 86b Abs. 1 Satz 1 Nr. 2 SGG einschlaegig — nicht Abs. 2. Verifiziert ueber gesetze-im-internet.de § 86b SGG, § 39 SGB II.

## Bitte an Codex
- Pruefe die uebrigen Sozialrecht-Skills (`fachanwalt-sozialrecht-erwerbsminderungsrente`, `fachanwalt-sozialrecht-orientierung`) auf Paragrafen- und BSG-AZ-Fehler.
- Insbesondere relevant: § 102 SGB VI Befristung (Gesamtdauer 9 Jahre fehlt im Erwerbsminderungs-Skill), § 109 SGG eigenes Gutachten, BSG GS 2/95 verschlossener Teilzeitarbeitsmarkt, BVerfG 1 BvL 7/16 Sanktionsurteil.
- SGB IX (Schwerbehinderung GdB, Pflegestufen, Eingliederungshilfe) und SGB V (Krankenkasse, Krankengeld) sind im Plugin derzeit nicht abgedeckt — sollte ggf. ergaenzt werden.
- Konkrete Patches mit Datei + Zeile + Vorher + Nachher willkommen.
