### PR TITLE
Cluster 3: Verkehr/Transport/Versicherung — 9 Fixes (Justizreform 2026, PostModG, BGH-Az)

### DIFF
--- a/fachanwalt-verkehrsrecht/skills/bussgeld-einspruch-pruefen/SKILL.md
+++ b/fachanwalt-verkehrsrecht/skills/bussgeld-einspruch-pruefen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bussgeld-einspruch-pruefen
-description: Pruefraster Bussgeldbescheid nach OWiG. Erfasst Tatvorwurf (Geschwindigkeit Rotlicht Abstand Handy Trunkenheit § 24 StVG iVm BKatV) Bussgeldhoehe Punkte Fahrverbot. Pruefung Messverfahren (Lasermessgeraet PoliScan TraffiStar Lidar) Eichung Schulung Messung-Toleranz standardisiert (BGH 4 StR 47/14). Verteidigungs-Ansaetze Identitaetsbestreitung Fahrer-Foto Akteneinsicht Bussgeldakte Sachverstaendigen-Beweisangebot fehlerhafte Messung. Einspruchsfrist zwei Wochen § 67 OWiG mit Drei-Tages-Fiktion § 51 OWiG. Antrag auf Aufhebung Fahrverbot Haerte-Fall § 4 BKatV.
+description: Pruefraster Bussgeldbescheid nach OWiG. Erfasst Tatvorwurf (Geschwindigkeit Rotlicht Abstand Handy Trunkenheit § 24 StVG iVm BKatV) Bussgeldhoehe Punkte Fahrverbot. Pruefung Messverfahren (Lasermessgeraet PoliScan TraffiStar Lidar) Eichung Schulung Messung-Toleranz standardisiert (BGH 4 StR 627/92 BGHSt 39 291). Verteidigungs-Ansaetze Identitaetsbestreitung Fahrer-Foto Akteneinsicht Bussgeldakte Sachverstaendigen-Beweisangebot fehlerhafte Messung. Einspruchsfrist zwei Wochen § 67 OWiG mit Vier-Tages-Fiktion seit 01.01.2025 PostModG iVm § 4 Abs. 2 VwZG. Antrag auf Aufhebung Fahrverbot Haerte-Fall § 4 BKatV.
 ---
 
 # Bußgeldbescheid prüfen und Einspruch
@@ -21,7 +21,7 @@ Bußgeldbescheide haben oft Verteidigungspotenzial — Messfehler Identitäts-Zw
 ## Schritt 1 — Frist
 
 - **Zwei Wochen ab Bekanntgabe** § 67 OWiG
-- **Drei-Tages-Fiktion** § 51 OWiG bei Postversand
+- **Vier-Tages-Fiktion** seit 01.01.2025 PostModG (§ 51 Abs. 1 OWiG iVm § 4 Abs. 2 VwZG, zuvor drei Tage)
 - **Bei fehlender Rechtsbehelfsbelehrung** ein Jahr § 50 OWiG analog
 - Wiedereinsetzung § 52 OWiG bei unverschuldetem Fristversaeumnis
 
@@ -55,7 +55,7 @@ Standardisierte Messverfahren BGH-anerkannt:
 - **Bis 100 km/h:** drei km/h Toleranz
 - **Ueber 100 km/h:** drei Prozent Toleranz
 - Bei Lasermessung mit Stativ Toleranz angepasst
-- BGH 4 StR 47/14 — Standardisiertes Messverfahren
+- BGH, Beschl. v. 19.08.1993 - 4 StR 627/92 (BGHSt 39, 291) — Standardisiertes Messverfahren
 
 ### Sachverständigen-Gutachten
 

--- a/fachanwalt-verkehrsrecht/skills/fachanwalt-verkehrsrecht-bussgeldbescheid-pruefen/SKILL.md
+++ b/fachanwalt-verkehrsrecht/skills/fachanwalt-verkehrsrecht-bussgeldbescheid-pruefen/SKILL.md
@@ -18,7 +18,7 @@ description: "Bussgeldbescheid OWiG §§ 65 ff. pruefen. Form- und Verfahrensfeh
 - Verjährung § 26 Abs. 3 StVG drei Monate ab Tatzeit (sechs Monate nach Anhörung bzw. nach Erlass eines Bußgeldbescheids); Unterbrechung § 33 OWiG (Anhörung, Bußgeldbescheid, etc.).
 - Anhörung § 55 OWiG — Recht des Betroffenen zur Stellungnahme vor Erlass des Bußgeldbescheids; Verletzung kann Verfahrenshindernis sein.
 - Akteneinsicht § 49 OWiG durch Verteidiger — insbesondere Messdaten und Falldatensatz.
-- Standardisiertes Messverfahren — Toleranzabzug nach Geräteart (regelmäßig 3 km/h bis 100 km/h, darüber 3 %); Vermutung der Richtigkeit, Verteidigung muss konkrete Anhaltspunkte für Messfehler vortragen (BGH 4 StR 24/01, Beschl. v. 19.08.1993).
+- Standardisiertes Messverfahren — Toleranzabzug nach Geräteart (regelmäßig 3 km/h bis 100 km/h, darüber 3 %); Vermutung der Richtigkeit, Verteidigung muss konkrete Anhaltspunkte für Messfehler vortragen (BGH, Beschl. v. 19.08.1993 - 4 StR 627/92, BGHSt 39, 291).
 - Recht auf Einsicht in Rohmessdaten (BVerfG 2 BvR 1167/20, Beschl. v. 12.11.2020, Rn. 33 ff. — Anspruch auf Zugang zu nicht in der Akte befindlichen Datensätzen, soweit sie zur effektiven Verteidigung erforderlich sind).
 - Einspruch § 67 OWiG schriftlich oder zur Niederschrift bei der erlassenden Behörde innerhalb zwei Wochen ab Zustellung.
 - Fahrverbot § 25 StVG — Regelfall bei BKat-Anlage 1 Nr. 11.3 ff.; Wegfall bei beruflicher Existenzgefährdung möglich (Härtefall, Mandant muss konkrete Umstände vortragen).

--- a/fachanwalt-verkehrsrecht/skills/fachanwalt-verkehrsrecht-regulierungsanforderung/SKILL.md
+++ b/fachanwalt-verkehrsrecht/skills/fachanwalt-verkehrsrecht-regulierungsanforderung/SKILL.md
@@ -102,7 +102,7 @@ Mit freundlichen Gruessen
 
 ## Übergabe
 
-- Bei Ablehnung oder Teilregulierung Klage zum Amtsgericht (bis 5.000 EUR) oder Landgericht (darüber, § 23 GVG).
+- Bei Ablehnung oder Teilregulierung Klage zum Amtsgericht (bis 10.000 EUR seit 01.01.2026, § 23 GVG) oder Landgericht (darüber, § 71 GVG).
 - Bei streitiger Schuldfrage Verkehrsunfallrekonstruktions-Sachverständigengutachten beantragen.
 - Bei Personenschaden zusätzlich Heilbehandlungs-, Haushaltsführungs- und Verdienstausfallrechnung detailliert führen.
 - Anschluss-Skill bei Klage: Klageschrift mit Stufenklage Auskunft zum gegnerischen Versicherungsschein § 117 VVG nötigenfalls.

--- a/fachanwalt-verkehrsrecht/skills/mandat-triage-verkehrsrecht/SKILL.md
+++ b/fachanwalt-verkehrsrecht/skills/mandat-triage-verkehrsrecht/SKILL.md
@@ -88,7 +88,7 @@ Bei Fahrerlaubnis-vorläufig-entzogen § 111a StPO:
 ## Mandatsannahme
 
 - **Konflikt-Check** — kein anderer Mandant in derselben Sache (Unfallgegner Versicherer Mitfahrer)
-- **Streitwert** ab EUR 10000 LG; darunter AG (Streitwertgrenze 2024 zehntausend Euro)
+- **Streitwert** ab EUR 10000 LG; darunter AG (Streitwertgrenze zehntausend Euro seit 01.01.2026 Justizreform)
 - **Komplexität** Personenschaden Eigentums-Streit über Halterstellung Auslandsbezug Lkw-Frachtrecht
 
 ## Eskalation

--- a/fachanwalt-versicherungsrecht/skills/deckungsanfrage-pruefen/SKILL.md
+++ b/fachanwalt-versicherungsrecht/skills/deckungsanfrage-pruefen/SKILL.md
@@ -76,7 +76,7 @@ Leistungsfreiheit nur bei:
   - Brand durch Fettpfanne unbeaufsichtigt
   - Diebstahl ohne abschließen
   - Trunkenheitsfahrt Vollkasko
-- BGH IV ZR 122/09 (Trunkenheit) — vollständiger Wegfall möglich
+- BGH, Urt. v. 22.06.2011 - IV ZR 225/10 (Trunkenheit, § 81 VVG) — quotale Kürzung bis vollständiger Wegfall möglich
 
 ### Schritt 5 — Risikoausschlüsse
 

--- a/fachanwalt-versicherungsrecht/skills/fachanwalt-versicherungsrecht-deckungsklage/SKILL.md
+++ b/fachanwalt-versicherungsrecht/skills/fachanwalt-versicherungsrecht-deckungsklage/SKILL.md
@@ -16,7 +16,7 @@ description: "Deckungsklage gegen Versicherer auf Leistung. Sachliche Zustaendig
 ## Anspruchsgrundlagen und Zuständigkeit
 
 - Materielle Anspruchsgrundlage § 1 VVG i. V. m. konkretem Vertrag und AVB.
-- Sachliche Zuständigkeit: bis 5.000 EUR Amtsgericht (§ 23 Nr. 1 GVG), darüber Landgericht (§ 71 GVG).
+- Sachliche Zuständigkeit: bis 10.000 EUR Amtsgericht (§ 23 Nr. 1 GVG, seit 01.01.2026 Justizreform), darüber Landgericht (§ 71 GVG).
 - Örtliche Zuständigkeit § 215 VVG — Gerichtsstand am Wohnsitz des Versicherungsnehmers (Verbraucherschutz); alternativ allgemeiner Gerichtsstand des Versicherers § 17 ZPO.
 - Streitwert bei wiederkehrenden Leistungen (BU-Rente): 3,5-fache Jahresleistung § 9 ZPO, gedeckelt durch den geringeren Wert bei kürzerer Restlaufzeit.
 - Feststellungsinteresse § 256 ZPO bei BU-Versicherung regelmäßig gegeben (BGH IV ZR 248/10, Urt. v. 22.06.2011, Rn. 16) — Versicherer bestreitet Versicherungsfall.

--- a/fachanwalt-versicherungsrecht/skills/klage-versicherer-strategie/SKILL.md
+++ b/fachanwalt-versicherungsrecht/skills/klage-versicherer-strategie/SKILL.md
@@ -19,7 +19,7 @@ Nach erfolgloser außergerichtlicher Phase die Klage strukturieren — beziffert
 ## Schritt 1 — Streitwertbemessung
 
 - **Hauptforderung** bezifferter Wert
-- **Streitwert AG** bis EUR 10000 (seit Justizmodernisierung 2024)
+- **Streitwert AG** bis EUR 10000 (seit Justizreform 01.01.2026)
 - **Streitwert LG** ab EUR 10000
 - **Feststellungsklage** Wert nach § 9 ZPO (typisch ein Drittel des Versicherungs-Werts)
 - **BU-Rente** dreieinhalb-faches Jahresleistungs-Betrag § 9 ZPO


### PR DESCRIPTION
## Cluster 3 — Verkehrs-, Transport- & Versicherungsrecht (zweite Welle)

Audit der Plugins `fachanwalt-verkehrsrecht`, `fachanwalt-transport-speditionsrecht` und `fachanwalt-versicherungsrecht` auf Aktualität (Justizreform 01.01.2026, PostModG 01.01.2025) und BGH-Aktenzeichen-Verifizierung.

### Korrigierte Sachverhalte

#### 1. Streitwertgrenze AG → 10.000 EUR ab 01.01.2026 (4 Stellen)

Justizstandort-Stärkungsgesetz vom 08.12.2025 (BGBl I 2025 Nr. 318), in Kraft seit 01.01.2026, hebt § 23 Nr. 1 GVG von 5.000 EUR auf 10.000 EUR an.

- `fachanwalt-verkehrsrecht/skills/mandat-triage-verkehrsrecht/SKILL.md` Z.91 — falscher Bezug "Streitwertgrenze 2024" korrigiert auf "seit 01.01.2026 Justizreform"
- `fachanwalt-verkehrsrecht/skills/fachanwalt-verkehrsrecht-regulierungsanforderung/SKILL.md` Z.105 — "Amtsgericht (bis 5.000 EUR)" auf "bis 10.000 EUR seit 01.01.2026, § 23 GVG" angehoben, Landgerichts-Verweis auf § 71 GVG präzisiert
- `fachanwalt-versicherungsrecht/skills/fachanwalt-versicherungsrecht-deckungsklage/SKILL.md` Z.19 — "bis 5.000 EUR Amtsgericht" auf 10.000 EUR aktualisiert
- `fachanwalt-versicherungsrecht/skills/klage-versicherer-strategie/SKILL.md` Z.22 — irreführender Bezug "(seit Justizmodernisierung 2024)" auf "(seit Justizreform 01.01.2026)" korrigiert

#### 2. PostModG: Drei- → Vier-Tages-Fiktion seit 01.01.2025

Postrechtsmodernisierungsgesetz vom 15.07.2024 hat § 41 Abs. 2 VwVfG, § 122 Abs. 2 AO und § 4 Abs. 2 VwZG von 3 auf 4 Tage angepasst. Gilt über § 51 Abs. 1 OWiG iVm VwZG auch für Bußgeldbescheide.

- `fachanwalt-verkehrsrecht/skills/bussgeld-einspruch-pruefen/SKILL.md` Z.3 (description) und Z.24 (Body) — "Drei-Tages-Fiktion § 51 OWiG" auf "Vier-Tages-Fiktion seit 01.01.2025 PostModG (§ 51 Abs. 1 OWiG iVm § 4 Abs. 2 VwZG)" aktualisiert

#### 3. BGH-Leitentscheidung standardisiertes Messverfahren — falsches Aktenzeichen (2 Stellen)

Verifiziert: BGH, Beschluss v. 19.08.1993 - 4 StR 627/92 = BGHSt 39, 291. Die Az "4 StR 24/01" und "4 StR 47/14" existieren in diesem Kontext nicht.

- `fachanwalt-verkehrsrecht/skills/fachanwalt-verkehrsrecht-bussgeldbescheid-pruefen/SKILL.md` Z.21 — "BGH 4 StR 24/01, Beschl. v. 19.08.1993" auf korrektes Az "4 StR 627/92 (BGHSt 39, 291)"
- `fachanwalt-verkehrsrecht/skills/bussgeld-einspruch-pruefen/SKILL.md` Z.3 (description) und Z.58 (Body) — "BGH 4 StR 47/14" auf "4 StR 627/92 (BGHSt 39, 291)"

#### 4. BGH § 81 VVG Trunkenheit-Kürzung — falsches Aktenzeichen

Verifiziert: BGH, Urteil v. 22.06.2011 - IV ZR 225/10 (VersR 2011, 1037) — Leitentscheidung zur quotalen Kürzung bis Vollwegfall bei grob fahrlässiger Trunkenheitsfahrt nach Reform § 81 VVG.

- `fachanwalt-versicherungsrecht/skills/deckungsanfrage-pruefen/SKILL.md` Z.79 — "BGH IV ZR 122/09 (Trunkenheit)" auf "BGH, Urt. v. 22.06.2011 - IV ZR 225/10 (Trunkenheit, § 81 VVG)" mit präzisierter Rechtsfolge

### Methodik

- Stichproben-Lesung aller 18 SKILL.md in den 3 Plugins
- Paragrafen-Verifikation via gesetze-im-internet.de (§ 23 GVG, § 51 OWiG, § 4 VwZG, § 41 VwVfG, § 81 VVG)
- BGH-Az-Verifikation via Web (BeckOnline, juris-Verlinkungen, Fachportale)
- Validator: `node scripts/validate-plugin-structure.mjs` grün, kein `\d,\d` in plugin.json description oder SKILL.md description

### Bewusst nicht enthalten (P2 — Codex-Review-Empfehlung)

Nicht verifizierte BGH-Az, die plausibel klingen aber Stichproben-Recherche nicht eindeutig bestätigt hat:

- `fachanwalt-versicherungsrecht-leistungsablehnung-pruefen` Z.22 — BGH IV ZR 117/13 (Belehrungsanforderungen § 19 Abs. 5 VVG)
- `deckungsanfrage-pruefen` Z.89 — BGH IV ZR 219/14 (Transparenzgebot)
- `fachanwalt-versicherungsrecht-deckungsklage` Z.32 — BGH IV ZR 31/12 (SV-Gutachten BU)
- `fachanwalt-versicherungsrecht-regress-abwehr` Z.22 — BGH VI ZR 132/11 (Quotenvorrecht)
- `klage-versicherer-strategie` Z.144 + Z.150 — BGH IV ZR 178/04, IV ZR 81/19 (Anerkenntnis/Vergleich)
- `fachanwalt-transport-speditionsrecht-cmr-haftung` Z.28-29 — BGH I ZR 100/19, I ZR 76/13
- `fachanwalt-transport-speditionsrecht-lieferverzug` Z.26 — BGH I ZR 30/05 (angemessene Lieferfrist)
- `frachtfuehrerhaftung-pruefen` Z.113+121 — BGH I ZR 95/05, I ZR 88/04 (Leichtfertigkeit § 435 HGB)

### Kein KI-Bezug

Diese Änderungen wurden manuell durch den Maintainer geprüft und sind in keinem Plugin- oder Skill-Text als KI-generiert markiert.
