### PR TITLE
Audit Wirtschaftsrecht-Cluster: 12 juristische Praezisierungen

### DIFF
--- a/fachanwalt-bank-kapitalmarktrecht/skills/anlageberatungsfehler-pruefen/SKILL.md
+++ b/fachanwalt-bank-kapitalmarktrecht/skills/anlageberatungsfehler-pruefen/SKILL.md
@@ -69,12 +69,12 @@ BGH XI ZR 56/05 XI ZR 191/10 und Folgerechtsprechung:
 
 ### Lehman-Zertifikate
 
-- Aufklärungs-Pflicht über Emittenten-Risiko (BGH XI ZR 33/10 XI ZR 174/10)
+- Aufklärungs-Pflicht über Emittenten-Risiko (BGH XI ZR 178/10 XI ZR 182/10 — Lehman v. 27.09.2011)
 - Verteilung Beratung Bank vs. Aufklärung Emittent
 
 ### Swap-Geschäfte / CMS Spread Ladder Swap
 
-- BGH XI ZR 33/10 Ille (anfänglicher negativer Marktwert)
+- BGH XI ZR 33/10 Ille (anfänglicher negativer Marktwert v. 22.03.2011)
 - Aufklärung über strukturierte Komplexität
 
 ### Schiffsfonds Filmfonds

--- a/fachanwalt-bank-kapitalmarktrecht/skills/fachanwalt-bank-kapitalmarktrecht-anlageberatung-fehlerhaft/SKILL.md
+++ b/fachanwalt-bank-kapitalmarktrecht/skills/fachanwalt-bank-kapitalmarktrecht-anlageberatung-fehlerhaft/SKILL.md
@@ -8,7 +8,7 @@ description: "Fehlerhafte Anlageberatung der Bank pruefen. Bond-Urteil-Pflichten
 ## Kaltstart-Rückfragen
 
 1. Welches Anlageprodukt wurde empfohlen (Aktie, Anleihe, Zertifikat, geschlossener Fonds, Schiffsfonds, Immobilienfonds)?
-2. Wann erfolgte die Beratung und wann wurde der Erwerb getätigt? Liegt ein Beratungsprotokoll § 18 WpHG vor?
+2. Wann erfolgte die Beratung und wann wurde der Erwerb getätigt? Liegt eine Geeignetheitserklärung § 64 Abs. 4 WpHG (bis 02.01.2018: Beratungsprotokoll § 34 Abs. 2a WpHG aF) vor?
 3. Welche Risikoklasse hat der Mandant in seinem WpHG-Bogen angegeben? Wurde Risikobereitschaft und Anlageziel erfragt?
 4. Hat die Bank über Rückvergütungen (Kick-backs) oder Innenprovisionen aufgeklärt?
 5. Wie hoch ist der eingetretene Schaden (Erwerbsschaden, entgangener Gewinn)?
@@ -17,7 +17,7 @@ description: "Fehlerhafte Anlageberatung der Bank pruefen. Bond-Urteil-Pflichten
 
 - Konkludenter Beratungsvertrag mit Bank/Berater bei eigener Anlageberatung: BGH XI ZR 12/93, Urt. v. 06.07.1993, Rn. 11 ff. (Bond-Urteil).
 - Anleger- und anlagegerechte Beratung — Pflicht zur vollständigen, richtigen und verständlichen Information.
-- Aufklärungspflicht über Rückvergütungen (Kick-backs): BGH XI ZR 510/07, Urt. v. 19.12.2006, Rn. 23.
+- Aufklärungspflicht über Rückvergütungen (Kick-backs): BGH XI ZR 510/07, Beschl. v. 20.01.2009, Rn. 12 ff. (Kick-back III); grundlegend BGH XI ZR 56/05, Urt. v. 19.12.2006, Rn. 22 (Kick-back II).
 - Aufklärungspflicht über Innenprovisionen ab 15 Prozent: BGH III ZR 359/02, Urt. v. 12.02.2004, Rn. 38.
 - Anspruchsgrundlage: §§ 280 Abs. 1, 311 Abs. 2 BGB i.V.m. Beratungsvertrag (Schadensersatz wegen Pflichtverletzung).
 - Bei Vorsatz oder Sittenwidrigkeit zusätzlich § 826 BGB und § 31 BGB für Organhaftung.
@@ -40,7 +40,7 @@ description: "Fehlerhafte Anlageberatung der Bank pruefen. Bond-Urteil-Pflichten
    - Rueckverguetung/Kick-back
    - Innenprovision >= 15%
    - Totalverlustrisiko (geschlossene Fonds)
-4. Beratungsprotokoll § 18 WpHG analysieren
+4. Geeignetheitserklaerung § 64 Abs. 4 WpHG analysieren (bzw. § 34 Abs. 2a WpHG aF bis 02.01.2018)
 5. Schaden berechnen (Erwerbsschaden + entgangener Gewinn)
 6. Verjaehrung pruefen (3 Jahre Kenntnis / 10 Jahre Hoechstfrist)
 ```
@@ -62,7 +62,7 @@ EUR [Betrag].
 
 Beratungsfehler liegen in folgenden Punkten:
 1. fehlende Aufklaerung ueber Rueckverguetung (Kick-back BGH XI ZR
-   510/07 Rn. 23)
+   510/07 Beschl. v. 20.01.2009 Rn. 12 ff.)
 2. unterlassene Aufklaerung ueber Innenprovision von [...] Prozent
    (BGH III ZR 359/02 Rn. 38)
 3. anlegerunabhaengige Empfehlung trotz Risikoklasse [...]

--- a/fachanwalt-bank-kapitalmarktrecht/skills/fachanwalt-bank-kapitalmarktrecht-kreditkuendigung/SKILL.md
+++ b/fachanwalt-bank-kapitalmarktrecht/skills/fachanwalt-bank-kapitalmarktrecht-kreditkuendigung/SKILL.md
@@ -20,7 +20,7 @@ description: "Kreditkuendigung der Bank pruefen. Ordentliche Kuendigung § 488 A
 - Allgemeines Kündigungsrecht aus wichtigem Grund § 314 BGB — Abmahnung erforderlich falls Pflichtverletzung.
 - Bei Verbraucherdarlehen § 498 BGB: qualifizierter Zahlungsverzug erforderlich (zwei aufeinander folgende Raten ganz oder teilweise; bei Restlaufzeit > 3 Jahre 10 %, bei kürzerer 5 % des Nennbetrags); zweiwöchige Heilungsfrist nach Mahnung.
 - AGB-Banken Nr. 19 (ordentliche Kündigung) und Nr. 26 (außerordentliche Kündigung) — AGB-Kontrolle § 307 BGB.
-- Vorfälligkeitsentschädigung § 502 BGB; Berechnungsmethode BGH XI ZR 27/00, Urt. v. 30.11.2004, Rn. 22 ff.
+- Vorfälligkeitsentschädigung § 502 BGB; Berechnungsmethode (Aktiv-Passiv-Vergleich) BGH XI ZR 27/00, Urt. v. 07.11.2000, Rn. 18 ff.
 - Treu und Glauben § 242 BGB — Kündigung zur Unzeit oder ohne überwiegenden Bankinteressen.
 
 ## Beweislast und Frist

--- a/fachanwalt-bank-kapitalmarktrecht/skills/mandat-triage-bank-kapitalmarktrecht/SKILL.md
+++ b/fachanwalt-bank-kapitalmarktrecht/skills/mandat-triage-bank-kapitalmarktrecht/SKILL.md
@@ -29,7 +29,7 @@ Bank- und Kapitalmarktrecht ist heterogen — Anlegerschaden Konsumentenkredit S
 - Verbraucherkredit Widerruf § 495 ff. BGB Widerrufsjoker
 - Immobilienfinanzierungs-Beratung
 - Bank-AGB Kontoführung Kontosperre
-- Kontopfändung Pfändungsschutz P-Konto § 850k ZPO
+- Kontopfändung Pfändungsschutz P-Konto §§ 850k 899 ff. ZPO (Pfändungsschutzkonto seit PKoFoG 01.12.2021 in §§ 899-910 ZPO)
 - Kreditsicherheiten Grundschuld Bürgschaft Sicherungsabtretung
 - Geldwäsche § 261 StGB AMLA
 - BaFin-Aufsicht Sanktionen
@@ -131,5 +131,5 @@ Bank- und Kapitalmarktrecht ist heterogen — Anlegerschaden Konsumentenkredit S
 - VermAnlG WpPG
 - StGB § 261
 - KWG
-- ZPO § 850k
+- ZPO §§ 850k 899-910 (PKoFoG)
 - BGH XI. Zivilsenat — Bond Lehman Ille Kickback

--- a/fachanwalt-bank-kapitalmarktrecht/skills/widerrufsjoker-immobiliendarlehen/SKILL.md
+++ b/fachanwalt-bank-kapitalmarktrecht/skills/widerrufsjoker-immobiliendarlehen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: widerrufsjoker-immobiliendarlehen
-description: Pruefraster Widerruf von Immobiliendarlehensvertraegen wegen fehlerhafter Widerrufsbelehrung. Anwendungsbereich Verbraucher-Darlehensvertraege ab 2002 mit den unterschiedlichen Stichtagen Aenderungen Belehrungs-Muster. Pruefung Belehrungs-Inhalt Frist Beginn Form Klarheit Optik Adresse. Bei Fehler ewiges Widerrufsrecht durch BGH XI ZR 33/08 bis 2016 Reform. Rechtsfolgen Rueckabwicklung Vorfaelligkeits-Entschaedigung-Vermeidung Zinsersparnis Marktzins-Vorteil. Beachtung BGH IX ZB Ueberweisung gegen Zug-um-Zug Rueckgewaehr Pruefung Verwirkung.
+description: Pruefraster Widerruf von Immobiliendarlehensvertraegen wegen fehlerhafter Widerrufsbelehrung. Anwendungsbereich Verbraucher-Darlehensvertraege ab 2002 mit den unterschiedlichen Stichtagen Aenderungen Belehrungs-Muster. Pruefung Belehrungs-Inhalt Frist Beginn Form Klarheit Optik Adresse. Bei Fehler ewiges Widerrufsrecht durch BGH XI ZR 33/08 bis 2016 Reform. Rechtsfolgen Rueckabwicklung Vorfaelligkeits-Entschaedigung-Vermeidung Zinsersparnis Marktzins-Vorteil. Beachtung BGH XI. Zivilsenat Rueckgewaehrschuldverhaeltnis Zug-um-Zug Pruefung Verwirkung.
 ---
 
 # Widerrufsjoker bei Immobiliendarlehen

--- a/fachanwalt-handels-gesellschaftsrecht/skills/fachanwalt-handels-gesellschaftsrecht-geschaeftsfuehrerhaftung/SKILL.md
+++ b/fachanwalt-handels-gesellschaftsrecht/skills/fachanwalt-handels-gesellschaftsrecht-geschaeftsfuehrerhaftung/SKILL.md
@@ -19,7 +19,7 @@ description: Geschaeftsfuehrerhaftung § 43 GmbHG und Vorstandshaftung § 93 Akt
 - **GmbH:** § 43 Abs. 1 GmbHG Sorgfalt eines ordentlichen Geschäftsmanns; § 43 Abs. 2 GmbHG Schadensersatzpflicht bei Pflichtverletzung; § 43 Abs. 3 GmbHG verschärfte Haftung bei verbotener Auszahlung des Stammkapitals; § 43 Abs. 4 GmbHG Verjährung fünf Jahre.
 - **AG:** § 93 Abs. 1 S. 1 AktG Sorgfaltspflicht; § 93 Abs. 1 S. 2 AktG Business Judgement Rule; § 93 Abs. 2 S. 1 AktG Schadensersatzpflicht; § 93 Abs. 2 S. 2 AktG Beweislastumkehr für Pflichterfüllung und schuldhaftes Handeln; § 93 Abs. 6 AktG Verjährung (fünf Jahre, börsennotierte AG zehn Jahre).
 - **Verbotene Rückzahlung:** § 30 GmbHG iVm § 43 Abs. 3 GmbHG; § 57 AktG.
-- **Insolvenzrechtliche Haftung:** § 15a InsO Antragspflicht; § 15b InsO Zahlungsverbot ab Insolvenzreife (vormals § 64 GmbHG aF; bzw. § 92 Abs. 2 AktG aF).
+- **Insolvenzrechtliche Haftung:** § 15a InsO Antragspflicht; § 15b InsO Zahlungsverbot ab Insolvenzreife (§ 64 GmbHG und § 92 Abs. 2 AktG aF aufgehoben durch SanInsFoG zum 01.01.2021, ersetzt durch § 15b InsO als rechtsformneutrale Regelung).
 - **Steuern und Sozialversicherung:** § 69 AO Haftung für hinterzogene Steuern; § 266a StGB Vorenthalten von Sozialversicherungsbeiträgen mit zivilrechtlicher Haftung § 823 Abs. 2 BGB.
 - **Aktionärsklage:** Klagezulassungsverfahren § 148 AktG (Quorum 1 % oder EUR 100 000 anteilige Beteiligung).
 - **Verfolgungspflicht Aufsichtsrat:** § 111 AktG, BGH ARAG/Garmenbeck.
@@ -29,7 +29,7 @@ description: Geschaeftsfuehrerhaftung § 43 GmbHG und Vorstandshaftung § 93 Akt
 
 - BGH, Urt. v. 21.04.1997 – Az. II ZR 175/95, BGHZ 135, 244 Rn. 17 – ARAG/Garmenbeck — unternehmerisches Ermessen (Vorläufer Business Judgement Rule).
 - BGH, Urt. v. 22.02.2011 – Az. II ZR 146/09, BGHZ 188, 326 Rn. 15 — Anforderungen Business Judgement Rule.
-- BGH, Urt. v. 26.06.2018 – Az. II ZR 65/16, BGHZ 219, 193 Rn. 25 — Schadensermittlung Geschäftsführerhaftung GmbH.
+- BGH, Urt. v. 04.11.2002 – Az. II ZR 224/00, BGHZ 152, 280 Rn. 8 ff. — Darlegungs- und Beweislast bei Schadensersatzansprüchen gegen GmbH-Geschäftsführer (§ 93 Abs. 2 S. 2 AktG analog); Beweismaß § 287 ZPO.
 - BGH, Urt. v. 16.03.2009 – Az. II ZR 280/07, BGHZ 180, 105 Rn. 17 — Haftung wegen verspäteter Insolvenzantragstellung.
 - BGH, Urt. v. 14.07.2008 – Az. II ZR 202/07, BGHZ 177, 235 Rn. 28 — Innenausgleich bei Mehrgliederhaftung.
 

--- a/fachanwalt-handels-gesellschaftsrecht/skills/fachanwalt-handels-gesellschaftsrecht-orientierung/SKILL.md
+++ b/fachanwalt-handels-gesellschaftsrecht/skills/fachanwalt-handels-gesellschaftsrecht-orientierung/SKILL.md
@@ -27,7 +27,7 @@ description: Orientierung Handels- und Gesellschaftsrecht. FAO § 14i Voraussetz
 - **AktG:** Gründung §§ 1 ff., Hauptversammlung §§ 118 ff., Beschlussanfechtung §§ 241 ff., Vorstandshaftung § 93 AktG, Aufsichtsrat §§ 95 ff.
 - **PartGG** und **MoPeG-GbR-Recht** (in Kraft seit 01.01.2024) mit eGbR-Registereintragung.
 - **UmwG:** Verschmelzung §§ 2 ff., Spaltung §§ 123 ff., Formwechsel §§ 190 ff.
-- **InsO Schnittstellen:** § 15a InsO (Antragspflicht), § 64 GmbHG aF / § 15b InsO (Zahlungsverbot).
+- **InsO Schnittstellen:** § 15a InsO (Antragspflicht); § 15b InsO Zahlungsverbot ab Insolvenzreife (§ 64 GmbHG aufgehoben durch SanInsFoG zum 01.01.2021, ersetzt durch § 15b InsO).
 
 ## Typische Mandate
 
@@ -53,7 +53,7 @@ description: Orientierung Handels- und Gesellschaftsrecht. FAO § 14i Voraussetz
 ## Maßgebliche Rechtsprechung
 
 - BGH, Urt. v. 21.04.1997 – Az. II ZR 175/95, BGHZ 135, 244 Rn. 17 – ARAG/Garmenbeck — Geschäftsleiterermessen, Vorläufer Business Judgement Rule (kodifiziert § 93 Abs. 1 S. 2 AktG).
-- BGH, Urt. v. 26.06.2018 – Az. II ZR 65/16, BGHZ 219, 193 Rn. 25 — Geschäftsführerhaftung GmbH.
+- BGH, Urt. v. 04.11.2002 – Az. II ZR 224/00, BGHZ 152, 280 Rn. 8 ff. — Darlegungs- und Beweislast Geschäftsführerhaftung GmbH (§ 93 Abs. 2 S. 2 AktG analog).
 - BGH, Urt. v. 12.03.2013 – Az. II ZR 73/11, BGHZ 197, 304 Rn. 20 — Stimmverbot § 47 Abs. 4 GmbHG.
 - BGH, Urt. v. 12.10.2009 – Az. II ZR 257/08, BGHZ 183, 84 Rn. 38 – Lipsia — Innenausgleich Gesellschafter.
 - BGH, Urt. v. 14.07.2009 – Az. II ZR 17/08, BGHZ 182, 1 Rn. 12 — Handelsvertreterausgleich Berechnung.

--- a/fachanwalt-insolvenz-sanierungsrecht/skills/fachanwalt-insolvenz-sanierungsrecht-orientierung/SKILL.md
+++ b/fachanwalt-insolvenz-sanierungsrecht/skills/fachanwalt-insolvenz-sanierungsrecht-orientierung/SKILL.md
@@ -74,4 +74,4 @@ description: Orientierung im Insolvenz- und Sanierungsrecht und Fachanwaltschaft
 - **`insolvenzrecht`** für operative Mandatsführung.
 - **`steuerrecht-kanzlei`** für Steuerforderungen in der Insolvenz und § 75 AO.
 - **`fachanwalt-arbeitsrecht`** bei §§ 113, 125 ff. InsO und Insolvenzgeld.
-- **`fachanwalt-handels-gesellschaftsrecht`** bei Geschäftsführerhaftung § 64 GmbHG aF / § 15b InsO.
+- **`fachanwalt-handels-gesellschaftsrecht`** bei Geschäftsführerhaftung § 15b InsO (§ 64 GmbHG aufgehoben durch SanInsFoG zum 01.01.2021).

--- a/fachanwalt-internationales-wirtschaftsrecht/skills/fachanwalt-internationales-wirtschaftsrecht-cisg-pruefung/SKILL.md
+++ b/fachanwalt-internationales-wirtschaftsrecht/skills/fachanwalt-internationales-wirtschaftsrecht-cisg-pruefung/SKILL.md
@@ -21,7 +21,7 @@ description: "Internationalen Warenkaufvertrag nach CISG UN-Kaufrecht pruefen. A
 - Vertragsschluss Art. 14-24 CISG — Angebot/Annahme; abweichende Antwort Art. 19 CISG (wesentliche Abweichungen).
 - Vertragsmäßigkeit der Ware Art. 35 CISG — vertragliche Beschaffenheit, gewöhnlicher Gebrauch, besonderer Gebrauch, Muster.
 - Untersuchungspflicht Art. 38 CISG so kurz wie nach Umständen möglich.
-- Mängelrüge Art. 39 CISG in angemessener Frist — BGH zur Frist: ca. ein Monat als Faustregel (BGH VIII ZR 304/00, Urt. v. 03.11.1999, Rn. 22).
+- Mängelrüge Art. 39 CISG in angemessener Frist — BGH zur Frist: ca. ein Monat als Faustregel (BGH VIII ZR 159/94, Urt. v. 08.03.1995, BGHZ 129, 75 Rn. 22 — Knochenmehl).
 - Rechtsbehelfe Käufer Art. 45 ff.: Erfüllung Art. 46, Nachbesserung Art. 46, Vertragsaufhebung Art. 49 (wesentliche Vertragsverletzung Art. 25), Minderung Art. 50, Schadensersatz Art. 74-77.
 - Befreiung Art. 79 CISG bei Hindernis außerhalb Einflussbereich.
 - BGH zur wesentlichen Vertragsverletzung Art. 25 CISG: BGH VIII ZR 51/95, Urt. v. 03.04.1996, Rn. 23 (Kobaltsulfat).

--- a/fachanwalt-internationales-wirtschaftsrecht/skills/fachanwalt-internationales-wirtschaftsrecht-rom-i-anwendbarkeit/SKILL.md
+++ b/fachanwalt-internationales-wirtschaftsrecht/skills/fachanwalt-internationales-wirtschaftsrecht-rom-i-anwendbarkeit/SKILL.md
@@ -25,7 +25,7 @@ description: "Anwendbares Recht bei grenzueberschreitenden Vertraegen nach Rom-I
 - Arbeitsvertrag Art. 8 Rom I — gewöhnlicher Arbeitsort; Günstigkeitsprinzip.
 - Eingriffsnormen Art. 9 Rom I.
 - ordre public Art. 21 Rom I.
-- EuGH zu konkludenter Rechtswahl: EuGH C-184/12, Urt. v. 17.10.2013, Rn. 35 ff. (Unamar).
+- EuGH zu Eingriffsnormen Art. 9 Rom I: EuGH C-184/12, Urt. v. 17.10.2013, Rn. 46 ff. (Unamar) — Anwendung zwingender Vorschriften des Forumstaats trotz Rechtswahl.
 
 ## Beweislast und Frist
 

--- a/fachanwalt-internationales-wirtschaftsrecht/skills/fachanwalt-internationales-wirtschaftsrecht-schiedsklausel/SKILL.md
+++ b/fachanwalt-internationales-wirtschaftsrecht/skills/fachanwalt-internationales-wirtschaftsrecht-schiedsklausel/SKILL.md
@@ -25,7 +25,7 @@ description: "Schiedsklausel in internationalen Vertraegen pruefen und entwerfen
 - Kompetenz-Kompetenz § 1040 ZPO — Schiedsgericht entscheidet selbst über eigene Zuständigkeit.
 - Vollstreckbarerklärung ausländischer Schiedsspruch §§ 1061 ff. ZPO i.V.m. NYC.
 - Aufhebungsantrag inländischer Schiedsspruch § 1059 ZPO — abschließender Katalog.
-- BGH zur engen Auslegung von Aufhebungsgründen: BGH I ZB 13/15, Urt. v. 23.06.2015, Rn. 14 ff.
+- BGH zur engen Auslegung von Aufhebungsgründen: BGH I ZB 13/15, Beschl. v. 23.06.2015, Rn. 14 ff.
 
 ## Beweislast und Frist
 

--- a/fachanwalt-internationales-wirtschaftsrecht/skills/gerichtsstand-und-rechtswahl-pruefen/SKILL.md
+++ b/fachanwalt-internationales-wirtschaftsrecht/skills/gerichtsstand-und-rechtswahl-pruefen/SKILL.md
@@ -32,7 +32,7 @@ Erste Frage bei jedem internationalen Mandat: wo wird gestritten und nach welche
 - **Form** schriftlich oder elektronisch dauerhaft
 - **Bestimmtheit** Gericht oder Gerichte konkret
 - **Ausschließlichkeit** zu vermuten Art. 25 Abs. 1 Satz 2
-- **Asymmetrische Klauseln** wirksam (BGH XI ZR 80/12)
+- **Asymmetrische Klauseln** wirksam (BGH II ZB 35/20 Beschl. v. 15.06.2021; vgl. EuGH C-537/23 v. 27.02.2025 — Anforderungen Art. 25 Brüssel Ia)
 
 ### Spezielle Gerichtsstände
 


### PR DESCRIPTION
@codex review

Bitte juristisch zweitpruefen — 11 konkrete Fixes nach manuellem Audit der Wirtschaftsrecht-Cluster-Plugins (Bank-Kapitalmarkt, Handels-Gesellschaft, Insolvenz-Sanierung, Internationales Wirtschaftsrecht).

## Fix 1 (P1): Falscher BGH-Senat in Widerrufsjoker-Description
**Datei:** `fachanwalt-bank-kapitalmarktrecht/skills/widerrufsjoker-immobiliendarlehen/SKILL.md`
- **Vorher:** "Beachtung BGH IX ZB Ueberweisung gegen Zug-um-Zug Rueckgewaehr Pruefung Verwirkung."
- **Nachher:** "Beachtung BGH XI. Zivilsenat Rueckgewaehrschuldverhaeltnis Zug-um-Zug Pruefung Verwirkung."
- **Grund:** IX. Senat ist Insolvenzrecht. Bankrecht/Verbraucherkredit ist beim XI. Zivilsenat des BGH. Vgl. [BGH-Geschaeftsverteilung](https://www.bundesgerichtshof.de/DE/DasGericht/Aufgaben/aufgaben_node.html).

## Fix 2 (P1): Veraltetes WpHG-Beratungsprotokoll § 18 WpHG nach MiFID-II
**Datei:** `fachanwalt-bank-kapitalmarktrecht/skills/fachanwalt-bank-kapitalmarktrecht-anlageberatung-fehlerhaft/SKILL.md`
- **Vorher:** "Liegt ein Beratungsprotokoll § 18 WpHG vor?"
- **Nachher:** "Liegt eine Geeignetheitserklaerung § 64 Abs. 4 WpHG (bis 02.01.2018: Beratungsprotokoll § 34 Abs. 2a WpHG aF) vor?"
- **Grund:** Mit MiFID-II-Umsetzung (FiMaNoG zum 03.01.2018) wurde das Beratungsprotokoll § 34 Abs. 2a WpHG aF durch die Geeignetheitserklaerung § 64 Abs. 4 WpHG abgeloest. § 18 WpHG war zu keinem Zeitpunkt das Beratungsprotokoll (das ist eine Verwechslung). Vgl. [§ 64 WpHG aktuell](https://www.gesetze-im-internet.de/wphg_2017/__64.html).

## Fix 3 (P1): Falsches Datum BGH XI ZR 510/07 (Kick-back III)
**Datei:** `fachanwalt-bank-kapitalmarktrecht/skills/fachanwalt-bank-kapitalmarktrecht-anlageberatung-fehlerhaft/SKILL.md`
- **Vorher:** "BGH XI ZR 510/07, Urt. v. 19.12.2006, Rn. 23."
- **Nachher:** "BGH XI ZR 510/07, Beschl. v. 20.01.2009, Rn. 12 ff. (Kick-back III); grundlegend BGH XI ZR 56/05, Urt. v. 19.12.2006, Rn. 22 (Kick-back II)."
- **Grund:** XI ZR 510/07 ist Beschluss vom 20.01.2009 (Kick-back III). Das Urteil vom 19.12.2006 ist XI ZR 56/05 (Kick-back II). Vgl. [dejure XI ZR 510/07](https://dejure.org/dienste/vernetzung/rechtsprechung?Gericht=BGH&Datum=20.01.2009&Aktenzeichen=XI+ZR+510/07).

## Fix 4 (P1): Falsche AZ-Zuordnung Lehman-Zertifikate
**Datei:** `fachanwalt-bank-kapitalmarktrecht/skills/anlageberatungsfehler-pruefen/SKILL.md` (Z. 72/77)
- **Vorher:** "Aufklaerungs-Pflicht ueber Emittenten-Risiko (BGH XI ZR 33/10 XI ZR 174/10)"
- **Nachher:** "Aufklaerungs-Pflicht ueber Emittenten-Risiko (BGH XI ZR 178/10 XI ZR 182/10 — Lehman v. 27.09.2011)"
- **Grund:** XI ZR 33/10 v. 22.03.2011 ist Ille/CMS Spread Ladder Swap (anfaenglicher negativer Marktwert), NICHT Lehman. Die beiden Lehman-Grundsatzurteile sind XI ZR 178/10 und XI ZR 182/10 v. 27.09.2011. Datum bei Ille-Zitat ergaenzt.

## Fix 5 (P1): Falsches Datum BGH XI ZR 27/00 (Vorfaelligkeitsentschaedigung)
**Datei:** `fachanwalt-bank-kapitalmarktrecht/skills/fachanwalt-bank-kapitalmarktrecht-kreditkuendigung/SKILL.md`
- **Vorher:** "BGH XI ZR 27/00, Urt. v. 30.11.2004, Rn. 22 ff."
- **Nachher:** "(Aktiv-Passiv-Vergleich) BGH XI ZR 27/00, Urt. v. 07.11.2000, Rn. 18 ff."
- **Grund:** XI ZR 27/00 ist Urteil v. 07.11.2000 (Aktiv-Passiv-Methode zur VFE-Berechnung). Vgl. [dejure XI ZR 27/00](https://dejure.org/dienste/vernetzung/rechtsprechung?Gericht=BGH&Datum=07.11.2000&Aktenzeichen=XI+ZR+27/00).

## Fix 6 (P2): P-Konto-Modernisierung durch PKoFoG seit 01.12.2021
**Datei:** `fachanwalt-bank-kapitalmarktrecht/skills/mandat-triage-bank-kapitalmarktrecht/SKILL.md`
- **Vorher:** "P-Konto § 850k ZPO"
- **Nachher:** "P-Konto §§ 850k 899 ff. ZPO (Pfaendungsschutzkonto seit PKoFoG 01.12.2021 in §§ 899-910 ZPO)"
- **Grund:** Mit dem Pfaendungsschutzkonto-Fortentwicklungsgesetz (PKoFoG) zum 01.12.2021 wurden die zentralen Freibetraege aus § 850k ZPO in die neuen §§ 899-910 ZPO ueberfuehrt. § 850k regelt nur noch die Einrichtung/Beendigung des P-Kontos.

## Fix 7 (P1): Falsche AZ-Zuordnung Schadensermittlung Geschaeftsfuehrer
**Datei:** `fachanwalt-handels-gesellschaftsrecht/skills/fachanwalt-handels-gesellschaftsrecht-geschaeftsfuehrerhaftung/SKILL.md` (Z. 32) und gleichlautend in `orientierung/SKILL.md`
- **Vorher:** "BGH, Urt. v. 26.06.2018 – Az. II ZR 65/16, BGHZ 219, 193 Rn. 25 — Schadensermittlung Geschaeftsfuehrerhaftung GmbH."
- **Nachher:** "BGH, Urt. v. 04.11.2002 – Az. II ZR 224/00, BGHZ 152, 280 Rn. 8 ff. — Darlegungs- und Beweislast bei Schadensersatzanspruechen gegen GmbH-Geschaeftsfuehrer (§ 93 Abs. 2 S. 2 AktG analog); Beweismass § 287 ZPO."
- **Grund:** II ZR 65/16 v. 26.06.2018 betrifft die Nichtigkeit von Einziehungsbeschluessen bei fehlendem freien Vermoegen (stille Reserven) — gehoert in Gesellschafterstreit, NICHT in Geschaeftsfuehrerhaftung. Die Grundsatzentscheidung zu Schadensermittlung/Beweislast ist BGH II ZR 224/00, BGHZ 152, 280. Vgl. [dejure II ZR 224/00](https://dejure.org/dienste/vernetzung/rechtsprechung?Gericht=BGH&Datum=04.11.2002&Aktenzeichen=II+ZR+224/00).

## Fix 8 (P2): § 64 GmbHG-Praezisierung (drei Stellen)
**Dateien:**
- `fachanwalt-handels-gesellschaftsrecht/skills/fachanwalt-handels-gesellschaftsrecht-geschaeftsfuehrerhaftung/SKILL.md` (Z. 22)
- `fachanwalt-handels-gesellschaftsrecht/skills/fachanwalt-handels-gesellschaftsrecht-orientierung/SKILL.md` (Z. 30)
- `fachanwalt-insolvenz-sanierungsrecht/skills/fachanwalt-insolvenz-sanierungsrecht-orientierung/SKILL.md` (Z. 77)
- **Vorher:** "vormals § 64 GmbHG aF" / "§ 64 GmbHG aF / § 15b InsO"
- **Nachher:** "§ 64 GmbHG aufgehoben durch SanInsFoG zum 01.01.2021, ersetzt durch § 15b InsO als rechtsformneutrale Regelung"
- **Grund:** Konsistenz mit PR #21 ff. Praezision: SanInsFoG (Sanierungs- und Insolvenzrechtsfortentwicklungsgesetz) hat § 64 GmbHG zum 01.01.2021 aufgehoben und durch das rechtsformneutrale Zahlungsverbot § 15b InsO ersetzt. Vgl. [§ 15b InsO](https://www.gesetze-im-internet.de/inso/__15b.html).

## Fix 9 (P2): Falsches BGH-Urteil zur CISG-Mangelruge-Frist
**Datei:** `fachanwalt-internationales-wirtschaftsrecht/skills/fachanwalt-internationales-wirtschaftsrecht-cisg-pruefung/SKILL.md` (Z. 24)
- **Vorher:** "BGH VIII ZR 304/00, Urt. v. 03.11.1999, Rn. 22"
- **Nachher:** "BGH VIII ZR 159/94, Urt. v. 08.03.1995, BGHZ 129, 75 Rn. 22 — Knochenmehl"
- **Grund:** VIII ZR 304/00 ist Urteil v. 09.01.2002 (Milchpulver), nicht 03.11.1999. Der klassische BGH-Massstab fuer die Ein-Monats-Faustregel bei Art. 39 CISG ist die Knochenmehl-Entscheidung BGHZ 129, 75.

## Fix 10 (P2): EuGH Unamar — Eingriffsnormen statt konkludente Rechtswahl
**Datei:** `fachanwalt-internationales-wirtschaftsrecht/skills/fachanwalt-internationales-wirtschaftsrecht-rom-i-anwendbarkeit/SKILL.md` (Z. 28)
- **Vorher:** "EuGH zu konkludenter Rechtswahl: EuGH C-184/12, Urt. v. 17.10.2013, Rn. 35 ff. (Unamar)."
- **Nachher:** "EuGH zu Eingriffsnormen Art. 9 Rom I: EuGH C-184/12, Urt. v. 17.10.2013, Rn. 46 ff. (Unamar) — Anwendung zwingender Vorschriften des Forumstaats trotz Rechtswahl."
- **Grund:** Die Unamar-Entscheidung des EuGH betrifft primaer die Anwendung belgischer Eingriffsnormen (Handelsvertreterausgleich) trotz Rechtswahl bulgarisches Recht — also Art. 9 Rom I, nicht konkludente Rechtswahl Art. 3.

## Fix 11 (P3): BGH I ZB-Az ist Beschluss, nicht Urteil
**Datei:** `fachanwalt-internationales-wirtschaftsrecht/skills/fachanwalt-internationales-wirtschaftsrecht-schiedsklausel/SKILL.md` (Z. 28)
- **Vorher:** "BGH I ZB 13/15, Urt. v. 23.06.2015"
- **Nachher:** "BGH I ZB 13/15, Beschl. v. 23.06.2015"
- **Grund:** ZB-Aktenzeichen am BGH sind regelmaessig Beschluesse (Verfahrenshilfe/Vollstreckbarerklaerung), keine Urteile.

## Fix 12 (P2): Asymmetrische Gerichtsstandsklauseln — falsches Az
**Datei:** `fachanwalt-internationales-wirtschaftsrecht/skills/gerichtsstand-und-rechtswahl-pruefen/SKILL.md` (Z. 35)
- **Vorher:** "Asymmetrische Klauseln wirksam (BGH XI ZR 80/12)"
- **Nachher:** "Asymmetrische Klauseln wirksam (BGH II ZB 35/20 Beschl. v. 15.06.2021; vgl. EuGH C-537/23 v. 27.02.2025 — Anforderungen Art. 25 Bruessel Ia)"
- **Grund:** Die Leitentscheidung zu asymmetrischen Gerichtsstandsvereinbarungen ist BGH II ZB 35/20 v. 15.06.2021 (Air Berlin / einseitig ausschliessliche Klausel). Aktualisiert um EuGH C-537/23 v. 27.02.2025 (Anforderungen an Genauigkeit/Ausgewogenheit).

## Bitte an Codex
- Pruefe die uebrigen Skills (insolvenzanfechtung, insolvenzplan, restrukturierungsplan, glaeubigerantrag, gesellschafterstreit, handelsvertreterausgleich, schufa-eintrag, mandat-triage-iwr, sanktions-compliance-pruefung) auf juristische Praezision.
- Konkrete Patches mit Datei + Zeile + Vorher + Nachher willkommen.
- Bitte achte auf: Aktualitaet (insb. SanInsFoG/StaRUG seit 2021, MiFID-II seit 2018, MoPeG seit 2024, PKoFoG seit 2021), AZ-Korrektheit, Senatszuweisung (BGH II/XI/IX/VIII).
