### PR TITLE
IT-Recht-Audit-Fixes: NIS2UmsuCG, TDDDG, DDG, §§ 327 ff. BGB, UsedSoft- und Symptomtheorie-AZ

### DIFF
--- a/fachanwalt-it-recht/skills/cyber-incident-response-72h/SKILL.md
+++ b/fachanwalt-it-recht/skills/cyber-incident-response-72h/SKILL.md
@@ -61,14 +61,14 @@ Bei aktivem Cyber-Vorfall sind die ersten 72 Stunden entscheidend — DSGVO-Meld
 
 - Art der Verletzung (Vertraulichkeits- Integritäts- Verfügbarkeits-Verlust)
 - Kategorien und Anzahl Betroffener
-- Kategorien und Anzahl betroffener Datensaetze
+- Kategorien und Anzahl betroffener Datensätze
 - Kontaktdaten DSB
 - Wahrscheinliche Folgen
 - Bereits ergriffene oder vorgeschlagene Maßnahmen
 
 ### Bei unvollständigen Informationen
 
-- Vorlaeufige Meldung möglich
+- Vorläufige Meldung möglich
 - Nachreichung unverzüglich
 
 ### Adressat
@@ -90,13 +90,14 @@ Bei aktivem Cyber-Vorfall sind die ersten 72 Stunden entscheidend — DSGVO-Meld
 ### Anwendbarkeit
 
 - Wenn Mandant unter NIS-2-Anwendungsbereich fällt
-- Wesentliche oder wichtige Einrichtung nach NIS2UmsuCG
+- Besonders wichtige oder wichtige Einrichtung nach NIS2UmsuCG (in Kraft seit 06.12.2025) — Rechtsgrundlage § 32 BSIG n.F.
 
-### Fristen
+### Fristen § 32 BSIG n.F.
 
-- **24 Stunden** Frühwarnung (initial)
-- **72 Stunden** Vorfallsmeldung (substantiiert)
-- **Ein Monat** Abschluss-Bericht
+- **24 Stunden** Frühwarnung (unverzüglich nach Kenntnis — Verdacht böswillige Handlung, grenzüberschreitende Auswirkungen)
+- **72 Stunden** Folgemeldung (Bewertung Schweregrad, Auswirkungen, Kompromittierungsindikatoren)
+- **Ein Monat** Abschlussbericht (Ursachenanalyse, Maßnahmen)
+- Zwischenmeldung auf Nachfrage des BSI
 
 ### Adressat
 
@@ -114,7 +115,7 @@ Bei aktivem Cyber-Vorfall sind die ersten 72 Stunden entscheidend — DSGVO-Meld
 - **§ 263a StGB** Computer-Betrug
 - **§ 303a StGB** Datenveränderung (Ransomware!)
 - **§ 303b StGB** Computer-Sabotage
-- **§ 269 StGB** Faelschung beweiserheblicher Daten
+- **§ 269 StGB** Fälschung beweiserheblicher Daten
 
 ### Anzeige beim Polizeipräsidium oder StA
 
@@ -226,7 +227,7 @@ Bei aktivem Cyber-Vorfall sind die ersten 72 Stunden entscheidend — DSGVO-Meld
 
 - DSGVO Art. 28 32 33 34
 - StGB §§ 202a–202d 263a 269 303a 303b
-- NIS2UmsuCG
+- NIS2UmsuCG (in Kraft seit 06.12.2025) — Meldepflichten § 32 BSIG n.F. Sanktionen § 65 BSIG n.F.
 - BetrVG § 87
 - BSI-Empfehlungen
 - DSK-Empfehlungen

--- a/fachanwalt-it-recht/skills/fachanwalt-it-recht-datenschutz-folgenabschaetzung/SKILL.md
+++ b/fachanwalt-it-recht/skills/fachanwalt-it-recht-datenschutz-folgenabschaetzung/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fachanwalt-it-recht-datenschutz-folgenabschaetzung
-description: "Datenschutz-Folgenabschaetzung nach Art. 35 DSGVO durchfuehren. Pflicht bei voraussichtlich hohem Risiko fuer Rechte und Freiheiten natuerlicher Personen insbesondere bei neuen Technologien systematischer Profilbildung umfangreicher Verarbeitung besonderer Kategorien § 9 DSGVO oder oeffentlichen Bereichen. Schwarze Liste der Aufsichtsbehoerden DSK beachten. Konsultation der Aufsichtsbehoerde Art. 36 DSGVO bei Restrisiko. Dokumentationspflicht Art. 30 DSGVO."
+description: "Datenschutz-Folgenabschaetzung nach Art. 35 DSGVO durchfuehren. Pflicht bei voraussichtlich hohem Risiko fuer Rechte und Freiheiten natuerlicher Personen insbesondere bei neuen Technologien systematischer Profilbildung umfangreicher Verarbeitung besonderer Kategorien Art. 9 DSGVO oder oeffentlichen Bereichen. Schwarze Liste der Aufsichtsbehoerden DSK beachten. Konsultation der Aufsichtsbehoerde Art. 36 DSGVO bei Restrisiko. Dokumentationspflicht Art. 30 DSGVO."
 ---
 
 # Datenschutz-Folgenabschätzung

--- a/fachanwalt-it-recht/skills/fachanwalt-it-recht-orientierung/SKILL.md
+++ b/fachanwalt-it-recht/skills/fachanwalt-it-recht-orientierung/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fachanwalt-it-recht-orientierung
-description: Orientierung im Informationstechnologierecht — FAO Voraussetzungen Normen typische Mandate Standardliteratur. Vertragsrecht IT (Software-Lizenz SaaS Cloud) DSGVO BDSG TTDSG TKG NIS2-Umsetzungsgesetz DDG (vormals TMG) DSA Digital Services Act DMA Digital Markets Act EU-KI-VO Verordnung 2024/1689. Open-Source-Compliance. Schnittstelle Plugin datenschutzrecht ki-governance vertragsrecht.
+description: Orientierung im Informationstechnologierecht — FAO Voraussetzungen Normen typische Mandate Standardliteratur. Vertragsrecht IT (Software-Lizenz SaaS Cloud) DSGVO BDSG TDDDG (vormals TTDSG) TKG NIS2-Umsetzungsgesetz BSIG n.F. DDG (vormals TMG) DSA Digital Services Act DMA Digital Markets Act EU-KI-VO Verordnung 2024/1689. Open-Source-Compliance. Schnittstelle Plugin datenschutzrecht ki-governance vertragsrecht.
 ---
 
 # Fachanwalt für Informationstechnologierecht — Orientierung
@@ -15,10 +15,10 @@ description: Orientierung im Informationstechnologierecht — FAO Voraussetzunge
 | Bereich | Norm |
 |---|---|
 | IT-Vertragsrecht | BGB §§ 305 ff. (AGB) §§ 631 ff. (Werkvertrag bei Softwareentwicklung) §§ 535 ff. (Mietrecht analog bei SaaS-Cloud-Modellen) |
-| Datenschutz | DSGVO BDSG TTDSG |
+| Datenschutz | DSGVO BDSG TDDDG (Telekommunikation-Digitale-Dienste-Datenschutz-Gesetz seit 14.05.2024 vormals TTDSG) |
 | Telekommunikation | TKG |
 | Digitale Dienste | DDG (Digitale-Dienste-Gesetz seit 14.05.2024 ersetzt TMG für Plattformbetreiber) |
-| Cybersicherheit | NIS2-Umsetzungsgesetz BSIG |
+| Cybersicherheit | NIS2UmsuCG (in Kraft seit 06.12.2025) BSIG n.F. § 32 BSIG Meldepflichten |
 | Plattformregulierung | DSA (EU 2022/2065) DMA (EU 2022/1925) |
 | Kuenstliche Intelligenz | EU-KI-VO (EU 2024/1689) |
 | Urheberrecht | UrhG bei Software §§ 69a ff. UrhG |
@@ -39,7 +39,7 @@ description: Orientierung im Informationstechnologierecht — FAO Voraussetzunge
 ## Fristen
 
 - **Datenpannenmeldung** DSGVO Art. 33 — 72 Stunden.
-- **NIS2-Meldepflicht** binnen 24 Stunden erste Meldung 72 Stunden Update.
+- **NIS2-Meldepflicht** § 32 BSIG n.F. — 24 Stunden Frühwarnung 72 Stunden Folgemeldung Abschlussbericht binnen eines Monats.
 - **Vertragsverjährung** regelmäßig drei Jahre (§ 195 BGB).
 - **Open-Source-Lizenzverletzung** Verjährung drei Jahre.
 

--- a/fachanwalt-it-recht/skills/mandat-triage-it-recht/SKILL.md
+++ b/fachanwalt-it-recht/skills/mandat-triage-it-recht/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mandat-triage-it-recht
-description: Strukturierte Eingangs-Abfrage fuer IT-rechtliche Mandate. Klaert Sachgebiet (Softwareerstellung Lizenzrecht SaaS Cloud Hosting IT-Sicherheit DSGVO IT-Compliance NIS-2 Cyber-Vorfall AI-Act KRITIS Telekommunikationsrecht TMG Provider-Haftung E-Commerce Domain-Recht Plattformrecht DSA) Mandantenrolle (Auftraggeber Auftragnehmer Plattform Hosting-Provider Nutzer) Vertragstyp Phase (vor Vertrag waehrend Projekt nach Abnahme Streit) Sofort-Fristen Cyber-Vorfall-Meldung 72-Stunden-DSGVO 24-Stunden-NIS-2 Stilllegungs-Anordnungen. Eskalation Telefon-Sofort bei Cyber-Vorfall Hacker-Angriff. Routing zu softwarefehler-mangelhaftung-pruefen.
+description: Strukturierte Eingangs-Abfrage fuer IT-rechtliche Mandate. Klaert Sachgebiet (Softwareerstellung Lizenzrecht SaaS Cloud Hosting IT-Sicherheit DSGVO IT-Compliance NIS-2 Cyber-Vorfall AI-Act KRITIS Telekommunikationsrecht TMG Provider-Haftung E-Commerce Domain-Recht Plattformrecht DSA TMG abgeloest durch DDG seit 14.05.2024) Mandantenrolle (Auftraggeber Auftragnehmer Plattform Hosting-Provider Nutzer) Vertragstyp Phase (vor Vertrag waehrend Projekt nach Abnahme Streit) Sofort-Fristen Cyber-Vorfall-Meldung 72-Stunden-DSGVO 24-Stunden-NIS-2 Stilllegungs-Anordnungen. Eskalation Telefon-Sofort bei Cyber-Vorfall Hacker-Angriff. Routing zu softwarefehler-mangelhaftung-pruefen.
 ---
 
 # Mandat-Triage IT-Recht
@@ -35,7 +35,7 @@ IT-Recht ist breit und stark im Wandel (DSGVO NIS-2 AI Act DSA). Triage stellt S
 - DSA Plattformhaftung
 - E-Commerce-Recht (Impressum AGB Verbraucherschutz)
 - Domain-Streit
-- Telekommunikationsrecht TKG
+- Telekommunikationsrecht TKG / TDDDG (vormals TTDSG)
 - IT-Strafrecht (§§ 202a 202b 202c 263a 303a 303b StGB)
 
 ### Frage 3 — Akute Eilbedürftigkeit?
@@ -135,7 +135,7 @@ Bei aktivem Hacker-Angriff:
 - BGB §§ 433 ff. 535 ff. 611 631 ff.
 - StGB §§ 202a 202b 202c 263a 303a 303b
 - DSGVO Art. 33 34
-- NIS-2-RL (in DE umgesetzt durch NIS2UmsuCG)
+- NIS-2-RL (in DE umgesetzt durch NIS2UmsuCG in Kraft seit 06.12.2025 — Hauptnorm § 32 BSIG n.F.)
 - AI Act
 - DSA
 - BGH VIII. Zivilsenat

--- a/fachanwalt-it-recht/skills/softwarefehler-mangelhaftung-pruefen/SKILL.md
+++ b/fachanwalt-it-recht/skills/softwarefehler-mangelhaftung-pruefen/SKILL.md
@@ -23,7 +23,7 @@ Software-Mängel sind häufige Streitthema — Bugs Performance-Probleme Schnitt
 | Konstellation | Vertragstyp |
 |---|---|
 | Standardsoftware auf Datenträger | Kaufrecht §§ 433 ff. BGB BGH VIII ZR 6/89 |
-| Standardsoftware-Download Lizenz-überlassung dauernd | Kaufrecht analog BGH VIII ZR 50/13 |
+| Standardsoftware-Download Lizenz-überlassung dauernd | Kaufrecht analog — Erschöpfung des Verbreitungsrechts § 69c Nr. 3 S. 2 UrhG BGH I ZR 129/08 v. 17.07.2013 (UsedSoft II); BGH I ZR 8/13 v. 11.12.2014 (UsedSoft III); EuGH C-128/11 v. 03.07.2012 (UsedSoft) |
 | Individualsoftware-Erstellung | Werkvertrag §§ 631 ff. BGB |
 | Software-Anpassung Customizing | Werkvertrag §§ 631 ff. BGB |
 | SaaS Software-as-a-Service | Mietrecht §§ 535 ff. BGB BGH XII ZR 120/04 ASP |
@@ -32,6 +32,14 @@ Software-Mängel sind häufige Streitthema — Bugs Performance-Probleme Schnitt
 | Lizenz-Überlassung zeitlich befristet | Mietrecht/Pacht analog |
 
 ## Schritt 2 — Mangelbegriff
+
+### Verbraucherverträge über digitale Produkte §§ 327 ff. BGB (seit 01.01.2022)
+
+- Eigenständige Mängelregelung für B2C-Verträge über digitale Inhalte/Dienstleistungen — auch wenn nur personenbezogene Daten als Gegenleistung
+- Aktualisierungspflicht § 327f BGB (Sicherheits- und Funktionsupdates)
+- Sachmangel § 327e BGB (subjektive und objektive Anforderungen)
+- Beweislastumkehr § 327k Abs. 1 BGB ein Jahr ab Bereitstellung
+- Verjährung § 327j BGB grundsätzlich zwei Jahre — bei dauerhafter Bereitstellung erweitert
 
 ### Kauf § 434 BGB
 
@@ -78,7 +86,7 @@ Software-Mängel sind häufige Streitthema — Bugs Performance-Probleme Schnitt
 
 ### Werk — Mangelrüge an sich
 
-- Substanziiert (Sympomtheorie BGH VII ZR 41/02)
+- Substanziiert (Symptomtheorie BGH VII ZR 210/96 v. 03.07.1997 — Grundsatz; bestätigt BGH VII ZR 41/14 v. 24.08.2016 — Mangelrüge erfasst alle Ursachen des bezeichneten Symptoms)
 - Fristsetzung zur Nachbesserung
 
 ## Schritt 5 — Nachbesserungsrecht
@@ -86,7 +94,7 @@ Software-Mängel sind häufige Streitthema — Bugs Performance-Probleme Schnitt
 - Erstmal Nacherfüllung § 439 BGB / § 635 BGB
 - Verkäufer Wahlrecht (Kauf) — Unternehmer Wahlrecht (Werk)
 - Frist setzen — angemessen unter Berücksichtigung Schwere Komplexität
-- Zwei Versuche im Kauf typisch BGH VIII ZR 159/97
+- Zwei Versuche im Kauf typisch (gesetzliche Vermutung Fehlschlagen nach zweitem Versuch § 440 S. 2 BGB)
 
 ## Schritt 6 — Sekundärrechte
 
@@ -100,8 +108,8 @@ Software-Mängel sind häufige Streitthema — Bugs Performance-Probleme Schnitt
 
 - **Kauf** zwei Jahre § 438 BGB ab Übergabe
 - **Werk** zwei Jahre § 634a BGB ab Abnahme
-- **Werk Bauwerk-Software** fünf Jahre — strittig ob ERP-Implementierung dazu zählt (eher nicht — BGH X ZR 76/05)
-- **Miete** drei Jahre § 195 BGB
+- **Werk Bauwerk-Software** fünf Jahre § 634a Abs. 1 Nr. 2 BGB — strittig ob ERP-Implementierung dazu zählt (eher nicht — BGH X ZR 76/05 v. 05.12.2006; vgl. BGH X ZR 57/02 v. 20.05.2003 zur Bauwerkseigenschaft technischer Anlagen)
+- **Miete/SaaS** Mängelrechte des Mieters ohne Sondervorschrift — Regelverjährung drei Jahre § 195 BGB (Ansprüche des Vermieters § 548 BGB sechs Monate ab Rückgabe)
 
 ## Schritt 8 — AGB-Kontrolle
 
@@ -143,7 +151,7 @@ Software-Mängel sind häufige Streitthema — Bugs Performance-Probleme Schnitt
 
 ## Quellen
 
-- BGB §§ 280 281 433 437 438 439 535 536 611 631–650 634a
+- BGB §§ 280 281 327 327a 327e 327f 327j 327k 433 437 438 439 440 535 536 611 631–650 634a 548
 - HGB § 377
 - DSGVO Art. 32 (Sicherheit)
 - BGH VIII. Zivilsenat VII. Zivilsenat X. Zivilsenat


### PR DESCRIPTION
@codex review

Bitte juristisch zweitpruefen — 9 konkrete Fixes nach manuellem Audit (Stand 23.05.2026, NIS2UmsuCG in Kraft seit 06.12.2025).

## Fix 1 (P1): Art. 9 DSGVO statt § 9 DSGVO
**Datei:** `fachanwalt-it-recht/skills/fachanwalt-it-recht-datenschutz-folgenabschaetzung/SKILL.md`
- **Vorher (description):** "besonderer Kategorien § 9 DSGVO"
- **Nachher (description):** "besonderer Kategorien Art. 9 DSGVO"
- **Grund:** Die DSGVO ist Verordnung — ihre Vorschriften heissen "Art.", nicht "§". Hauskonvention durchgaengig.

## Fix 2 (P1): TTDSG umbenannt zu TDDDG
**Datei:** `fachanwalt-it-recht/skills/fachanwalt-it-recht-orientierung/SKILL.md` (description Z. 3, Tabelle Z. 18)
- **Vorher:** "TTDSG"
- **Nachher:** "TDDDG (Telekommunikation-Digitale-Dienste-Datenschutz-Gesetz seit 14.05.2024 vormals TTDSG)"
- **Grund:** Das TTDSG wurde mit dem DDG-Begleitgesetz am 14.05.2024 in TDDDG umbenannt (Telekommunikation-Digitale-Dienste-Datenschutzgesetz). Quelle: LfD Niedersachsen FAQ TDDDG; siehe auch ascon-datenschutz.de zur Umbenennung.

## Fix 3 (P1): TMG durch DDG ersetzt — Mandat-Triage description
**Datei:** `fachanwalt-it-recht/skills/mandat-triage-it-recht/SKILL.md` (description, Z. 38)
- **Vorher:** "Telekommunikationsrecht TMG Provider-Haftung"
- **Nachher:** "TMG abgeloest durch DDG seit 14.05.2024 ... TKG / TDDDG (vormals TTDSG)"
- **Grund:** Das TMG ist mit Inkrafttreten des DDG am 14.05.2024 (BGBl. I Nr. 149) vollstaendig durch das Digitale-Dienste-Gesetz ersetzt worden — Umsetzung des Digital Services Act. Quelle: gesetz-digitale-dienste.de, IHK Nordschwarzwald.

## Fix 4 (P1): NIS2UmsuCG ist in Kraft — § 32 BSIG n.F. als Rechtsgrundlage
**Dateien:**
- `cyber-incident-response-72h/SKILL.md` (Z. 93, 95–100, Quellen 230)
- `fachanwalt-it-recht-orientierung/SKILL.md` (Tabelle, Fristen)
- `mandat-triage-it-recht/SKILL.md` (Quellen)
- **Vorher (Beispiel):** "NIS2UmsuCG" / "Wesentliche oder wichtige Einrichtung"
- **Nachher (Beispiel):** "NIS2UmsuCG (in Kraft seit 06.12.2025) — Rechtsgrundlage § 32 BSIG n.F.; Besonders wichtige oder wichtige Einrichtung"
- **Grund:** Das NIS2-Umsetzungs- und Cybersicherheitsstaerkungsgesetz wurde am 13.11.2025 vom Bundestag beschlossen, am 05.12.2025 im BGBl. verkuendet und ist am 06.12.2025 in Kraft getreten. Hauptmeldepflicht steht in § 32 BSIG n.F. — Bussgeldobergrenze § 65 BSIG n.F. Begrifflich heisst die hoehere Kategorie korrekt "besonders wichtige Einrichtung" (nicht "wesentliche"). Quellen: security-insider.de v. 14.11.2025, openkritis.de, bsig-gesetz.de.

## Fix 5 (P2): Symptomtheorie-AZ korrigiert
**Datei:** `fachanwalt-it-recht/skills/softwarefehler-mangelhaftung-pruefen/SKILL.md` (Z. 81)
- **Vorher:** "Substanziiert (Sympomtheorie BGH VII ZR 41/02)"
- **Nachher:** "Substanziiert (Symptomtheorie BGH VII ZR 210/96 v. 03.07.1997 — Grundsatz; bestaetigt BGH VII ZR 41/14 v. 24.08.2016 — Mangelruege erfasst alle Ursachen des bezeichneten Symptoms)"
- **Grund:** Das Aktenzeichen "VII ZR 41/02" existiert in dieser Sache nicht. Grundsatzurteil zur Symptomtheorie ist BGH VII ZR 210/96 v. 03.07.1997 (BauR 1997, 1029); juengste Bestaetigung BGH VII ZR 41/14 v. 24.08.2016. Quelle: jenanwalt.de, dejure.org.

## Fix 6 (P2): UsedSoft-Rechtsprechung praezisiert
**Datei:** `fachanwalt-it-recht/skills/softwarefehler-mangelhaftung-pruefen/SKILL.md` (Z. 26)
- **Vorher:** "Standardsoftware-Download Lizenz-ueberlassung dauernd | Kaufrecht analog BGH VIII ZR 50/13"
- **Nachher:** "Kaufrecht analog — Erschoepfung des Verbreitungsrechts § 69c Nr. 3 S. 2 UrhG BGH I ZR 129/08 v. 17.07.2013 (UsedSoft II); BGH I ZR 8/13 v. 11.12.2014 (UsedSoft III); EuGH C-128/11 v. 03.07.2012 (UsedSoft)"
- **Grund:** Die maßgebliche UsedSoft-Rechtsprechung steht im I. Zivilsenat (Urheberrecht), nicht im VIII. (Kaufrecht). Grundsatzurteil EuGH C-128/11; deutsche Umsetzung BGH I ZR 129/08 (UsedSoft II) und I ZR 8/13 (UsedSoft III). "VIII ZR 50/13" gibt es zu diesem Thema nicht. Quelle: dejure.org, vendosoft.eu.

## Fix 7 (P2): § 440 S. 2 BGB statt nicht-belegbarem BGH-AZ
**Datei:** `fachanwalt-it-recht/skills/softwarefehler-mangelhaftung-pruefen/SKILL.md` (Z. 89)
- **Vorher:** "Zwei Versuche im Kauf typisch BGH VIII ZR 159/97"
- **Nachher:** "Zwei Versuche im Kauf typisch (gesetzliche Vermutung Fehlschlagen nach zweitem Versuch § 440 S. 2 BGB)"
- **Grund:** Die "Zwei-Versuche-Regel" ergibt sich aus § 440 S. 2 BGB selbst, nicht aus einem alten BGH-Urteil von 1997 (vor der Schuldrechtsreform). Quelle: autokaufrecht.info.

## Fix 8 (P1): §§ 327 ff. BGB (digitale Produkte fuer Verbraucher) ergaenzt
**Datei:** `fachanwalt-it-recht/skills/softwarefehler-mangelhaftung-pruefen/SKILL.md` (neuer Block in Schritt 2)
- **Neu:** Eigener Abschnitt "Verbrauchervertraege ueber digitale Produkte §§ 327 ff. BGB (seit 01.01.2022)" mit Aktualisierungspflicht § 327f, Sachmangel § 327e, Beweislastumkehr § 327k, Verjaehrung § 327j.
- **Grund:** Die §§ 327 ff. BGB sind seit dem 01.01.2022 in Kraft (Umsetzung Richtlinie 2019/770) und sind die zentrale Anspruchsgrundlage fuer Verbrauchervertraege ueber Software/SaaS/digitale Inhalte. In einem aktuellen IT-Recht-Skill bisher komplett gefehlt. Quelle: BGBl. 2021, IHK Giessen, uni-trier.de Skript Neues Kaufrecht 2022.

## Fix 9 (P3): SaaS-Verjaehrung praezisiert + Umlaut-Konsistenz Cyber-Skill
**Dateien:** `softwarefehler-mangelhaftung-pruefen/SKILL.md` (Z. 104), `cyber-incident-response-72h/SKILL.md` (Z. 64, 71, 117)
- Z. 104 alt: "Miete drei Jahre § 195 BGB"
- Z. 104 neu: "Miete/SaaS Maengelrechte des Mieters ohne Sondervorschrift — Regelverjaehrung drei Jahre § 195 BGB (Ansprueche des Vermieters § 548 BGB sechs Monate ab Rueckgabe)"
- Cyber-Skill: "Faelschung"/"Datensaetze"/"Vorlaeufige" → "Fälschung"/"Datensätze"/"Vorläufige" (Umlaut-Konsistenz mit Rest der Datei)
- **Grund:** § 548 BGB regelt nur Vermieter-Ansprueche, nicht Mieter-Maengelrechte — die verjaehren regelmaessig. ASCII-Mix in Datei mit sonst durchgaengigen Umlauten ist Stil-Bruch.

## Bitte an Codex
- Pruefe `fachanwalt-it-recht-vertragsstrafe-pruefen` und `fachanwalt-it-recht-software-mangel` — beide noch nicht ediert — auf weitere AZ-Genauigkeit.
- Insbesondere BGH VII ZR 165/14 (Vertragsstrafe-Hoechstgrenze AGB) und BGH VII ZR 210/01 (5%-Bauvertrag-Grenze) und das neue BGH VII ZR 42/22 v. 15.02.2024 (Abrechnungssumme als Bezugsgroesse) sind dort einzuordnen.
- BGH VIII ZR 6/89 als AZ fuer Standardsoftware-als-Sache verifizieren — verbreiteter ist BGHZ 102, 135 = BGH VIII ZR 314/86 v. 18.10.1989.
- Konkrete Patches mit Datei + Zeile + Vorher + Nachher willkommen.
