### PR TITLE
gesellschaftsgruender massiv erweitert: 17 → 34 Skills + Schulungsakte mit Gesellschafterstreit

### DIFF
--- a/gesellschaftsgruender/README.md
+++ b/gesellschaftsgruender/README.md
@@ -1,34 +1,50 @@
 # gesellschaftsgruender — Gruendungsassistent fuer deutsche Gesellschaften
 
-Freistehendes Plugin, das durch die Gruendung einer deutschen Gesellschaft fuehrt — von der Rechtsformwahl ueber den Notarsitz, das Handelsregister, Behoerdenanmeldungen bis hin zu den ersten 100 Tagen Geschaeftsfuehrer-Pflichten.
+Freistehendes Plugin, das durch die Gruendung einer deutschen Gesellschaft fuehrt — von der Rechtsformwahl ueber Cap Table, Class-Shares, Notar, Handelsregister, Behoerdenanmeldungen bis hin zu den ersten 100 Tagen Geschaeftsfuehrer-Pflichten und Streit-Eskalationen.
 
 ## Mandatsperspektive
 
 **Du als Anwalt, Steuerberater, Gruender oder Notarberater.** Das Plugin
 
+- erfasst die **Gruender-Eckdaten** strukturiert,
 - klaert die **Rechtsformwahl** (GmbH, UG, GbR, OHG, KG, GmbH & Co. KG, AG, PartG, gGmbH, eK),
-- bereitet die **Notarsitzung** vor,
+- entwickelt **Cap Table** mit Pre/Post-Money und Verwaesserungs-Simulation,
+- liefert **Class-Shares** (A/B/C/Common) mit Liquidation Preference,
+- erstellt **Gesellschaftervereinbarung (SHA)** mit Vesting, Drag/Tag, Stimmverpflichtungen,
+- bereitet die **Notarsitzung** vor (auch DiRUG-online),
 - begleitet die **Handelsregister-Anmeldung**,
-- koordiniert die **Behoerden-Anmeldungen** (Gewerbeamt, Finanzamt, IHK, Berufsgenossenschaft, Transparenzregister),
+- koordiniert die **Behoerden-Anmeldungen** (Gewerbe, Finanzamt, IHK, BG, TraFinG),
+- liefert eine **Geschaeftsordnung der Geschaeftsfuehrung** und Meeting-Templates,
+- erstellt **Gesellschafterversammlungs-Einladungen** und **Protokolle**,
+- vermittelt **bilinguale Dokumente** Deutsch/Englisch,
+- klaert den **Sozialversicherungs-Status** des Geschaeftsfuehrers,
+- begleitet **Gesellschafterstreit** mit Eilantraegen LG und Registergericht,
+- prueft den **Firmennamen** (HR, IHK, DPMA, EUIPO),
 - liefert eine **erste 100-Tage-Checkliste** fuer den Geschaeftsfuehrer.
 
-Berueksichtigt aktuelle Gesetzeslage Stand 2026 inkl. **MoPeG** (Modernisierung Personengesellschaftsrecht, Januar 2024) und **DiRUG** (Online-Gruendung per Videokonferenz, August 2022).
+Beruecksichtigt aktuelle Gesetzeslage Stand 2026 inkl. **MoPeG** (Modernisierung Personengesellschaftsrecht, Januar 2024) und **DiRUG** (Online-Gruendung per Videokonferenz, August 2022).
 
 ## Aufbau
 
 Der Lebenszyklus einer Gruendung laeuft in fuenf Phasen:
 
 ```
-Phase 0 — Rechtsformwahl (Woche 1)
-  └─ GmbH vs. UG vs. GbR vs. KG vs. AG vs. ... — Entscheidung mit Begruendung
+Phase 0 — Intake und Rechtsformwahl (Woche 1)
+  └─ Gruender-Intake → Rechtsformwahl → Firmenname-Pruefung
+     → Cap Table initial
 
 Phase A — Vorbereitung (Woche 2-3)
-  └─ Gesellschafterstruktur, Firmenname, Sitz, Gegenstand, Stammkapital
+  └─ Gesellschafterstruktur, Class-Shares, Stammkapital
+     Beirat / Advisory Board einplanen
 
 Phase B — Vertraege (Woche 3-4)
-  └─ Gesellschaftsvertrag/Satzung
-     Gesellschaftervereinbarung (SHA mit Vesting, Drag/Tag, Liquidation Preference)
-     Geschaeftsfuehrer-Anstellungsvertrag
+  └─ Gesellschaftsvertrag/Satzung mit B-Shares Vetorechten
+     Gesellschaftervereinbarung mit Vesting Drag Tag
+     Geschaeftsfuehrer-Anstellungsvertrag mit SV-Status
+     Geschaeftsordnung der Geschaeftsfuehrung
+     Beiratsordnung
+     Stimmverpflichtungs-Vereinbarungen SHA-Satzung
+     Bilinguale Fassungen Deutsch / Englisch
 
 Phase C — Notar + Handelsregister (Woche 4-6)
   └─ Beurkundung (physisch oder online nach DiRUG)
@@ -40,51 +56,100 @@ Phase D — Behoerden und operativer Start (Woche 6-8)
   └─ Gewerbeamt, Finanzamt-Erfassung, IHK, BG, Transparenzregister
      Geschaeftskonto, Buchhaltung, Compliance-Aufbau
      Erste 100 Tage Geschaeftsfuehrer-Pflichten
+     Gesellschafterversammlungen Einladungen Protokolle
+
+Phase E — Laufender Betrieb und Konflikt-Mass nahmen
+  └─ Kapitalerhoehungen (genehmigtes Kapital, Bezugsrecht)
+     Pflichtversammlung bei Stammkapital-Verlust Paragraf 49 III GmbHG
+     Gesellschafterstreit Eilantraege LG Registergericht
+     Schlichtung durch Beirat
 ```
 
-## Enthaltene Skills (17)
+## Enthaltene Skills (34)
 
-### Phase 0 — Rechtsformwahl (2 Skills)
+### Phase 0 — Intake und Rechtsformwahl (5 Skills)
 
 | Slug | Beschreibung |
 |---|---|
 | `gesellschaftsgruender-kommandocenter` | Master-Workflow mit Fristen Beteiligten Kosten |
+| `gesellschaftsgruender-gruender-intake` | Strukturierte Eingangs-Abfrage Gruender Anteile Class-Shares Geschaeftsmodell |
 | `gesellschaftsgruender-rechtsformwahl` | Entscheidungsmatrix GmbH/UG/GbR/OHG/KG/AG/PartG/gGmbH/eK |
+| `gesellschaftsgruender-firmenname-pruefung` | HR DPMA EUIPO Domain Verwechslungsgefahr Irrefuehrungsverbot |
+| `gesellschaftsgruender-cap-table` | Capitalization Table Pre/Post-Money Verwaesserung Liquidation-Waterfall |
 
-### Phase A — Vorbereitung (4 Skills)
-
-| Slug | Beschreibung |
-|---|---|
-| `gesellschaftsgruender-gmbh-vorbereitung` | Sieben Bausteine: Firma, Sitz, Gegenstand, Stammkapital, Gesellschafter, GF, Satzung |
-| `gesellschaftsgruender-ug-vorbereitung` | UG-Spezifika, Thesaurierungspflicht Paragraf 5a III GmbHG |
-| `gesellschaftsgruender-egbr-mopeg` | GbR nach MoPeG 2024, Gesellschaftsregister, Pflichteintragung bei Grundstuecksgeschaeften |
-| `gesellschaftsgruender-kg-und-gmbhcokg` | KG und GmbH & Co. KG, Komplementaer/Kommanditist, Hafteinlage |
-
-### Phase B — Vertraege (3 Skills)
+### Phase A — Strukturen und Sondervetorechte (4 Skills)
 
 | Slug | Beschreibung |
 |---|---|
-| `gesellschaftsgruender-gesellschaftsvertrag-gmbh` | Satzung mit Pflicht- und Standard-Klauseln, Musterprotokoll vs. individuell |
-| `gesellschaftsgruender-gesellschaftervereinbarung` | SHA: Vesting, Leaver, Drag/Tag, Liquidation Preference, Anti-Dilution |
-| `gesellschaftsgruender-geschaeftsfuehrervertrag` | GF-Anstellung: Vergueutung, Wettbewerbsverbot, D&O, SV-Status, vGA-Risiken |
+| `gesellschaftsgruender-gmbh-vorbereitung` | Sieben Bausteine: Firma Sitz Gegenstand Stammkapital Anteile GF Satzungswahl |
+| `gesellschaftsgruender-ug-vorbereitung` | UG-Spezifika Thesaurierungspflicht Paragraf 5a III GmbHG |
+| `gesellschaftsgruender-egbr-mopeg` | GbR nach MoPeG 2024 Gesellschaftsregister Pflichteintragung Grundstuecksgeschaefte |
+| `gesellschaftsgruender-kg-und-gmbhcokg` | KG und GmbH und Co KG Komplementaer Kommanditist Hafteinlage |
+| `gesellschaftsgruender-share-classes-a-b-c` | Anteilsklassen A/B/C Common Liquidation Preference Anti-Dilution |
+| `gesellschaftsgruender-golden-share-und-vetorechte` | Golden Share Sperrminoritaet Vetorechte Restrukturierung |
+
+### Phase B — Vertraege und Geschaeftsordnung (8 Skills)
+
+| Slug | Beschreibung |
+|---|---|
+| `gesellschaftsgruender-gesellschaftsvertrag-gmbh` | Satzung mit Pflicht-/Standard-Klauseln Musterprotokoll vs individuell |
+| `gesellschaftsgruender-gesellschaftervereinbarung` | SHA: Vesting Leaver Drag Tag Liquidation Anti-Dilution Pönalen |
+| `gesellschaftsgruender-sha-satzung-stimmverpflichtung` | Stimmverpflichtung Innenverhaeltnis Joinder Agreement Pönalen |
+| `gesellschaftsgruender-geschaeftsfuehrervertrag` | GF-Anstellung Vergueutung Wettbewerb D&O SV-Status vGA |
+| `gesellschaftsgruender-gf-sozialversicherungs-status` | Fremd-GF Mehrheits-/Minderheits-GF Statusfeststellung Paragraf 7a SGB IV |
+| `gesellschaftsgruender-geschaeftsordnung-gf` | Geschaeftsordnung der Geschaeftsfuehrung Zustimmungs-Kataloge |
+| `gesellschaftsgruender-gf-meeting-templates` | Tagesordnung Einladung Protokoll Umlauf-Beschluss bilingual |
+| `gesellschaftsgruender-beirat-advisory-board` | Beirat Advisory Board Beiratsordnung Schlichtungs-Funktion |
+| `gesellschaftsgruender-bilinguale-dokumente` | Deutsch und Englisch parallel Vorrang-Klausel Uebersetzungs-Fallen |
 
 ### Phase C — Notar und Handelsregister (3 Skills)
 
 | Slug | Beschreibung |
 |---|---|
-| `gesellschaftsgruender-notar-vorbereitung` | Notarsitzung: Unterlagen, Kosten GNotKG, Sacheinlage-Vorbereitung |
-| `gesellschaftsgruender-online-gruendung-dirug` | DiRUG-Online-Gruendung per Videokonferenz seit August 2022 |
-| `gesellschaftsgruender-handelsregister-anmeldung` | Anmeldung, Versicherungen Paragraf 8 II GmbHG, Vor-GmbH, Gesellschafterliste |
+| `gesellschaftsgruender-notar-vorbereitung` | Notarsitzung Unterlagen GNotKG-Kosten Sacheinlage |
+| `gesellschaftsgruender-online-gruendung-dirug` | DiRUG-Online-Gruendung Videokonferenz seit August 2022 |
+| `gesellschaftsgruender-handelsregister-anmeldung` | Anmeldung Versicherungen Paragraf 8 II GmbHG Vor-GmbH |
 
 ### Phase D — Behoerden und Start (5 Skills)
 
 | Slug | Beschreibung |
 |---|---|
-| `gesellschaftsgruender-gewerbeanmeldung-finanzamt` | Gewerbeamt Paragraf 14 GewO, Fragebogen ELSTER, USt-Wahl, Kleinunternehmer |
-| `gesellschaftsgruender-transparenzregister` | TraFinG-Meldung, wirtschaftlich Berechtigter, Sonderkonstellationen |
-| `gesellschaftsgruender-ihk-und-berufsgenossenschaft` | IHK/HwK-Pflicht, BG binnen 1 Woche, Freiberufler-Spezifika |
-| `gesellschaftsgruender-stammkapital-einzahlung` | Bareinlage, freie Verfuegung Paragraf 7 II 2 GmbHG, Hin- und Herzahlen verboten |
-| `gesellschaftsgruender-geschaeftsfuehrer-pflichten-startphase` | Erste 100 Tage: Buchhaltung, Steuern, SV, Compliance, Haftung Paragraf 43 GmbHG |
+| `gesellschaftsgruender-gewerbeanmeldung-finanzamt` | Gewerbeamt Paragraf 14 GewO ELSTER USt-Wahl Kleinunternehmer |
+| `gesellschaftsgruender-transparenzregister` | TraFinG wirtschaftlich Berechtigter Bussgeld bis 150000 EUR |
+| `gesellschaftsgruender-ihk-und-berufsgenossenschaft` | IHK HwK BG binnen 1 Woche Freiberufler-Spezifika |
+| `gesellschaftsgruender-stammkapital-einzahlung` | Bareinlage freie Verfuegung Paragraf 7 II 2 GmbHG Hin-und-Herzahlen verboten |
+| `gesellschaftsgruender-geschaeftsfuehrer-pflichten-startphase` | Erste 100 Tage Buchhaltung Steuern SV Compliance Haftung Paragraf 43 GmbHG |
+
+### Phase E — GV und Konflikt-Mass nahmen (5 Skills)
+
+| Slug | Beschreibung |
+|---|---|
+| `gesellschaftsgruender-gv-einladung-tagesordnung` | Einladung Paragraf 51 GmbHG Frist Form Tagesordnung Beschluss-Vorlage |
+| `gesellschaftsgruender-gv-protokoll-und-versammlungsleiter` | Protokoll Versammlungsleiter Wahl Streit notarielle Beurkundung |
+| `gesellschaftsgruender-stammkapitalverlust-paragraf-49-gmbhg` | Pflichtversammlung bei Verlust Haelfte Stammkapital |
+| `gesellschaftsgruender-genehmigtes-kapital` | Vorratsbeschluss Paragraf 55a GmbHG bis 50% des Stammkapitals 5 Jahre |
+| `gesellschaftsgruender-kapitalerhoehung-bezugsrecht` | Kapitalerhoehung Bezugsrecht Bezugsrechtsausschluss BGH-Linie Kali-Salz |
+| `gesellschaftsgruender-gesellschafterstreit-eilantraege` | Einstweilige Verfuegung LG Anmeldungs-Sperre Registergericht Anfechtungsklage |
+
+## Schulungsakte
+
+Im Verzeichnis `testakten/gesellschaftsgruender-streit-roeschen-tech/` befindet sich eine **vollstaendige Schulungsakte** mit dem Szenario einer fiktiven Roeschen Tech GmbH:
+
+- Gruendung mit drei Gruendern und Stammkapital 30.000 EUR
+- Series-A-Aufnahme von Stahlauge Ventures AG mit B-Shares
+- 2. Kapitalerhoehung mit Bezugsrechtsausschluss zugunsten Pi Mu Holding GmbH
+- **Streit** der Minderheits-Gesellschafterin Christine Linnenbach mit Anfechtungsklage, Eilantrag LG, Anmeldungs-Sperre Registergericht
+- Schlichtung durch Beirat
+
+Enthaelt:
+
+- Vollstaendige Satzung
+- Shareholder Agreement
+- Cap Table (Stand 1-4)
+- Einladung und Protokoll der streitigen GV
+- Anfechtungsklage und Eilantraege
+- Beirat-Schlichtungs-Empfehlung
+- Schulungsbegleiter mit Lernzielen und Aufgaben
 
 ## Pluginscope und Stoppschilder
 
@@ -95,21 +160,25 @@ Phase D — Behoerden und operativer Start (Woche 6-8)
 - Fristen und Beteiligte aufstellen
 - Typische Fallstricke benennen
 - Praktische Schritt-fuer-Schritt-Anleitungen
+- Bilinguale Vorlagen (Deutsch/Englisch)
+- Konflikt-Werkzeuge (Eilantraege, Anfechtungsklagen)
 
-### Was das Plugin NICHT macht
+### Was nicht
 
-- **Keine Notar-Beurkundung**: muss vor Notar erfolgen
-- **Keine Steuerberatung**: Steuerberater fuer Mandate erforderlich
-- **Keine Vertretung im Streit**: Anwalt fuer Konflikt-Mandate
+- **Keine Notar-Beurkundung** (muss vor Notar erfolgen)
+- **Keine Steuerberatung** (Steuerberater zwingend bei Mandaten)
+- **Keine Vertretung im Streit** (Anwalt bei Konflikt-Mandaten)
+- **Kein Mandanten-Vertretungs-Vertrag** mit Pflichten zur Schweigepflicht
 
 ### Wann zwingend Anwalt / Notar / Steuerberater
 
 - Bei Sacheinlagen mit Werthaltigkeits-Risiko (Differenzhaftung Paragraf 9 GmbHG)
 - Bei Beteiligung von Auslandsgesellschaftern (Sanktionsrecht, Investitionspruefung)
-- Bei gemeinnuetzigen Zwecken (Voraussetzungen Paragrafen 52-68 AO)
+- Bei gemeinnuetzigen Zwecken
 - Bei Konzern- und Holding-Strukturen
 - Bei Family-Buy-In / Buy-Out
 - Bei wirtschaftlicher Krise (Insolvenzantragspflicht Paragraf 15a InsO)
+- Bei Gesellschafterstreit mit Klage-Vorbereitung
 
 ## Zitierweise
 
@@ -120,10 +189,12 @@ Sämtliche Zitierweise-Vorgaben folgen `references/zitierweise.md` des übergeor
 Beruecksichtigt:
 
 - **MoPeG** (Modernisierung Personengesellschaftsrecht, 1.1.2024) — eGbR-Eintragung, Pflicht bei Grundstuecksgeschaeften
-- **DiRUG** (Digitalisierungsrichtlinie-Umsetzungsgesetz, 1.8.2022) — Online-Gruendung GmbH/UG
+- **DiRUG** (Digitalisierungsrichtlinie-Umsetzungsgesetz, 1.8.2022) — Online-Gruendung
 - **TraFinG** (2021) — Transparenzregister als Vollregister
-- **GWG**-Novellen — wirtschaftlich Berechtigter, Bussgeldrahmen bis 150.000 EUR
-- **Geldwaesche-Strafrecht** Paragraf 261 StGB
+- **GwG**-Novellen — wirtschaftlich Berechtigter, Bussgeld bis 150.000 EUR
+- **BGH Kali+Salz** (BGHZ 71, 40) — Bezugsrechtsausschluss-Linie
+- **BGH Macrotron** (BGH NJW 2005, 985) — Bezugsrecht-Schutz
+- **BGH NJW 2007, 917 / 2018, 1233** — Treuepflicht in Kapitalgesellschaften
 
 ## Tipps fuer die Bearbeitung
 
@@ -137,4 +208,12 @@ Beruecksichtigt:
 
 5. **D&O-Versicherung von Anfang an**: GF-Haftung Paragraf 43 GmbHG ist real.
 
-6. **Fristen sind unverzeihlich**: Insolvenzantrag binnen 3 Wochen, BG binnen 1 Woche, Fragebogen Finanzamt binnen 1 Monat.
+6. **Vesting fuer Gruender**: Vermeidet Frust, wenn ein Gruender nach 6 Monaten ausscheidet.
+
+7. **Bezugsrechte ernst nehmen**: Bei Kapitalerhoehung **immer** Bezugsrechte anbieten — sonst Anfechtungs-Risiko.
+
+8. **Beirat als Schlichter**: Vor Klage anrufen, wenn vorgesehen.
+
+9. **Bilinguale Dokumente**: Deutsche Fassung geht vor.
+
+10. **Fristen sind unverzeihlich**: Insolvenzantrag binnen 3 Wochen, Anfechtungsklage binnen 1 Monat, BG binnen 1 Woche.

--- a/gesellschaftsgruender/skills/gesellschaftsgruender-beirat-advisory-board/SKILL.md
+++ b/gesellschaftsgruender/skills/gesellschaftsgruender-beirat-advisory-board/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: gesellschaftsgruender-beirat-advisory-board
+description: "Beirat Advisory Board Aufsichtsrat. Beiratsordnung Aufgaben Besetzung Vergueutung. Pflicht vs freiwillig. Bei GmbH typisch freiwillig Empfehlung bei Mittelstand und Family Office. Beispiel-Klausel Satzung Beiratsordnung Tagesordnung Beirat-Meeting. Streit-Schlichtungs-Funktion."
+---
+
+# Beirat / Advisory Board
+
+## Zweck
+
+Der **Beirat** ist ein freiwilliges Beratungs- und Aufsichtsorgan der GmbH. Er kann Geschaeftsfuehrung beraten, Strategie-Entwicklung begleiten, bei Konflikten schlichten — oder mit echten Befugnissen ausgestattet werden. Bei der GmbH **freiwillig** (anders als bei AG, wo Aufsichtsrat Pflicht ist).
+
+## 1) Begriffliche Klarheit
+
+### Beirat (deutsch)
+
+- Beratungs- und/oder Kontrollorgan
+- Freiwillig bei GmbH
+- Befugnisse in Satzung / Beiratsordnung festgelegt
+
+### Advisory Board
+
+- Beratung ohne echte Entscheidungsbefugnis
+- Typisch in Startups
+- Ehrenamtlich oder gegen Optionen
+
+### Aufsichtsrat
+
+- Bei AG Pflicht (Paragraf 95 AktG)
+- Bei mitbestimmter GmbH ab 500 / 2.000 Beschaeftigten Pflicht (DrittelbG, MitbestG)
+- Pflicht-Aufgaben: Bestellung Vorstand, Pruefung Jahresabschluss
+
+## 2) Wann sinnvoll
+
+### Bei Mittelstand-GmbH
+
+- Externe Expertise (Branche, Steuern, IT, Compliance)
+- Streit-Schlichtungs-Funktion bei Gesellschafter-Konflikten
+- Nachfolge-Planung
+- Vertretung der Familien-Interessen bei Family Business
+
+### Bei Startup
+
+- Advisory Board mit Experten / Investoren
+- Strategie-Sparring, Netzwerk
+- Vergueutung typisch durch ESOP-Optionen
+
+### Bei Investor-Beteiligung
+
+- Investor verlangt Sitz im Beirat
+- Beirat als Kontroll-Instrument fuer Investor
+- Beirat-Veto bei wesentlichen Entscheidungen
+
+## 3) Aufgaben (typisch)
+
+### Beratung
+
+- Strategie-Diskussion
+- Markt-Trends, Branchen-Expertise
+- Personal-Empfehlungen (insbesondere C-Level)
+
+### Aufsicht
+
+- Pruefung Jahresabschluss vor GV
+- Risiko-Bewertung
+- Compliance-Monitoring
+- Bewertung der Geschaeftsfuehrer-Leistung
+
+### Schlichtung
+
+- Bei Gesellschafter-Konflikten
+- Bei GF-Konflikten
+- Vor Anfechtungsklage
+
+### Repraesentation
+
+- Externe Wahrnehmung (PR-Wert)
+- Reputations-Trager (z.B. Branchen-Promis)
+
+## 4) Beirat-Klausel in Satzung — Beispiel
+
+```
+§ X Beirat
+
+(1) Die Gesellschaft hat einen Beirat. Er besteht
+aus mindestens 3, hoechstens 7 Mitgliedern.
+
+(2) Die Mitglieder des Beirats werden von der
+Gesellschafterversammlung mit einfacher Mehrheit
+fuer eine Amtszeit von 3 Jahren bestellt. Erneut-
+Bestellung ist zulaessig.
+
+(3) Der Beirat hat folgende Aufgaben:
+a) Beratung der Geschaeftsfuehrung in strategischen
+   Fragen,
+b) Pruefung des Jahresabschlusses vor Vorlage in
+   der Gesellschafterversammlung,
+c) Empfehlungen zu Investitionen ueber 500.000 EUR,
+d) Vorabschlichtung bei Gesellschafter-Konflikten.
+
+(4) Folgende Geschaefte beduerfen der Zustimmung
+des Beirats:
+a) Aufnahme von Krediten ueber 1.000.000 EUR,
+b) Veraeusserung wesentlicher Aktiva (> 20 % der
+   Bilanzsumme),
+c) Eingehung von Joint Ventures,
+d) Anstellung von Geschaeftsfuehrern.
+
+(5) Das Naehere regelt die Beiratsordnung, die von
+der Gesellschafterversammlung beschlossen wird.
+```
+
+## 5) Beiratsordnung — Standard-Inhalt
+
+### Konstituierung
+
+- Anzahl Mitglieder
+- Vorsitzender / Stellvertreter
+- Amtszeit, Wiederwahl
+
+### Aufgaben und Befugnisse
+
+- Beratungs-, Kontroll-, ggf. Entscheidungs-Befugnisse
+- Zustimmungspflichtige Geschaefte
+- Berichtspflichten
+
+### Meeting-Rhythmus
+
+- Mindestens vierteljaehrlich
+- Einberufung durch Vorsitzenden
+- Tagesordnung mit Frist
+- Protokoll-Pflicht
+
+### Beschlussfassung
+
+- Mehrheits-Erfordernisse
+- Stimmrechts-Verteilung
+- Stimmrechts-Verbot bei Eigen-Interesse
+
+### Vergueutung
+
+- Sitzungsgeld
+- Jahres-Festbetrag
+- Reisekostenerstattung
+- Bei Startup: ESOP-Optionen
+
+### Beiratsvertraege
+
+- Schriftlicher Beirats-Mitgliedschaftsvertrag
+- D&O-Versicherung (analog GF-Haftung)
+- Verschwiegenheitspflicht
+- Wettbewerbsverbot (ggf.)
+
+## 6) Beispiel-Beiratsordnung
+
+```
+BEIRATSORDNUNG der [Firma] GmbH
+
+§ 1 Aufgaben
+[wie oben]
+
+§ 2 Zusammensetzung
+(1) Der Beirat besteht aus 5 Mitgliedern:
+- 1 Vorsitzender
+- 1 stellvertretender Vorsitzender
+- 3 weitere Mitglieder
+
+(2) Mindestens 2 Mitglieder sind unabhaengig im
+Sinne der Deutschen Corporate Governance Empfehlung.
+
+§ 3 Meetings
+(1) Vier reguläre Sitzungen pro Geschaeftsjahr.
+(2) Tagesordnung wird vom Vorsitzenden vorbereitet
+und 1 Woche vor Sitzung verteilt.
+(3) Beschlussfaehigkeit: mindestens 3 Mitglieder
+anwesend.
+(4) Beschluesse mit einfacher Mehrheit der
+abgegebenen Stimmen.
+
+§ 4 Vergueutung
+(1) Jahresfestbetrag: 12.000 EUR fuer Mitglieder,
+   18.000 EUR fuer Vorsitzenden.
+(2) Sitzungsgeld: 1.500 EUR pro Sitzung.
+(3) Reisekosten gegen Beleg.
+
+§ 5 Verschwiegenheit
+[Klausel]
+
+§ 6 Aenderungen
+Aenderungen der Beiratsordnung beduerfen einer
+Mehrheit von 75 % der Gesellschafter und der
+Zustimmung des Beirats mit Zwei-Drittel-Mehrheit.
+```
+
+## 7) Advisory Board (Startup-Variante)
+
+### Unterschiede zum Beirat
+
+- **Keine Entscheidungs-Befugnis** (rein beratend)
+- **Lockerer Rhythmus** (z.B. monatliches Call, vierteljaehrliches Praesenz-Meeting)
+- **Mitglieder oft Branchen-Experten / Mentoren**
+- **Vergueutung durch ESOP-Optionen** statt Bargeld
+
+### Advisory Agreement
+
+```
+ADVISORY AGREEMENT
+
+Zwischen der [Firma] GmbH (Gesellschaft)
+und Herrn/Frau [Name] (Advisor)
+
+Aufgaben des Advisors:
+- Beratung in strategischen Fragen
+- Vermittlung von Kontakten
+- 1 Stunde Call pro Monat
+- 1 Praesenz-Meeting pro Quartal
+
+Vergueutung:
+- Option auf 0,5 % der Anteile (ESOP-Pool)
+- Vesting: 25 % nach 12 Monaten Cliff,
+  danach monatlich 1/48 ueber 36 Monate
+- Bei vorzeitiger Beendigung: nur vested Anteile
+
+Vertraulichkeit, Wettbewerbsverbot
+[Klauseln]
+
+Dauer:
+2 Jahre, automatische Verlaengerung um 1 Jahr,
+sofern nicht 3 Monate vor Ablauf gekuendigt.
+```
+
+## 8) Meeting-Tagesordnung Beirat
+
+```
+TAGESORDNUNG Beirat-Meeting
+[Firma] GmbH, [Datum]
+
+1. Begruessung, Beschlussfaehigkeit
+2. Genehmigung Protokoll Vor-Sitzung
+3. Quartalsbericht der Geschaeftsfuehrung
+   - Umsatz, EBITDA, Cash Burn, Runway
+   - Plan-Ist-Vergleich
+   - Wesentliche Ereignisse
+4. Strategie-Themen:
+   - [konkrete Themen]
+5. Zustimmungspflichtige Beschluesse:
+   - Investition X (> 500 K EUR)
+6. Empfehlungen an Gesellschafterversammlung
+7. Naechstes Meeting, Sonstiges
+```
+
+## 9) Streit-Schlichtungs-Funktion
+
+### Konstellation
+
+- Gesellschafter-Konflikt eskaliert
+- Vor Anfechtungsklage: Beirat-Vermittlung
+
+### Beiratsordnungs-Klausel
+
+```
+§ Y Schlichtungs-Funktion
+
+(1) Bei Konflikten zwischen Gesellschaftern, die zu
+einer Klage gegen die Gesellschaft oder einen
+Gesellschafter fuehren koennten, ist der Beirat
+vor Klageerhebung anzurufen.
+
+(2) Der Beirat hat innerhalb von 4 Wochen einen
+Schlichtungs-Vorschlag zu unterbreiten.
+
+(3) Die Schlichtungs-Empfehlung ist nicht bindend,
+aber die Pflicht zur Anrufung vor Klage besteht.
+
+(4) Bei Versaeumnis der Anrufung kann die Klage
+durch Einrede der Unzulaessigkeit der Klage
+zurueckgewiesen werden.
+```
+
+## 10) Praktische Empfehlung
+
+### Bei Gruendung
+
+- Beirat in Satzung verankert, auch wenn anfangs nicht besetzt
+- Beiratsordnung als Vorlage in der Schublade
+- Bei Bedarf binnen Wochen aktivierbar
+
+### Bei Investor-Eintritt
+
+- Investor verlangt typisch Sitz im Beirat
+- Beirats-Klausel bei Series-A-Verhandlung mit ausgehandelt
+
+### Bei Mittelstand
+
+- Beirat als Strategie-Sparring, fuer Risk-Management
+- Empfehlung: 3-5 Mitglieder, davon mindestens 1 unabhaengig
+
+### Bei Family Business
+
+- Beirat als Nachfolge-Vorbereitung
+- Erste Generation in der GF, zweite Generation im Beirat lernen
+
+## Anschluss
+
+- `gesellschaftsgruender-geschaeftsordnung-gf` — Verzahnung mit GF
+- `gesellschaftsgruender-gesellschaftsvertrag-gmbh` — Satzungs-Klausel
+- `gesellschaftsgruender-gesellschafterstreit-eilantraege` — Schlichtungs-Funktion

--- a/gesellschaftsgruender/skills/gesellschaftsgruender-bilinguale-dokumente/SKILL.md
+++ b/gesellschaftsgruender/skills/gesellschaftsgruender-bilinguale-dokumente/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: gesellschaftsgruender-bilinguale-dokumente
+description: "Bilinguale Dokumente Deutsch und Englisch parallel. Satzung Gesellschaftervereinbarung Geschaeftsfuehreranstellungsvertrag Beiratsordnung Term Sheet Convertible Loan Agreement. Vorrang-Klausel deutscher Text geht vor. Typische Uebersetzungs-Fallen Class A Vorzugsanteile Liquidation Preference Drag-Along Tag-Along Anti-Dilution Vesting Cliff."
+---
+
+# Bilinguale Dokumente
+
+## Zweck
+
+Bei internationalen Investoren oder auslaendischen Gesellschaftern sind **bilinguale Dokumente** (Deutsch / Englisch) ueblich. Die deutsche Fassung soll typisch vorrangig sein — sonst gibt es Risiken bei Auslegung und Vollstreckung in Deutschland.
+
+## 1) Grundsatz: Deutscher Text geht vor
+
+### Rechtsfolge
+
+- Im deutschen Rechtsraum ist die deutsche Sprache **Amts- und Gerichtssprache** (Paragraf 184 GVG)
+- Eintragungen ins Handelsregister erfolgen auf Deutsch
+- Notarielle Beurkundung erfolgt auf Deutsch (Paragraf 5 BeurkG; bei Auslaendern mit Dolmetscher)
+
+### Standardklausel
+
+```
+Diese Vereinbarung wird in deutscher und englischer
+Sprache abgefasst. Bei Widerspruechen zwischen den
+beiden Sprachfassungen geht die deutsche Fassung
+vor.
+
+This Agreement is drafted in German and English
+language. In case of discrepancies between the two
+language versions, the German version shall prevail.
+```
+
+### Notarielle Beurkundung
+
+Bei notarieller Beurkundung mit auslaendischen Beteiligten:
+
+- Beurkundung in deutscher Sprache (Pflicht Paragraf 5 BeurkG)
+- Auslaendischer Beteiligter erhaelt **Uebersetzung** durch vereidigten Dolmetscher
+- Beide Fassungen werden unterschrieben, deutsche bleibt verbindlich
+
+## 2) Welche Dokumente bilingual
+
+### Pflicht-Dokumente
+
+- Satzung (Articles of Association)
+- Gesellschaftervereinbarung (Shareholder Agreement)
+- Geschaeftsfuehreranstellungsvertrag (Managing Director's Agreement)
+- Beiratsordnung (Advisory Board Charter)
+
+### Investor-Dokumente
+
+- Term Sheet
+- Convertible Loan Agreement (CLA)
+- Subscription Agreement (Beitritts-Vereinbarung)
+- Vesting Agreement
+
+### Operative Dokumente
+
+- Geschaeftsordnung der Geschaeftsfuehrung (Management Rules of Procedure)
+- AGB (General Terms)
+- Datenschutzerklaerung (Privacy Policy)
+
+### Behoerden-Dokumente
+
+- Werden **nur** auf Deutsch eingereicht
+- Anmeldung Handelsregister, Gewerbeamt, Finanzamt: Deutsch
+- TraFinG-Meldung: Deutsch
+
+## 3) Typische Uebersetzungs-Fallen
+
+### Class A Anteile
+
+- ❌ „Class A Stocks" (klingt nach AG)
+- ✅ „Class A Shares" oder „Class A Geschaeftsanteile"
+- Beide Fassungen: „Class A" als feste Bezeichnung
+
+### Liquidation Preference
+
+- Etablierter englischer Begriff
+- Deutsch: „Liquidationsvorrang" oder bei Notar-Beurkundung „Vorrang bei der Aufloesung der Gesellschaft"
+- Im Vertrag: **„Liquidation Preference (Liquidationsvorrang)"** mit Klarstellung
+
+### Drag-Along / Tag-Along
+
+- „Mitziehverpflichtung" (Drag-Along), „Mitveraeusserungsrecht" (Tag-Along)
+- Praxis: englische Begriffe **plus** deutsche Erlaeuterung
+
+### Anti-Dilution
+
+- „Verwaesserungsschutz"
+- Sub-Varianten:
+  - Full Ratchet: „voller Ausgleich"
+  - Weighted Average broad-based: „gewichteter Mittelwert (breite Basis)"
+
+### Vesting / Cliff
+
+- „Vesting" -> „Erdienen"
+- „Cliff" -> „Cliff-Periode" oder „Anlauffrist"
+- Praxis: englisch + Erlaeuterung
+
+### Geschaeftsfuehrer
+
+- „Managing Director" Standard-Uebersetzung
+- **Nicht** „CEO" — das ist kein Rechtsbegriff in Deutschland
+- Im Anstellungsvertrag: Doppel-Bezeichnung möglich
+
+### Bezugsrecht
+
+- „Subscription right" oder „pre-emption right"
+- „Pre-emption right" beim juristischen Englisch besser
+
+### Sondervetorecht (Golden Share)
+
+- „Veto right" oder „Special Veto right"
+- „Golden Share" auch international verstaendlich
+
+### Gesellschafterversammlung
+
+- „Shareholders' Meeting" oder „General Meeting"
+- „Gesellschafterversammlung" bleibt Original-Bezeichnung
+
+### Genehmigtes Kapital
+
+- „Authorized capital" Standard
+- Mit Erlaeuterung der GmbHG-Norm
+
+## 4) Beispiel-Klausel — Drag-Along bilingual
+
+### Deutsch
+
+```
+§ Y Mitziehverpflichtung (Drag-Along)
+
+(1) Stimmen Gesellschafter, die zusammen mehr als
+75 % der Stimmrechte an der Gesellschaft halten,
+einem Verkauf saemtlicher Anteile an der Gesellschaft
+an einen Dritten zu, koennen sie die uebrigen
+Gesellschafter verpflichten, ihre Anteile zu
+denselben Bedingungen mitzuveraeussern.
+
+(2) Die Mitziehverpflichtung gilt nur, wenn der
+Verkaufspreis pro Anteil gleichbleibend fuer alle
+Gesellschafter ist.
+```
+
+### English
+
+```
+§ Y Drag-Along Obligation
+
+(1) If shareholders holding in aggregate more than
+75 % of the voting rights in the Company agree to
+sell all shares in the Company to a third party,
+they may oblige the remaining shareholders to
+co-sell their shares on the same terms.
+
+(2) The drag-along obligation shall only apply if
+the sales price per share is the same for all
+shareholders.
+```
+
+### Vorrang-Klausel
+
+```
+Bei Inkonsistenzen zwischen der deutschen und der
+englischen Fassung geht die deutsche Fassung vor.
+(In case of inconsistencies, the German version
+shall prevail.)
+```
+
+## 5) Notar und Bilingualitaet
+
+### Beurkundung
+
+- Notar beurkundet **deutsche** Fassung
+- Englische Fassung als **Anlage** mit Vorrang-Klausel
+- Auslaendischer Beteiligter erhaelt Uebersetzung durch vereidigten Dolmetscher
+
+### Kosten
+
+- Beurkundung der deutschen Fassung nach GNotKG
+- Dolmetscher-Kosten extra (Auslaender-Pflichtkosten)
+
+### Praxis
+
+- Anwalt liefert deutsche **und** englische Fassung
+- Notar beurkundet deutsche, englische bleibt als Anlage
+- Beide werden vom Beteiligten unterzeichnet
+
+## 6) Term Sheet bilingual — Beispiel-Spalten
+
+```
+| German               | English                | Comment            |
+|----------------------|------------------------|--------------------|
+| Investitionsbetrag   | Investment Amount      |                    |
+| Pre-Money-Bewertung  | Pre-Money Valuation    |                    |
+| Liquidationsvorrang  | Liquidation Preference | 1x non-participating |
+| Drag-Along-Schwelle  | Drag-Along Threshold   | 75 %               |
+| Vesting              | Vesting                | 4 Jahre / 12 Mon. Cliff |
+| Berichtspflichten    | Reporting Obligations  | Quartalsweise      |
+| Sondervetorechte     | Special Veto Rights    | Liste in SHA       |
+| Mitarbeiter-Pool     | ESOP Pool              | 10 % vorgesehen    |
+```
+
+## 7) Typische Uebersetzungs-Fehler
+
+1. **„Limited Liability Company"** statt „GmbH" — ungenau, weil amerikanische LLC anders strukturiert
+2. **„Statute"** statt „Articles of Association" — „Statute" ist mehrdeutig
+3. **„Corporate Resolution"** statt „Shareholders' Resolution" — Corporate Resolution ist breiter
+4. **„Stock"** vs. „Shares"** — Stocks ist amerikanisch, Shares britisch — bei deutscher GmbH lieber „shares"
+5. **„CEO"** als Rechtsbegriff — gibt es im deutschen Recht nicht; nur „Geschaeftsfuehrer" / „Managing Director"
+
+## 8) Workflow bei bilingualer Erstellung
+
+### Schritt 1: Deutsche Master-Fassung
+
+- Erstellung der vollstaendigen deutschen Fassung
+- Pruefung durch deutschen Anwalt
+
+### Schritt 2: Englische Uebersetzung
+
+- Durch juristischen Uebersetzer mit deutschem Recht-Hintergrund
+- **Nicht** durch maschinelle Uebersetzung allein
+
+### Schritt 3: Cross-Pruefung
+
+- Anwalt liest beide Fassungen parallel
+- Bei Inkonsistenzen: deutsche Fassung anpassen oder Vorrang-Klausel verstaerken
+
+### Schritt 4: Vorrang-Klausel
+
+- Standardklausel am Anfang oder Ende
+- Notarielle Beurkundung auf Deutsch
+
+## 9) Bei Schiedsverfahren
+
+### Schiedsklausel
+
+- Sprache des Schiedsverfahrens festlegen (Deutsch / Englisch / beide)
+- Bei DIS-Schiedsklauseln: Sprache typisch Deutsch
+- Bei Englisch: keine besonderen Pflichten zur deutschen Beurkundung
+
+### Englisches Schiedsverfahren mit deutscher GmbH
+
+- Schiedsspruch wird in Deutsch oder Englisch verfasst
+- Vollstreckung in Deutschland: Anerkennung Paragrafen 1061 ff. ZPO
+- Bei Vollstreckung: deutsche Uebersetzung des Schiedsspruchs zwingend (Paragraf 1064 III ZPO)
+
+## 10) Praktische Empfehlung
+
+- **Deutsche Master-Fassung** ist immer Pflicht
+- **Englische Fassung** auf Anforderung, mit Vorrang-Klausel
+- **Juristischer Uebersetzer** mit deutschem Recht-Hintergrund
+- **Konsistenz-Pruefung** durch Anwalt vor Beurkundung
+- **Standard-Glossar** im Mandat aufbauen, das ueber alle Dokumente konsistent verwendet wird
+
+## Anschluss
+
+- `gesellschaftsgruender-gv-einladung-tagesordnung` — Einladung bilingual
+- `gesellschaftsgruender-geschaeftsfuehrervertrag` — Anstellungsvertrag bilingual
+- `gesellschaftsgruender-gesellschaftervereinbarung` — SHA bilingual
+- `common-law-kompass` — fuer Common-Law-Spezifika

--- a/gesellschaftsgruender/skills/gesellschaftsgruender-cap-table/SKILL.md
+++ b/gesellschaftsgruender/skills/gesellschaftsgruender-cap-table/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: gesellschaftsgruender-cap-table
+description: "Cap-Table-Erzeugung Capitalization Table. Pre-Money und Post-Money-Bewertung Bezugsrechtsverteilung Verwaesserung Anteilsklassen. Liquidation-Preference-Waterfall. Cap-Table als Excel JSON oder Markdown. Schnittstelle zum Notar mit beglaubigter Gesellschafterliste Paragraf 40 GmbHG. Vesting-Schedule pro Gruender. Mit Beispielen Solo Gruender bis Series A."
+---
+
+# Cap Table
+
+## Zweck
+
+Der Cap Table (Capitalization Table) zeigt **wer wieviele Anteile zu welchem Wert** haelt — Grundlage fuer Notar-Anmeldung, Investor-Verhandlungen, Verwaesserungs-Simulationen und steuerliche Bewertungen.
+
+## 1) Inhalte
+
+### Pflicht-Spalten
+
+- Gesellschafter (Name, Geburtsdatum)
+- Anteilsklasse (Common, A, B, C, ...)
+- Anzahl Anteile / Nennwert pro Anteil / Summe Nennwert
+- Anteil in Prozent
+- Stimmrechte (falls abweichend von Quote)
+- Vesting-Status (gevested / ungevested, Cliff-Datum)
+
+### Optionale Spalten
+
+- Erwerbs-Datum
+- Erwerbs-Preis pro Anteil
+- Aktueller Verkehrswert pro Anteil
+- Liquidation Preference (z.B. 1x non-participating)
+- Anti-Dilution-Status
+
+## 2) Beispiel: Solo-Gruender mit Pre-Seed-Investor
+
+```
+| Gesellschafter        | Klasse | Anteile | Nennwert | %     | Stimmen | Vesting |
+|-----------------------|--------|---------|----------|-------|---------|---------|
+| Anna Mueller (Gruender)| Common | 20.000  | 1 EUR    | 80 %  | 80 %    | 25/48 nach 12 Monaten Cliff |
+| Investor I AG         | A      | 5.000   | 1 EUR    | 20 %  | 20 %    | -       |
+| Stammkapital gesamt   |        | 25.000  | 25.000 EUR | 100 %| 100 %  |         |
+```
+
+## 3) Beispiel: Mehrgruender-GmbH mit Class-Shares nach Series A
+
+```
+| Gesellschafter        | Klasse | Anteile | %     | Stimmen | Liquidation Preference |
+|-----------------------|--------|---------|-------|---------|------------------------|
+| Anna Mueller (CEO)    | Common | 12.000  | 30 %  | 30 %    | -                      |
+| Bernd Schmidt (CTO)   | Common | 12.000  | 30 %  | 30 %    | -                      |
+| Carla Wagner (CFO)    | Common | 4.000   | 10 %  | 10 %    | -                      |
+| Founders Holding GmbH | Common | 4.000   | 10 %  | 10 %    | -                      |
+| Investor I AG         | A      | 6.000   | 15 %  | 18 % (1,2x)| 1x non-participating|
+| Investor II Capital   | B      | 2.000   | 5 %   | 6 % (1,2x) | 1,5x participating |
+| ESOP-Pool             | Common | 0       | 0 %   | 0 %     | (reserviert 10 %)      |
+| Stammkapital gesamt   |        | 40.000  | 100 % | 94 %    |                        |
+```
+
+(Stimmrechte > 100 % moeglich bei Vorzugsklassen mit Mehrstimmrecht)
+
+## 4) Pre-Money / Post-Money
+
+### Begriffe
+
+- **Pre-Money**: Bewertung vor Investment
+- **Post-Money**: Bewertung nach Investment = Pre-Money + Investment-Summe
+- **Investor-Anteil** = Investment / Post-Money
+
+### Beispiel
+
+- Pre-Money: 4 Mio. EUR
+- Investment: 1 Mio. EUR
+- Post-Money: 5 Mio. EUR
+- Investor-Anteil: 1 / 5 = 20 %
+- Gruender-Verwaesserung: von 100 % auf 80 %
+
+## 5) Bezugsrechte und Verwaesserung
+
+### Bezugsrecht (Paragraf 55 II GmbHG bzw. analog)
+
+- Bei Kapitalerhoehung: bestehende Gesellschafter haben Bezugsrecht auf neue Anteile **anteilig**
+- Vermeidet Verwaesserung
+- Kann durch Gesellschafterbeschluss (75 %) **ausgeschlossen** werden — `gesellschaftsgruender-kapitalerhoehung-bezugsrecht`
+
+### Verwaesserung simulieren
+
+Bei nicht mitziehender Bezugsrechte-Ausuebung:
+
+```
+Vor Runde:  Gruender 80 %, Pre-Money 4 Mio.
+Series A:   2 Mio. EUR neue Anteile, Bezugsrecht ausgeschlossen
+Post-Money: 6 Mio. EUR
+Investor:   33 %
+Gruender:   80 % * (4 / 6) = 53 %
+```
+
+## 6) Liquidation-Waterfall
+
+Bei Exit / Aufloesung:
+
+1. **Liquidation Preference** der Vorzugsanteile (sortiert nach Vorrang)
+2. Restbetrag wird nach Anteilen verteilt (bei „participating" zusaetzlich)
+
+### Beispiel
+
+- Exit-Preis: 10 Mio. EUR
+- Investor I A: 1 Mio. EUR Investment, 1x non-participating, 20 % Anteil
+- Investor II B: 0,5 Mio. EUR Investment, 1,5x participating, 5 % Anteil
+- Gruender: 75 % Anteil
+
+Waterfall:
+
+- Investor II B: 0,5 * 1,5 = 0,75 Mio. (Preference)
+- Restbetrag fuer Investor I A: max(1 Mio., 20 % * Rest)
+- Schritt 1: Restbetrag = 10 - 0,75 = 9,25 Mio.
+- 20 % davon: 1,85 Mio. — also Investor I A waehlt **anteilig** (1,85 > 1,0)
+- Investor I A: 1,85 Mio.
+- Investor II B (participating, anteilig zusaetzlich): 5 % * 9,25 = 0,46 Mio. ZUSAETZLICH zur Preference
+- Investor II B insgesamt: 0,75 + 0,46 = 1,21 Mio.
+- Gruender: 9,25 - 1,85 - 0,46 = 6,94 Mio.
+
+## 7) Vesting-Schedule
+
+Standard:
+
+- **4 Jahre Vesting**, **12 Monate Cliff**
+- Bis 12 Monate: 0 vested
+- Bei 12 Monaten: 25 % vested (12/48)
+- Danach: monatlich 1/48 zusaetzlich
+- Bei 48 Monaten: 100 %
+
+Bei Bad-Leaver vor Vollvestung: Anteile gehen zurueck an die Gesellschaft (Einziehung Paragraf 34 GmbHG oder Pflicht-Rueckverkauf zum Nominalwert).
+
+## 8) Format-Vorlagen
+
+- **Excel/CSV** (Standard bei Investoren-Reportings)
+- **Markdown** (in Datenraum)
+- **JSON** (fuer automatische Pipelines)
+- **PDF** (mit Stempel-/Signatur fuer Notar / Investor)
+
+## 9) Gesellschafterliste Paragraf 40 GmbHG
+
+### Pflicht
+
+- Erste Liste mit Notar-Anmeldung
+- Jede Aenderung: neue Liste binnen Aenderung
+- Notar reicht ein bei Anteilsuebertragung (Paragraf 40 II GmbHG)
+- Im Handelsregister hinterlegt, oeffentlich einsehbar
+
+### Inhalt der Gesellschafterliste
+
+- Vor- und Nachname (bei juristischer Person Firma)
+- Anschrift, Geburtsdatum
+- Geschaeftsanteile mit Nummer und Nennwert
+- Eintragungs-Datum
+
+### Cap Table vs. Gesellschafterliste
+
+Der Cap Table ist die **interne** Uebersicht (alle Klassen, Verwaesserung, Vesting). Die Gesellschafterliste ist die **oeffentliche** Liste (HR). Beide muessen konsistent sein.
+
+## 10) Typische Cap-Table-Fehler
+
+1. **Vesting nicht abgebildet** im Cap Table -> bei Leaver-Diskussion fehlt Datenbasis
+2. **Liquidation Preference nicht waterfall-simuliert** -> Investor versteht Konsequenzen nicht
+3. **ESOP-Pool vergessen** -> Spaetere Aufnahme verwaessert Gruender, nicht Investor
+4. **Genehmigtes Kapital nicht beruecksichtigt** -> Bei Aufstockung Verwirrung
+5. **Anteilsklassen vermischt** -> Stimmrechte und wirtschaftliche Anteile divergieren, im Cap Table aber nicht klar abgebildet
+
+## Anschluss
+
+- `gesellschaftsgruender-share-classes-a-b-c` — bei mehreren Klassen
+- `gesellschaftsgruender-kapitalerhoehung-bezugsrecht` — Verwaesserung
+- `gesellschaftsgruender-genehmigtes-kapital` — Vorrats-Beschluss
+- `gesellschaftsgruender-notar-vorbereitung` — Gesellschafterliste fuer Anmeldung

--- a/gesellschaftsgruender/skills/gesellschaftsgruender-firmenname-pruefung/SKILL.md
+++ b/gesellschaftsgruender/skills/gesellschaftsgruender-firmenname-pruefung/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: gesellschaftsgruender-firmenname-pruefung
+description: "Pruefung des Firmennamens vor Notar-Termin. Handelsregister-Suche Paragraf 30 HGB Verwechslungsgefahr. IHK-Firmenvorpruefung. Marken-Suche DPMA EUIPO. Domain-Verfuegbarkeit. Bei Beanstandung Alternative-Vorschlaege. Irrefuehrungsverbot Paragraf 18 II HGB. Kennzeichnungs-Kraft Paragraf 18 I HGB."
+---
+
+# Firmenname-Pruefung
+
+## Zweck
+
+Vor Notar-Termin muss der Firmenname **vollstaendig** auf Verfuegbarkeit, Verwechslungsfaehigkeit, Marken-Konflikte und Domain geprueft werden. Spaeter laesst sich der Name nur mit Notar-Beurkundung und Handelsregister-Aenderung wechseln — teuer und unangenehm.
+
+## 1) Pruefungs-Schritte
+
+### A. Handelsregister-Suche
+
+- **Common Register Search**: gemeinsam.handelsregister.de
+- Suche nach identischem Namen am Sitz / Nachbar-Bezirken
+- **Paragraf 30 HGB**: Verwechslungsgefahr vermeiden
+- Verwechslungsgefahr besteht bei ahnlichem Klang, Bedeutung, Schreibweise
+
+### B. IHK-Firmenvorpruefung
+
+- **Kostenlos** oder geringe Gebuehr
+- IHK prueft die Firma auf Zulaessigkeit (Paragraf 18 HGB) und Verwechslungsgefahr (Paragraf 30 HGB)
+- Bestaetigung als Beweis fuer Notar
+- Empfehlung: **immer** machen
+
+### C. Marken-Suche
+
+- **DPMA-Recherche** (registrierte deutsche Marken): www.dpma.de
+- **EUIPO** (EU-Marken): www.euipo.europa.eu
+- **TMview** (international): www.tmdn.org
+- Pruefen auf Verwechslung mit eingetragenen Marken in der eigenen Branche
+
+### D. Domain-Verfuegbarkeit
+
+- .de (DENIC), .com, .eu, branchenrelevante TLD
+- Domain-Reseller: Strato, 1&1, GoDaddy, etc.
+- Bei strategischer Bedeutung: Domain **vor** der Notar-Beurkundung sichern
+
+### E. Social-Media-Handles
+
+- Facebook, Instagram, LinkedIn, X (Twitter), TikTok
+- Bei Marketing-Bedeutung pruefen
+
+### F. Sprachen / Internationalisierung
+
+- Bei internationaler Aktivitaet: Bedeutung in anderen Sprachen
+- Kuriose Bedeutungen in Zielmaerkten
+- Schwer aussprechbare Namen vermeiden
+
+## 2) Anforderungen an die Firma Paragraf 17 ff. HGB
+
+### Kennzeichnungs-Kraft Paragraf 18 I HGB
+
+- Firma muss zur **Kennzeichnung** des Kaufmanns geeignet sein
+- Unterscheidungs-Funktion gegenueber anderen
+- Beispiele:
+  - ✅ „Mueller Maschinenbau GmbH" — kennzeichnungsfaehig
+  - ❌ „Deutsche Firma GmbH" — zu allgemein
+
+### Irrefuehrungsverbot Paragraf 18 II HGB
+
+- Keine **irrefuehrenden Angaben** in der Firma
+- Beispiele:
+  - ❌ „Bundesweite Versorgung GmbH" — wenn nur regional taetig
+  - ❌ „Bank-Beratung GmbH" — wenn keine Bank-Lizenz
+  - ❌ „International Holding GmbH" — wenn keine internationale Holding-Struktur
+
+### Rechtsform-Zusatz
+
+- **Pflicht**: GmbH, UG (haftungsbeschraenkt), AG, OHG, KG, ...
+- **Nicht** abkuerzungsfaehig (z.B. „GmbH" muss ausgeschrieben oder durch Standard-Abkuerzung)
+
+### Verwechslungs-Gefahr Paragraf 30 HGB
+
+- Im gleichen oertlichen Bereich (= Bezirk des Registergerichts) keine Verwechslung mit eingetragenen Firmen
+- Bei Verwechslungsgefahr: Beanstandung durch HR-Gericht
+
+## 3) Typische Beanstandungs-Gruende
+
+1. **Zu allgemein** („Deutsche Firma GmbH")
+2. **Verwechslungsfaehig** mit anderer eingetragener Firma in Bezirk
+3. **Irrefuehrend** in Branchenbezeichnung
+4. **Geschuetzt** als Marke eines Dritten (Beanstandung indirekt: Klage des Markeninhabers)
+5. **Geschuetzte Berufsbezeichnung** ohne Zulassung (z.B. „Steuerberatungs-GmbH" ohne StBerG-Zulassung)
+6. **Personennamen** ohne Berechtigung (Paragraf 12 BGB)
+7. **Geografische Bezeichnungen** ohne Bezug (z.B. „Berlin AG" als rein bayerisches Unternehmen — moeglich, aber im Marketing problematisch)
+
+## 4) Beispiele
+
+### Empfohlen
+
+- „[Personenname] [Branche] GmbH" — z.B. „Mueller Maschinenbau GmbH"
+- „[Fantasiename] [Branche] GmbH" — z.B. „Solis Vision GmbH"
+- „[Branche] [Region] GmbH" — z.B. „Hanseatische Vermoegensverwaltung GmbH"
+
+### Riskant
+
+- „[Sehr generischer Begriff] GmbH" — z.B. „Erfolg GmbH"
+- „[Geschuetzter Begriff] GmbH" — z.B. „Stiftung Warentest GmbH"
+
+## 5) Alternative-Strategie
+
+### Plan A: Wunsch-Firma
+
+### Plan B: Wenn A beanstandet wird
+
+- Erweiterung um Branche: „Mueller GmbH" -> „Mueller IT-Beratung GmbH"
+- Erweiterung um Region: „Mueller GmbH" -> „Mueller GmbH Berlin"
+- Erweiterung um Personenname: „Mueller GmbH" -> „Mueller & Schmidt GmbH"
+
+### Plan C: Komplett anders
+
+- Bei wiederholten Beanstandungen: kompletter Wechsel
+
+### Praxis-Tipp
+
+- **3-5 Alternativen** vor Notar-Termin bereithalten
+- IHK kann mehrere parallel pruefen
+
+## 6) Marken-Strategie
+
+### Bei strategischer Marken-Bedeutung
+
+- **Firmenname und Marke kollidieren-frei**: Anmeldung der Marke parallel zur Gesellschaftsgruendung
+- DPMA-Anmeldung: ca. 290 EUR pro Klasse
+- EUIPO-Anmeldung: ca. 850 EUR pro Klasse
+- Pruefung 6-12 Monate
+
+### Bei spaeterer Marken-Anmeldung
+
+- Risiko: Dritter kann Marke fuer den eigenen Firmennamen anmelden
+- Bei Verlust: Firmen-Umfirmierung erforderlich
+
+### Anmeldung Marken-Inhaber als Gesellschaft
+
+- Bei Marken-Anmeldung als „[Firma] GmbH i.G.": geht oft, aber Inhaber ist erst nach Eintragung definitiv
+- Sicher: Anmeldung im Namen eines Gruenders, spaetere Uebertragung auf die GmbH
+
+## 7) Workflow
+
+### Tag T-14 (vor Notar)
+
+1. **Vorschlaege sammeln**: 3-5 Wunsch-Namen
+2. **HR-Suche** in Common Register
+3. **DPMA-Recherche** bei strategischer Bedeutung
+4. **Domain-Pruefung**
+5. **Vorpruefung IHK** beantragt
+
+### Tag T-7
+
+6. **IHK-Bescheinigung** liegt vor
+7. **Domain** gesichert
+8. **Marken-Anmeldung** ggf. eingereicht
+
+### Tag T (Notar)
+
+9. **Beurkundung** mit gewaehltem Namen
+
+### Tag T+5 bis T+14
+
+10. **HR-Eintragung** (Pruefung HR-Gericht)
+11. **Bei Beanstandung**: alternative Firma -> Satzungsaenderung -> erneute Beurkundung
+
+## 8) Pruef-Checkliste
+
+```
+| Pruefung | Stelle | Ergebnis |
+|---|---|---|
+| HR-Suche bundesweit | gemeinsam.handelsregister.de | [ ] OK / [ ] Konflikt |
+| IHK-Firmenvorpruefung | oertliche IHK | [ ] Bescheinigung erhalten |
+| DPMA-Marken | dpma.de | [ ] OK / [ ] Konflikt |
+| EUIPO-Marken | euipo.europa.eu | [ ] OK / [ ] Konflikt |
+| Domain .de | DENIC | [ ] verfuegbar |
+| Domain .com | Reseller | [ ] verfuegbar |
+| Social-Media Handles | je Plattform | [ ] verfuegbar |
+| Bedeutung in Zielsprachen | manuell | [ ] OK |
+| Rechtsform-Zusatz | Selbst | [ ] vorhanden |
+| Kennzeichnungs-Kraft | Selbst | [ ] OK |
+| Keine Irrefuehrung | Selbst | [ ] OK |
+```
+
+## 9) Typische Fehler
+
+1. **Nur IHK-Vorpruefung, keine HR-Suche**. IHK prueft regional, HR-Suche zeigt bundesweite Verwechslungen.
+2. **Marken-Suche ueberhaupt nicht**. Spaetere Marken-Klage moeglich.
+3. **Domain nicht gesichert**. Nach Gruendung steht Domain nicht zur Verfuegung.
+4. **Branchen-Bezeichnung ohne Zulassung**. Z.B. „[Name] Bank GmbH" ohne BaFin-Lizenz -> Untersagung.
+5. **Personennamen ohne Berechtigung**. Z.B. „Einstein Energie GmbH" — Erben pruefen lassen.
+6. **Geografische Falsch-Bezeichnung**. „Hamburger Holding GmbH" mit Sitz Muenchen -> Beanstandung moeglich.
+
+## 10) Kosten
+
+| Pruefung | Kosten |
+|---|---|
+| IHK-Vorpruefung | 0-100 EUR |
+| HR-Suche | 0 EUR online |
+| DPMA-Recherche | 0 EUR online (Stichprobe), prof. Recherche 200-1.000 EUR |
+| EUIPO-Recherche | analog |
+| Domain | 5-20 EUR pro Jahr |
+| Marken-Anmeldung DPMA | ab 290 EUR |
+| Marken-Anmeldung EUIPO | ab 850 EUR |
+
+## Anschluss
+
+- `gesellschaftsgruender-gmbh-vorbereitung` — Firma als Baustein
+- `gesellschaftsgruender-notar-vorbereitung` — IHK-Bescheinigung vorlegen
+- `gesellschaftsgruender-handelsregister-anmeldung` — Pruefung durch HR-Gericht

--- a/gesellschaftsgruender/skills/gesellschaftsgruender-genehmigtes-kapital/SKILL.md
+++ b/gesellschaftsgruender/skills/gesellschaftsgruender-genehmigtes-kapital/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: gesellschaftsgruender-genehmigtes-kapital
+description: "Genehmigtes Kapital Paragraf 55a GmbHG. Vorratsbeschluss der Gesellschafter Hoechstbetrag 50 Prozent des bisherigen Stammkapitals Geltungsdauer 5 Jahre. Erleichterung von Kapitalerhoehungen ohne weitere GV-Beschluesse. Satzungs-Klausel Beispiel. Wandel von Wandeldarlehen. Bezugsrechtsausschluss-Pruefung."
+---
+
+# Genehmigtes Kapital (Paragraf 55a GmbHG)
+
+## Zweck
+
+Das **genehmigte Kapital** ist ein Vorratsbeschluss der Gesellschafterversammlung, der die Geschaeftsfuehrung ermaechtigt, das Stammkapital bis zu einem bestimmten Hoechstbetrag ohne weiteren GV-Beschluss zu erhoehen. Erleichtert spaetere Finanzierungsrunden, Mitarbeiter-Beteiligungen oder die Wandlung von Wandeldarlehen.
+
+## 1) Rechtsgrundlagen
+
+- **Paragraf 55a GmbHG**: genehmigtes Kapital
+- **Paragrafen 55 ff. GmbHG**: ordentliche Kapitalerhoehung (zum Vergleich)
+
+## 2) Voraussetzungen
+
+### Vorratsbeschluss
+
+- **Satzungsaenderung** mit 75 %-Mehrheit (Paragraf 53 II GmbHG)
+- **Notarielle Beurkundung**
+
+### Inhalt
+
+- **Hoechstbetrag** der Erhoehung: max. **50 %** des bisherigen Stammkapitals (Paragraf 55a I 1 GmbHG)
+- **Geltungsdauer**: max. **5 Jahre** ab Eintragung der Satzungsaenderung
+- **Klassen-Festlegung**: welche Klasse(n) bei Erhoehung ausgegeben werden
+- **Bedingungen**: an wen, zu welchem Preis, mit welchen Rechten
+
+## 3) Beispiel-Satzungs-Klausel
+
+```
+§ X Genehmigtes Kapital
+
+(1) Die Geschaeftsfuehrer sind ermaechtigt, das
+Stammkapital der Gesellschaft bis zum [Datum, Frist
+5 Jahre ab Eintragung] um insgesamt bis zu
+12.500 EUR durch Ausgabe neuer Geschaeftsanteile gegen
+Einzahlung in Bareinlage oder Sacheinlage zu erhoehen
+(genehmigtes Kapital).
+
+(2) Die neuen Geschaeftsanteile koennen als
+Stammanteile (Class Common) oder als Vorzugsanteile
+(Class A oder Class B) ausgegeben werden.
+
+(3) Die Geschaeftsfuehrer sind ermaechtigt, das
+Bezugsrecht der Gesellschafter mit Zustimmung der
+Gesellschafterversammlung mit einer Mehrheit von
+75 % ganz oder teilweise auszuschliessen.
+
+(4) Die naeheren Bedingungen der jeweiligen Aus-
+gabe (insbesondere Ausgabe-Preis, Bezugsrecht,
+Klasse, Stimmrechte) werden durch die Gesellschafter-
+versammlung mit einfacher Mehrheit beschlossen.
+
+(5) Diese Ermaechtigung gilt bis zum [Datum].
+```
+
+## 4) Anwendungs-Konstellationen
+
+### Wandel von Wandeldarlehen
+
+- Investor gibt Wandeldarlehen vor Series A
+- Bei Series A wandelt sich Darlehen in Anteile
+- Wandlung erfolgt durch Beschluss der Geschaeftsfuehrung aus dem genehmigten Kapital — **ohne** weiteren GV-Beschluss
+
+### Mitarbeiter-Beteiligung (ESOP / VSOP)
+
+- Mitarbeiter erhalten Anteilsoptionen
+- Bei Ausuebung: Erhoehung aus genehmigtem Kapital
+- Vermeidet wiederholte GV-Beschluesse
+
+### Series-A-Investor
+
+- Investor verlangt schnelle Eintragung
+- Mit genehmigtem Kapital: Notar-Termin, Beschluss aus genehmigtem Kapital, Eintragung HR
+- Ohne genehmigtes Kapital: zusaetzliche GV-Einberufung mit 1-2 Wochen Vorlauf
+
+## 5) Beschluss-Verfahren bei Ausuebung
+
+### Schritt 1: GF-Beschluss
+
+- Geschaeftsfuehrung beschliesst Kapitalerhoehung aus dem genehmigten Kapital
+- Beschluss mit allen Bedingungen (Klasse, Preis, Bezugsrecht)
+
+### Schritt 2: Notar-Beurkundung
+
+- Beurkundung der Erhoehung
+- **Bei Bezugsrechtsausschluss**: zusaetzlich GV-Beschluss mit 75 %-Mehrheit erforderlich (Paragraf 55a IV GmbHG)
+
+### Schritt 3: Einzahlung
+
+- Wie bei normaler KE: Bareinlage muss vor Anmeldung erbracht sein
+- Bei Sacheinlage: Sachgruendungsbericht aequivalent (Paragraf 56 GmbHG)
+
+### Schritt 4: Anmeldung HR
+
+- Mit Bestaetigung der Einzahlung
+- Aktualisierte Gesellschafterliste
+
+## 6) Bezugsrechtsausschluss
+
+### Konzept
+
+- Beim Ausgleichen von Anteilen erhalten bestehende Gesellschafter Bezugsrecht (Paragraf 55 II GmbHG)
+- Ausschluss moeglich, aber begruendungsbeduerftig
+
+### Begruendung
+
+- Sachlich gerechtfertigt: z.B. Strategischer Investor, der nur ohne Bezugsrechte einsteigt
+- Verhaeltnismaessig: nicht ueber das hinausgehend, was Zweck erfordert
+- Angemessen: keine Verwaesserung zum Schaden Minderheits-Gesellschafter ohne sachlichen Grund
+
+### Anfechtbarkeit
+
+- Bei unbegruendetem Bezugsrechtsausschluss
+- Anfechtungsklage gegen den Beschluss
+
+→ `gesellschaftsgruender-kapitalerhoehung-bezugsrecht`
+
+## 7) Bedeutung im Investor-Verhandlungs-Kontext
+
+### Pro genehmigtes Kapital
+
+- **Schnelle Umsetzung** von Finanzierungsrunden
+- **Wandeldarlehen-tauglich** ohne wiederkehrende GV-Einberufung
+- **Wertvoll im Investor-Reporting** — zeigt Vorbereitung
+
+### Contra genehmigtes Kapital
+
+- Reduziert Investor-Verhandlungs-Kontrolle bei kuenftigen Erhoehungen
+- Bei aggressiv gewaehltem Hoechstbetrag: Verwaesserungsangst der bestehenden Gesellschafter
+
+### Empfehlung
+
+- **Bei Tech-Startup mit absehbarer Series A**: genehmigtes Kapital von Anfang an
+- **Bei Solo-Gruender ohne Investor**: nicht zwingend, kann spaeter beschlossen werden
+- **Hoechstbetrag**: typisch 40-50 % des Stammkapitals
+
+## 8) Erlöschen / Verlaengerung
+
+### Automatisches Erloeschen
+
+- Nach 5 Jahren ab Eintragung (Paragraf 55a I 1 GmbHG)
+- Nach Vollausschoepfung des Hoechstbetrags
+
+### Verlaengerung
+
+- Durch neuen Vorratsbeschluss
+- 75 %-Mehrheit, Notar-Beurkundung
+- Bei kontinuierlicher Verwendung sinnvoll
+
+## 9) Typische Stolpersteine
+
+1. **Hoechstbetrag zu niedrig**: bei Anwendung schon ausgeschoepft, neuer Beschluss erforderlich.
+2. **Bezugsrechtsausschluss ohne 75 %-Beschluss**: Erhoehung anfechtbar.
+3. **Bezugsrechtsausschluss ohne sachliche Rechtfertigung**: anfechtbar.
+4. **Geltungsdauer abgelaufen**: ohne Verlaengerung keine Anwendung.
+5. **Falsche Klassen-Ausgabe**: Beschluss-Vorlage muss klar bezeichnen, welche Klasse ausgegeben wird.
+
+## 10) Konsequenzen fuer Cap Table
+
+Bei Vorratsbeschluss zeigt der Cap Table:
+
+```
+Stammkapital aktuell:        25.000 EUR (25.000 Anteile)
+Genehmigtes Kapital:         12.500 EUR (Hoechstbetrag)
+Stammkapital max. moeglich:  37.500 EUR
+
+Pro forma Verwaesserung
+(bei voller Ausschöpfung):    33 % der Gruender
+```
+
+## Anschluss
+
+- `gesellschaftsgruender-cap-table` — Auswirkung im Cap Table
+- `gesellschaftsgruender-kapitalerhoehung-bezugsrecht` — bei konkreter Erhoehung
+- `gesellschaftsgruender-share-classes-a-b-c` — Klassen-Festlegung
+- `gesellschaftsgruender-gesellschaftsvertrag-gmbh` — Klausel in Satzung

--- a/gesellschaftsgruender/skills/gesellschaftsgruender-geschaeftsordnung-gf/SKILL.md
+++ b/gesellschaftsgruender/skills/gesellschaftsgruender-geschaeftsordnung-gf/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: gesellschaftsgruender-geschaeftsordnung-gf
+description: "Geschaeftsordnung der Geschaeftsfuehrung. Zustimmungspflichtige Geschaefte Berichtspflichten Meeting-Rhythmus Entscheidungs-Prozesse Eskalations-Matrix bei Mehrgliedrigkeit. Abgrenzung Satzung SHA Geschaeftsordnung. Aenderbarkeit Form. Beispiel-Kataloge fuer Standard-GmbH und Tech-Startup."
+---
+
+# Geschaeftsordnung Geschaeftsfuehrung
+
+## Zweck
+
+Die **Geschaeftsordnung fuer die Geschaeftsfuehrung** regelt die innerorganisatorischen Ablaeufe bei mehrgliedrigen Geschaeftsfuehrungen. Sie ist **kein** Pflicht-Dokument (anders als bei AG Paragraf 77 AktG), aber bei Mehr-GF-Konstellationen sehr empfehlenswert.
+
+## 1) Rechtsgrundlagen
+
+- **Paragraf 37 I GmbHG**: Geschaeftsfuehrer haben die Gesellschaft nach Gesetz, Satzung und Beschluessen der Gesellschafterversammlung zu fuehren
+- **Paragraf 37 II GmbHG**: bei Mehrgliedrigkeit Gesamtgeschaeftsfuehrung, sofern Satzung / Geschaeftsordnung nicht anders bestimmt
+- Geschaeftsordnung ist **freiwillig** — wird typisch von Gesellschafterversammlung beschlossen
+
+## 2) Wann sinnvoll
+
+- **Mehrere Geschaeftsfuehrer**: Ressort-Trennung, Entscheidungs-Prozesse
+- **Investor-Beteiligung**: Berichtspflichten an Investor-Beirat
+- **Komplexe Geschaeftsmodelle**: Zustimmungs-Kataloge je nach Geschaeftsart
+- **Compliance-bewusste Unternehmen**: schriftliche Prozess-Dokumentation
+
+## 3) Pflicht-Inhalte einer guten Geschaeftsordnung
+
+### A. Ressort-Verteilung
+
+```
+Ressort-Verteilung:
+- Geschaeftsfuehrer A (CEO): Strategie, Vertrieb, M&A
+- Geschaeftsfuehrer B (CTO): Technik, IT, Datenschutz
+- Geschaeftsfuehrer C (CFO): Finanzen, Buchhaltung, Reporting, Personal
+```
+
+### B. Zustimmungspflichtige Geschaefte
+
+Geschaefte, die Zustimmung **aller** GF oder der Gesellschafterversammlung erfordern:
+
+```
+Zustimmungspflicht der gesamten Geschaeftsfuehrung
+(einstimmig) bei:
+- Investitionen ueber 50.000 EUR
+- Anstellung von Mitarbeitern mit Jahresgehalt > 100.000 EUR
+- Vertraegen mit Laufzeit > 3 Jahre
+- Aufnahme von Krediten > 100.000 EUR
+- Aufnahme von Geschaeftsbeziehungen mit verbundenen Unternehmen
+
+Zustimmungspflicht der Gesellschafterversammlung
+(einfache Mehrheit) bei:
+- Investitionen ueber 250.000 EUR
+- Verkauf wesentlicher Aktiva (> 20 % der Bilanzsumme)
+- Aufnahme von Krediten > 500.000 EUR
+- Beteiligungen an anderen Gesellschaften
+- Veraeusserung wesentlicher Patente / Lizenzen
+
+Zustimmungspflicht der Gesellschafterversammlung
+(75 % Mehrheit) bei:
+- Satzungsaenderung
+- Stellung Antrag StaRUG-Restrukturierungsverfahren
+- Stellung Insolvenzantrag (Paragraf 15a InsO bleibt
+  unberuehrt — die Antragspflicht der GF entfaellt nicht)
+- Wesentliche Aenderung des Geschaeftsmodells
+```
+
+### C. Meeting-Rhythmus
+
+```
+Geschaeftsfuehrer-Meetings:
+- Woechentlich (vorbereitete Tagesordnung)
+- Quartalsweise mit Beirat / Investor
+- Halbjaehrlich Strategie-Meeting
+- Jaehrlich vor Bilanz-Aufstellung
+
+Gesellschafterversammlungen:
+- Mindestens 1x jaehrlich (Pflichtversammlung
+  Paragraf 42a GmbHG fuer Jahresabschluss)
+- Bei Bedarf ausserordentliche Versammlung
+```
+
+→ `gesellschaftsgruender-gf-meeting-templates`
+
+### D. Berichtspflichten
+
+```
+Quartalsweise Reporting an Gesellschafterversammlung:
+- Umsatz und Auftragsbestand
+- Liquiditaet (3-Monats-Vorschau)
+- Personalstaerke und Veraenderungen
+- Wesentliche Risiken
+- Compliance-Stand (DSGVO, GwG, Steuer)
+
+Monatsweise Reporting an Investor (bei
+SHA-Verpflichtung):
+- Cash Burn / Runway
+- KPI nach Vereinbarung
+```
+
+### E. Entscheidungs-Prozesse
+
+- Bei Patt-Situation (z.B. 2 GF, beide unterschiedlicher Meinung): Eskalation zur Gesellschafterversammlung
+- Bei Eilbeduerftigkeit: Einzelvertretung mit nachtraeglicher Genehmigung
+
+### F. Eskalations-Matrix
+
+```
+Konflikt-Eskalation:
+1. Bilateral GF-GF
+2. Gesamte Geschaeftsfuehrung
+3. Beirat (falls vorhanden)
+4. Gesellschafterversammlung
+5. Schlichtung / Mediation
+6. Schiedsgericht / ordentliche Gerichte
+```
+
+## 4) Form und Erlass
+
+### Erlass durch Gesellschafterversammlung
+
+- Gesellschafterversammlung kann Geschaeftsordnung beschliessen (Paragraf 46 Nr. 6 GmbHG)
+- Einfache Mehrheit ausreichend
+- Beschluss-Protokoll dokumentiert die Geschaeftsordnung
+
+### Erlass durch Geschaeftsfuehrung (selbstauferlegt)
+
+- Bei Solo-GF oft selbstauferlegt
+- Bei Mehr-GF: Einigung der GF
+- Wirkung: bindet die GF selbst, nicht aber die Gesellschafterversammlung
+
+### Aenderung
+
+- Wenn von Gesellschafterversammlung erlassen: Aenderung nur durch GV (einfache Mehrheit)
+- Wenn von GF selbst: aenderbar mit Mehrheit der GF
+
+### Form
+
+- **Schriftform empfohlen** (Beweisbarkeit)
+- Nicht zwingend notariell
+
+## 5) Beispiel-Schablone — Tech-Startup mit 3 GF
+
+```
+GESCHAEFTSORDNUNG fuer die Geschaeftsfuehrung
+der [Name] GmbH
+
+§ 1 Geltungsbereich
+Diese Geschaeftsordnung regelt die innerorganisatorische
+Zusammenarbeit der Geschaeftsfuehrer der Gesellschaft.
+
+§ 2 Ressort-Verteilung
+(1) Anna Mueller (CEO): Strategie, M&A, Vertrieb
+(2) Bernd Schmidt (CTO): Technik, IT, Produktentwicklung
+(3) Carla Wagner (CFO): Finanzen, Buchhaltung, Personal
+
+§ 3 Vertretung
+Die Gesellschaft wird gemaess Satzung durch zwei
+Geschaeftsfuehrer gemeinschaftlich vertreten. Die
+Aufteilung der Ressorts beruehrt die externe
+Vertretungsmacht nicht.
+
+§ 4 Beschluesse der Geschaeftsfuehrung
+(1) Wesentliche Entscheidungen bedurfen der
+Zustimmung aller Geschaeftsfuehrer:
+[Liste — siehe oben]
+
+(2) Bei Patt: Eskalation an Gesellschafterversammlung
+binnen 14 Tagen.
+
+§ 5 Meetings
+(1) Reguläres Geschaeftsfuehrer-Meeting woechentlich,
+Dienstag 9 Uhr.
+(2) Tagesordnung wird spaetestens Montag 12 Uhr
+verteilt.
+(3) Protokoll wird durch rotierende Schriftfuehrung
+gefuehrt, binnen 48 Stunden verteilt.
+
+§ 6 Berichtspflichten
+(1) Quartalsbericht an Gesellschafterversammlung
+binnen 4 Wochen nach Quartalsende.
+(2) Monatsbericht an Investor I AG (Series A) gemaess
+Shareholder Agreement.
+
+§ 7 Konflikt-Loesung
+[Eskalations-Matrix]
+
+§ 8 Schlussbestimmungen
+(1) AEnderungen dieser Geschaeftsordnung erfolgen
+durch Beschluss der Gesellschafterversammlung mit
+einfacher Mehrheit.
+(2) Diese Geschaeftsordnung tritt mit Beschluss
+der Gesellschafterversammlung am [Datum] in Kraft.
+```
+
+## 6) Abgrenzung Satzung — SHA — Geschaeftsordnung
+
+| Aspekt | Satzung | SHA | Geschaeftsordnung |
+|---|---|---|---|
+| Vertretung extern | + | - | (Bezug) |
+| Vesting | - | + | - |
+| Zustimmungs-Kataloge | (typisch ja) | (typisch nein) | (typisch ja, ergaenzend) |
+| Meeting-Rhythmus | (selten) | (manchmal) | + (Standard) |
+| Berichtspflichten | (selten) | (typisch ja fuer Investor) | + |
+| Aenderbarkeit | 75 % Mehrheit + Notar | einstimmig | einfache Mehrheit |
+| Form | notariell | schriftlich | schriftlich |
+
+## 7) Typische Fehler
+
+1. **Geschaeftsordnung ohne Zustimmungs-Katalog**. „GF handelt im Rahmen der Gesetze" reicht nicht — bei strittigen Geschaeften keine Orientierung.
+2. **Zustimmungs-Schwellen zu hoch**. Wenn Schwelle 1 Mio. EUR, aber Jahresumsatz 500 K — Schwelle praktisch wirkungslos.
+3. **Patt-Mechanismus fehlt**. Bei 2-GF-Konstellation ohne Eskalation: GmbH handlungsunfaehig.
+4. **Keine Berichts-Pflichten**. Investoren / Beirat haben kein Steuerungs-Hebel ohne Reports.
+5. **Geschaeftsordnung wird vergessen**. Erlassen, aber nie angepasst, nie gelebt -> praktisch tot.
+
+## Anschluss
+
+- `gesellschaftsgruender-gf-meeting-templates` — Tagesordnungen, Protokoll-Vorlagen
+- `gesellschaftsgruender-geschaeftsfuehrervertrag` — Geschaeftsfuehrer-Anstellung
+- `gesellschaftsgruender-gv-einladung-tagesordnung` — Gesellschafterversammlung

--- a/gesellschaftsgruender/skills/gesellschaftsgruender-gesellschafterstreit-eilantraege/SKILL.md
+++ b/gesellschaftsgruender/skills/gesellschaftsgruender-gesellschafterstreit-eilantraege/SKILL.md
@@ -1,0 +1,307 @@
+---
+name: gesellschaftsgruender-gesellschafterstreit-eilantraege
+description: "Gesellschafterstreit Eilantrag einstweilige Verfuegung Landgericht Anmeldungs-Sperre Registergericht Paragraf 16 HGB. Streitige Gesellschafterversammlung Versammlungsleiter Konflikt. Anfechtungsklage Paragraf 246 AktG analog. FamFG Verfahren. Verfuegungsantrag Glaubhaftmachung Eilbeduerftigkeit. Tenor-Vorschlaege."
+---
+
+# Gesellschafterstreit — Eilantraege
+
+## Zweck
+
+Bei Streit der Gesellschafter kommt es typischerweise zu **Eilbeduerftigkeit**: ein streitiger Beschluss soll nicht ins Handelsregister, eine Versammlung soll oder soll nicht stattfinden. Dieser Skill behandelt das Werkzeug-Set: einstweilige Verfuegung beim LG, Anmeldungs-Sperre beim Registergericht, Anfechtungsklage.
+
+## 1) Typische Streit-Konstellationen
+
+1. **Bezugsrechtsausschluss-Streit**: Minderheit klagt gegen Kapitalerhoehung mit Bezugsrechtsausschluss
+2. **Geschaeftsfuehrer-Abberufungs-Streit**: Mehrheit will abberufen, Minderheit oder GF wehrt sich
+3. **Versammlungsleiter-Streit**: bei streitiger GV — wer leitet?
+4. **Verwaesserungs-Streit**: KE soll bestimmte Anteile entwerten
+5. **Konkurrenz-Streit**: Gesellschafter macht konkurrierende Geschaefte
+6. **Restrukturierungs-Streit**: GF plant StaRUG-Antrag gegen Golden-Share-Veto
+
+## 2) Werkzeug-Set des Eilrechtsschutzes
+
+### A. Einstweilige Verfuegung beim Landgericht (Paragrafen 935 ff. ZPO)
+
+- Sitz der Gesellschaft (Paragraf 17 ZPO)
+- Glaubhaftmachung von **Verfuegungsanspruch** und **Verfuegungsgrund** (Eilbeduerftigkeit)
+- Verfahren: meist binnen 1-2 Wochen, ohne muendliche Verhandlung moeglich
+
+#### Antragsarten
+
+- **Verbot der Beschluss-Ausfuehrung**
+- **Stimmverbot** fuer bestimmte Beschluesse
+- **Anweisung an GF**, bestimmte Handlungen zu unterlassen
+- **Einsetzung eines Notgeschaeftsfuehrers** (selten)
+
+### B. Anmeldungs-Sperre beim Registergericht (Paragraf 16 II HGB analog)
+
+- Antrag direkt beim Registergericht (HRB-Gericht der Gesellschaft)
+- **FamFG-Verfahren** (Paragrafen 374 ff. FamFG fuer Registersachen)
+- Antrag: Sperrung der Eintragung des streitigen Beschlusses
+
+#### Voraussetzung
+
+- Glaubhaftmachung der Anfechtbarkeit / Nichtigkeit des Beschlusses
+- Eilbeduerftigkeit (Eintragung waere unwiderruflich)
+
+### C. Anfechtungsklage (Paragrafen 246, 248 AktG analog)
+
+- Klage in Hauptsache gegen die Gesellschaft
+- Frist: 1 Monat ab Beschlussfassung
+- Beim Landgericht (Gesellschaftssitz)
+
+## 3) Beispiel: Einstweilige Verfuegung gegen Kapitalerhoehung
+
+### Sachverhalt
+
+- GV-Beschluss vom 15.06.2026: KE um 10.000 EUR mit Bezugsrechtsausschluss zugunsten Investor I AG
+- Minderheits-Gesellschafter B (40 %) lehnte ab; Beschluss mit 60 % Mehrheit gefasst (= 75 %-Schwelle wegen Klassenstimmen erreicht)
+- Wert der Anteile B sinkt von 4 Mio. auf 2,8 Mio. EUR
+
+### Antrag
+
+```
+Landgericht [Ort]
+Az. [...]
+
+Verfuegungsklaeger:
+Gesellschafter B
+vertreten durch RAin Mueller
+
+Verfuegungsbeklagte:
+[Firma] GmbH
+vertreten durch GF Mueller und Schmidt
+
+Antrag auf einstweilige Verfuegung
+
+Es wird beantragt, der Verfuegungsbeklagten zu
+untersagen,
+
+die Anmeldung der mit Beschluss der Gesellschafter-
+versammlung vom 15.06.2026 (TOP 2) beschlossenen
+Kapitalerhoehung um 10.000 EUR mit Bezugsrechtsaus-
+schluss zugunsten der Investor I AG beim Handels-
+register einzureichen,
+
+bis zur rechtskraeftigen Entscheidung des in der
+Hauptsache anhaengigen Anfechtungsverfahrens.
+
+Verfuegungsanspruch:
+1. Beschluss wurde unter Verstoss gegen die sachliche
+   Rechtfertigung des Bezugsrechtsausschlusses gefasst.
+2. Die behaupteten strategischen Beitraege der Investor
+   I AG sind nicht substantiiert.
+3. Verwaesserung der bestehenden Gesellschafter
+   betraegt 28 % und ist nicht verhaeltnismaessig.
+
+Verfuegungsgrund (Eilbeduerftigkeit):
+Mit Eintragung der Kapitalerhoehung im Handelsregister
+wird die Verwaesserung des Verfuegungsklaegers
+unwiderruflich. Im Verfahren der Hauptsache wuerde
+eine Rueckabwicklung nur unter Schwierigkeiten
+moeglich sein.
+
+Glaubhaftmachung:
+- Protokoll der GV (Anlage K1)
+- Sachstands-Bericht der Geschaeftsfuehrung
+  (Anlage K2)
+- Eigene eidesstattliche Versicherung (Anlage K3)
+```
+
+## 4) Anmeldungs-Sperre beim Registergericht
+
+### Konzept
+
+- Direkt beim Registergericht (Paragraf 16 II HGB)
+- FamFG-Verfahren (Paragrafen 374 ff. FamFG)
+- Schneller als LG, aber an Voraussetzungen geknuepft
+
+### Antrag
+
+```
+Amtsgericht [Sitz Gesellschaft] — Registergericht
+HRB [...]
+
+Antrag auf Anmeldungs-Sperre Paragraf 16 II HGB
+
+Antragsteller: Gesellschafter B
+Beteiligte: [Firma] GmbH
+
+Es wird beantragt:
+
+Das Registergericht moege anordnen, dass die
+beabsichtigte Eintragung der Kapitalerhoehung vom
+15.06.2026 (Anmeldung durch Notar [...] vom [Datum])
+bis zur rechtskraeftigen Entscheidung des in der
+Hauptsache anhaengigen Anfechtungsverfahrens
+nicht erfolgt.
+
+Begruendung:
+[wie LG-Antrag]
+```
+
+### Praxis
+
+- Registergericht entscheidet meist binnen Tagen
+- Bei begruendetem Antrag: Sperre, GF kann nicht eintragen
+- Bei Ablehnung: Anmeldung erfolgt
+
+## 5) Streitige Gesellschafterversammlung — Versammlungsleiter
+
+### Konstellation
+
+- Versammlung beginnt, kein Konsens ueber Versammlungsleiter
+- Verschiedene Vorschlaege, keine eindeutige Mehrheit
+- GF moechte als Versammlungsleiter fungieren, Minderheit will eigenen Kandidaten
+
+### Loesungs-Optionen
+
+#### Option 1: Wahl-Vorschlag durchsetzen
+
+- Mehrheits-Beschluss zur Wahl des Versammlungsleiters
+- Bei 51 %+ Mehrheit: durchsetzbar
+
+#### Option 2: Notar als neutralen Versammlungsleiter
+
+- Vorab bestellter Notar uebernimmt Leitungs-Funktion
+- Beurkundet Versammlungsverlauf
+
+#### Option 3: Vertagung
+
+- Ohne Versammlungsleiter keine wirksame Beschlussfassung
+- Versammlung wird vertagt, Klaerung im Anfechtungs-/Eilrechtsschutz
+
+#### Option 4: Mehrere Protokolle
+
+- Beide Seiten erstellen eigenes Protokoll
+- Streit verlagert sich in Anfechtungs-Verfahren
+
+→ `gesellschaftsgruender-gv-protokoll-und-versammlungsleiter`
+
+## 6) Anfechtungsklage
+
+### Frist
+
+- **Monatsfrist** ab Beschluss (BGH-Linie analog Paragraf 246 AktG)
+- Versaeumnis: Beschluss wird endgueltig wirksam (ausser bei Nichtigkeit Paragrafen 241, 249 AktG analog)
+
+### Antragsformulierung
+
+```
+LG [Ort]
+
+Klage gegen Beschluss der GV
+
+Klagantrag:
+
+Es wird festgestellt, dass der von der Gesellschafter-
+versammlung der Beklagten am 15.06.2026 unter TOP 2
+gefasste Beschluss zur Kapitalerhoehung um 10.000 EUR
+mit Bezugsrechtsausschluss zugunsten der Investor I AG
+nichtig ist, hilfsweise: dass der Beschluss aufgehoben
+wird (Anfechtung).
+
+Klagegrund: Verstoss gegen die sachliche Rechtfertigung
+des Bezugsrechtsausschlusses Paragraf 55 IV GmbHG analog
+Paragraf 186 III AktG (Kali+Salz-Linie).
+```
+
+### Anfechtbarkeit vs. Nichtigkeit
+
+| Mangel | Folge |
+|---|---|
+| Form- oder Verfahrensfehler | Anfechtbarkeit, Monatsfrist |
+| Schwere Verstoesse (z.B. Sittenwidrigkeit) | Nichtigkeit, keine Frist |
+| Nicht eingeladene Gesellschafter | Nichtigkeit (BGH) |
+| Sondervetorecht missachtet | Anfechtbarkeit |
+
+## 7) Streit-Vermeidung durch Prevention
+
+### Praeventive Klauseln in Satzung / SHA
+
+- **Schiedsklausel** (mit DIS-Schiedsordnung typisch)
+- **Mediations-Pflicht** vor Klage
+- **Vorab-Bestellung** eines neutralen Notars / Schlichters
+- **Pönalen** bei Stimmverstoss → `gesellschaftsgruender-sha-satzung-stimmverpflichtung`
+
+### Beirat als Streit-Loeser
+
+- Beirat kann bei Patt zwischen Gesellschaftern als Schlichter fungieren
+
+→ `gesellschaftsgruender-beirat-advisory-board`
+
+## 8) Konkrete Verfahrens-Schritte beim Konflikt
+
+### Tag 0: Beschluss-Fassung
+
+- Streitiger Beschluss wird gefasst
+- Protokoll wird erstellt (ggf. mehrere)
+
+### Tag 0-2: Sofort-Massnahmen
+
+- Anwalt einschalten
+- Beschluss pruefen (Form, Inhalt, Mehrheits-Berechnung)
+- Eilbeduerftigkeit pruefen (drohende Eintragung im HR?)
+
+### Tag 2-5: Eilantrag
+
+- Einstweilige Verfuegung beim LG **und/oder**
+- Anmeldungs-Sperre beim Registergericht
+- Glaubhaftmachung mit eidesstattlicher Versicherung
+
+### Tag 5-30: Reaktion
+
+- Gegen-Stellungnahme der Gesellschaft / Mehrheits-Gesellschafter
+- LG entscheidet ueber EV (meist binnen 2 Wochen)
+- Registergericht entscheidet schneller (binnen Tagen)
+
+### Tag 0-30: Anfechtungsklage
+
+- Klage muss binnen 1 Monat ab Beschluss erhoben werden
+- Hauptverfahren laeuft parallel zum Eilrechtsschutz
+
+### Hauptverfahren
+
+- LG entscheidet ueber Anfechtbarkeit (Dauer typisch 6-18 Monate)
+- Berufung OLG moeglich
+- Revisionszulassung selten
+
+## 9) Schiedsklausel-Alternative
+
+### Statt LG
+
+```
+Alle Streitigkeiten aus oder im Zusammenhang mit
+diesem Gesellschaftsvertrag und ihrem Bestand werden
+nach der Schiedsgerichtsordnung der Deutschen
+Institution fuer Schiedsgerichtsbarkeit (DIS) ohne
+Beschreiten des ordentlichen Rechtsweges endgueltig
+entschieden. Schiedsort ist [Stadt]. Schiedssprache
+ist Deutsch.
+```
+
+### Vorteile
+
+- Vertraulichkeit
+- Schnelleres Verfahren (typisch 6-12 Monate)
+- Fachkundige Schiedsrichter
+
+### Nachteile
+
+- Hoehere Kosten
+- Eilrechtsschutz schwieriger (DIS-Notschiedsverfahren moeglich, aber ungewohnter)
+
+## 10) Praktische Empfehlung
+
+- **Bei Anzeichen** des Konflikts sofort Anwalt einschalten
+- **Beschluss dokumentieren** mit allen Details (Anwesenheit, Stimmenverhalten)
+- **Eilrechtsschutz** parallel: LG **und** Registergericht
+- **Anfechtungsfrist** beachten (1 Monat ab Beschluss)
+- **Schiedsklausel** im Vorfeld als Praevention
+
+## Anschluss
+
+- `gesellschaftsgruender-gv-protokoll-und-versammlungsleiter` — Versammlungsleiter
+- `gesellschaftsgruender-kapitalerhoehung-bezugsrecht` — typischer Streit-Anlass
+- `gesellschaftsgruender-sha-satzung-stimmverpflichtung` — Stimmverpflichtungs-Streit
+- `gesellschaftsgruender-golden-share-und-vetorechte` — Vetorecht-Streit

--- a/gesellschaftsgruender/skills/gesellschaftsgruender-gf-meeting-templates/SKILL.md
+++ b/gesellschaftsgruender/skills/gesellschaftsgruender-gf-meeting-templates/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: gesellschaftsgruender-gf-meeting-templates
+description: "Templates Geschaeftsfuehrer-Meetings Tagesordnung Einladung Protokoll. Wochentlicher Rhythmus Standing Agenda. Quartalsreview mit Beirat. Strategie-Meeting halbjaehrlich. Bei Konflikt: dokumentierte Diskussion. Schriftliche Beschluss-Faehigkeit bei verhinderter Anwesenheit per Umlauf-Beschluss. Bilinguale Vorlagen Deutsch Englisch."
+---
+
+# GF-Meeting-Templates
+
+## Zweck
+
+Vorlagen fuer Tagesordnung, Einladung und Protokoll der Geschaeftsfuehrer-Meetings. Bei mehrgliedriger Geschaeftsfuehrung sind dokumentierte Meetings essentiell — sowohl zur Entscheidungs-Dokumentation als auch zur Haftungs-Praevention.
+
+## 1) Einladung — Standard-GF-Meeting
+
+```
+Subject: Einladung GF-Meeting [KW XX] [Datum]
+
+Liebe Geschaeftsfuehrer-Kollegen,
+
+hiermit lade ich euch zum naechsten GF-Meeting ein:
+
+Datum:     Dienstag, [Datum]
+Uhrzeit:   09:00 - 10:30 Uhr
+Ort:       Video-Conference [Link] / Konferenzraum [Ort]
+Teilnehmer: Anna Mueller (CEO), Bernd Schmidt (CTO),
+            Carla Wagner (CFO)
+
+TAGESORDNUNG:
+1. Begruessung und Beschlussfaehigkeit
+2. Genehmigung Protokoll vorheriges Meeting
+3. Status Q-Plan / KPIs
+4. [konkrete Punkte]
+5. Beschlussfassungen
+6. Sonstiges / Ausblick naechste Woche
+
+Unterlagen:
+- Status-Dashboard (Anhang)
+- Entwurf [konkrete Vorlagen]
+
+Bei Verhinderung bitte rechtzeitig Bescheid geben;
+ggf. Umlauf-Beschluss fuer eilbeduerftige Themen.
+
+Beste Gruesse
+[Name]
+```
+
+### Bilingual (DE/EN)
+
+```
+INVITATION MANAGEMENT MEETING [Date]
+
+Dear colleagues,
+
+I hereby invite you to the next management meeting.
+
+Date:        Tuesday, [Date]
+Time:        9:00 a.m. - 10:30 a.m. CET
+Location:    Video conference [Link]
+Participants: Anna Mueller (CEO), Bernd Schmidt (CTO),
+              Carla Wagner (CFO)
+
+AGENDA:
+1. Welcome and quorum check
+2. Approval of previous minutes
+3. Status Q-plan / KPIs
+4. [specific items]
+5. Resolutions
+6. Misc / Outlook
+
+The German version of this invitation shall prevail
+in case of inconsistencies. [Bei Inkonsistenzen geht
+die deutsche Fassung vor.]
+
+Best regards,
+[Name]
+```
+
+→ `gesellschaftsgruender-bilinguale-dokumente`
+
+## 2) Standing Agenda (wiederkehrend)
+
+```
+Standing-Agenda Punkte (woechentlich)
+- Status Pipeline / Umsatz
+- Personal-Entwicklung (Einstellungen, Abgaenge)
+- Liquiditaet (Cash Burn, Runway)
+- Risiken und Compliance
+- Naechste Meilensteine
+```
+
+## 3) Protokoll-Vorlage — Standard
+
+```
+PROTOKOLL GF-Meeting [KW XX] / [Datum]
+
+Beginn:    09:00 Uhr
+Ende:      10:30 Uhr
+Ort:       Video
+Teilnehmer:
+- Anna Mueller (CEO), anwesend
+- Bernd Schmidt (CTO), anwesend
+- Carla Wagner (CFO), anwesend
+Schriftfuehrung: Carla Wagner
+Beschlussfaehigkeit: festgestellt
+
+TOP 1 — Genehmigung Vorprotokoll
+Beschluss: einstimmig genehmigt
+
+TOP 2 — Status Q-Plan
+[Konkrete Status-Punkte]
+
+TOP 3 — Beschluss zur Einstellung eines IT-Sicherheits-
+Beauftragten
+Hintergrund: NIS-2-Umsetzung, DSGVO-Anforderung
+Diskussion: [knappe Zusammenfassung]
+Vorschlag: Stelle mit Jahresgehalt 90.000 EUR
+Beschluss: einstimmig zustimmend (Anna, Bernd, Carla)
+
+TOP 4 — [...]
+
+NAECHSTE SCHRITTE
+- Carla: Stellenanzeige, Frist 7 Tage
+- Bernd: Anforderungsprofil IT-Sicherheit
+- Anna: Information an Investor I AG
+
+Naechstes Meeting:
+Dienstag, [Datum], 09:00 Uhr
+
+Genehmigung dieses Protokolls:
+Carla Wagner       _______________
+Anna Mueller       _______________
+Bernd Schmidt      _______________
+```
+
+## 4) Umlauf-Beschluss bei Verhinderung
+
+### Voraussetzungen
+
+- **Einstimmigkeit** erforderlich (Paragraf 48 II GmbHG analog fuer GF-Beschluss)
+- Schriftform oder Textform (E-Mail genuegt)
+- Dokumentiert im naechsten Protokoll
+
+### Vorlage
+
+```
+Subject: Umlauf-Beschluss [Thema] - [Datum]
+
+Liebe Kollegen,
+
+aufgrund Eilbeduerftigkeit bitten wir um schriftliche
+Beschlussfassung im Umlauf-Verfahren.
+
+THEMA: [konkreter Beschluss]
+HINTERGRUND: [knappe Begruendung]
+VORSCHLAG: [konkreter Antrag]
+
+Antwort-Optionen:
+[ ] Zustimmung
+[ ] Ablehnung
+[ ] Diskussionsbedarf (dann Praesenz-Meeting noetig)
+
+Antwort-Frist: [Datum / Uhrzeit]
+
+Bei einstimmiger Zustimmung ist der Beschluss
+gefasst und wird im naechsten GF-Meeting protokolliert.
+
+Beste Gruesse
+[Name]
+```
+
+## 5) Quartalsreview mit Beirat / Investor
+
+```
+TAGESORDNUNG QUARTALSREVIEW Q[X] / [Jahr]
+
+Beginn:    14:00 Uhr
+Ende:      17:00 Uhr
+Ort:       Konferenzraum / Hybrid
+Teilnehmer:
+- Geschaeftsfuehrung (CEO, CTO, CFO)
+- Beirat: [Namen]
+- Investor I AG: [Vertreter]
+
+TAGESORDNUNG:
+1. Begruessung und Vorstellungsrunde
+2. Wirtschaftliche Lage (CFO, 30 Min.)
+   - Umsatz, EBITDA, Cash Burn, Runway
+   - Vergleich Plan / Ist
+3. Produkt und Technik (CTO, 30 Min.)
+4. Markt und Vertrieb (CEO, 30 Min.)
+5. Personal und Organisation (CFO, 15 Min.)
+6. Risiken und Compliance (CFO, 15 Min.)
+7. Strategie-Updates und Beirat-Empfehlungen (60 Min.)
+8. Beschlussfassungen (bei Bedarf)
+9. Naechste Schritte
+
+Materialien (Frist: 5 Tage vor Termin):
+- Quartalsbericht (P&L, Cash Flow, Bilanz-Auszug)
+- KPI-Dashboard
+- Plan-Ist-Vergleich
+- Risiko-Bericht
+```
+
+## 6) Strategie-Meeting (halbjaehrlich)
+
+Laenger angelegt (z.B. ganztaegig), oft mit externem Moderator. Themen:
+
+- Mission / Vision Review
+- Marktanalyse, Wettbewerber
+- Produkt-Roadmap
+- Personal-Planung
+- Finanzplanung 12-24 Monate
+- Risiko-Strategie
+- Exit-Strategie
+
+## 7) Bei Konflikt-Diskussion
+
+### Dokumentation der Differenzen
+
+- Wenn GF unterschiedlicher Auffassung: **beide Positionen** ins Protokoll
+- Stimmverhalten pro GF dokumentieren
+- Bei Patt: Eskalation an Gesellschafterversammlung
+
+### Beispiel
+
+```
+TOP 3 — Aufnahme Series B Verhandlungen mit
+[Investor X]
+
+Diskussion:
+- Anna Mueller (CEO): pro, da Wachstumsfinanzierung
+  benoetigt und Bewertung attraktiv
+- Bernd Schmidt (CTO): kontra, da Verwaesserung der
+  Gruender bedenklich und Investor-Pool zu klein
+- Carla Wagner (CFO): zustimmend zu Verhandlungen,
+  aber mit Forderung: Pre-Money mindestens 8 Mio. EUR
+
+Beschluss: Aufnahme der Verhandlungen mit klaren
+Vorgaben: Pre-Money 8 Mio. EUR, Anti-Dilution
+broad-based weighted average, Liquidation Preference
+1x non-participating. Status-Bericht in 4 Wochen.
+
+Stimmen: Anna pro, Bernd kontra, Carla mit Vorgaben
+Mehrheit: 2:1 zustimmend
+```
+
+## 8) Form und Aufbewahrung
+
+- **Schriftform** des Protokolls (idR im internen System)
+- **Aufbewahrung** mindestens 10 Jahre (Paragraf 257 HGB)
+- **Vertraulichkeit**: nicht extern weitergeben ohne Gesellschafter-Zustimmung
+- Bei Investor-Berichtspflicht: nur relevanter Auszug
+
+## 9) Typische Fehler
+
+1. **Keine Tagesordnung**. Diskussion ohne Struktur, Beschluesse spaeter nicht nachvollziehbar.
+2. **Schriftliche Beschluesse fehlen**. Bei Streit nicht beweisbar.
+3. **Stimmverhalten nicht dokumentiert**. Bei spaeterer Haftungsfrage problematisch.
+4. **Beschluesse nicht eindeutig**. „Wir denken ueber X nach" ist kein Beschluss.
+5. **Naechste Schritte vergessen**. Wer macht was bis wann?
+
+## Anschluss
+
+- `gesellschaftsgruender-geschaeftsordnung-gf` — Rahmen-Geschaeftsordnung
+- `gesellschaftsgruender-gv-einladung-tagesordnung` — Gesellschafterversammlung
+- `gesellschaftsgruender-bilinguale-dokumente` — DE/EN-Vorlagen

--- a/gesellschaftsgruender/skills/gesellschaftsgruender-gf-sozialversicherungs-status/SKILL.md
+++ b/gesellschaftsgruender/skills/gesellschaftsgruender-gf-sozialversicherungs-status/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: gesellschaftsgruender-gf-sozialversicherungs-status
+description: "Sozialversicherungs-Status des Geschaeftsfuehrers. Fremd-GF sozialversicherungspflichtig. Gesellschafter-GF Mehrheits-Beteiligung typisch frei Minderheits-Beteiligung typisch pflichtig. Sperrminoritaet ueber Sondervetorecht. Statusfeststellung Paragraf 7a SGB IV. BSG-Linie zur Weisungsfreiheit. Konsequenzen rueckwirkende Beitragsforderung."
+---
+
+# Sozialversicherungs-Status des Geschaeftsfuehrers
+
+## Zweck
+
+Bei jedem Geschaeftsfuehrer ist zu klaeren, ob er **sozialversicherungspflichtig** ist (Renten-, Arbeitslosen-, Kranken-, Pflegeversicherung). Bei falscher Annahme drohen rueckwirkende Beitragsforderungen ueber 4 Jahre (Paragraf 25 SGB IV) — fuer Gesellschaft und Geschaeftsfuehrer empfindlich.
+
+## 1) Grundsatz
+
+### Sozialversicherungspflicht
+
+- Pflicht entsteht bei **abhaengiger Beschaeftigung** (Paragraf 7 SGB IV)
+- Wesentliche Merkmale:
+  - Weisungsabhaengigkeit
+  - Eingliederung in fremde Betriebsorganisation
+  - Kein wesentliches unternehmerisches Risiko
+  - Kein eigenes Kapital im Spiel
+
+### Sozialversicherungsfrei
+
+- **Selbststaendige Taetigkeit**
+- Wesentliche Merkmale:
+  - Weisungsfreiheit
+  - Eigenes unternehmerisches Risiko
+  - Eigenes Kapital eingebracht
+  - Selbstaendige Geschaeftsausuebung
+
+## 2) BSG-Linie
+
+### Bei Solo-Gesellschafter-GF (100 %)
+
+- **Sozialversicherungsfrei**
+- Klare Eigenverantwortung, kein Fremd-Weisungsrecht
+
+### Bei Mehrheits-Gesellschafter-GF (> 50 %)
+
+- **Meist sozialversicherungsfrei**
+- BSG NJW 2012, 2310 / BSG SGb 2018, 612
+- Voraussetzung: Mehrheit beschluesst Geschaeftsfuehrer-Anweisungen — Mehrheits-GF kann sich nicht selbst weisen
+
+### Bei 50 %-Gesellschafter-GF
+
+- **Strittig**
+- Bei zustaendigem Sondervetorecht ueber Beschluesse: meist sozialversicherungsfrei
+- Sonst: sozialversicherungspflichtig
+- BSG NJW 2017, 1056
+
+### Bei Minderheits-Gesellschafter-GF (< 50 %)
+
+- **Meist sozialversicherungspflichtig**
+- Ausnahme: **Sperrminoritaet ueber Sondervetorecht** oder **gesellschaftsvertragliche Vereinbarung der Weisungsfreiheit**
+
+### Bei Fremd-GF (kein Gesellschafter)
+
+- **Sozialversicherungspflichtig** (regelmaessig)
+- Status-Feststellung dennoch sinnvoll, da im Einzelfall Abweichungen moeglich
+
+## 3) Statusfeststellung Paragraf 7a SGB IV
+
+### Was ist das
+
+- **Optionale, formelle Feststellung** des Status durch die Clearingstelle der Deutschen Rentenversicherung Bund
+- Bindend fuer alle Sozialversicherungstraeger (Krankenkasse, RV, AV, PV)
+
+### Wann beantragen
+
+- **Vor** Aufnahme der Taetigkeit empfohlen
+- Bei jedem neuen GF
+- Bei Aenderung der Anteilshoehe
+- Bei Aenderung der Vetorechte / Stimmrechts-Struktur
+
+### Antrag
+
+- Online ueber Deutsche Rentenversicherung Bund
+- Formular V0027 (oder spezieller Antrag fuer GF)
+- Beilagen:
+  - Gesellschaftsvertrag
+  - Geschaeftsfuehrer-Anstellungsvertrag
+  - Beschluss zur Bestellung
+  - Aktueller HR-Auszug
+  - Gesellschafterliste
+
+### Dauer
+
+- Typisch 2-6 Monate
+- Bei komplexen Konstellationen laenger
+
+### Ergebnis
+
+- Schriftlicher Bescheid
+- Bindend gegenueber Sozialversicherungstraegern
+- Anfechtbar bei Ablehnung (Widerspruch -> Sozialgericht)
+
+## 4) Kriterien-Katalog
+
+| Kriterium | spricht FUER Sozialversicherungspflicht | spricht GEGEN |
+|---|---|---|
+| Anteil < 25 % | + | - |
+| Anteil 25-50 % | + (eher) | - (bei Sperrminoritaet) |
+| Anteil > 50 % | - | + |
+| Sondervetorecht | - | + |
+| Weisungs-Pflicht im Anstellungsvertrag | + | - |
+| Eigene Kapital-Risiko-Beteiligung | - | + |
+| Persoenliche Buergschaft fuer Verbindlichkeiten | - | + |
+| Familienangehoeriger im Mehrheitsbesitz | + | - |
+
+### Faustregel
+
+- **Anteil + Vetorechte = "echte Mitbestimmung"** -> SV-frei
+- **Lediglich Anteil ohne Veto + Familien-Verflechtung** -> oft SV-pflichtig
+
+## 5) Konsequenzen bei falscher Annahme
+
+### Bei rueckwirkender Pflichtigerklaerung
+
+- **Beitragsforderung** bis 4 Jahre rueckwirkend (Paragraf 25 I SGB IV)
+- Bei vorsaetzlicher Hinterziehung: 30 Jahre (Paragraf 25 I 2 SGB IV)
+- **Saeumniszuschlag** 1 % pro Monat (Paragraf 24 SGB IV)
+
+### Beispielrechnung
+
+```
+GF-Gehalt: 100.000 EUR jaehrlich (Brutto)
+SV-Pflichtteil: 20.000-22.000 EUR jaehrlich
+4 Jahre rueckwirkend: 80.000-88.000 EUR
+Plus Saeumniszuschlaege: ca. 20 % zusaetzlich
+Gesamt: ca. 100.000 EUR
+```
+
+### Strafbarkeit
+
+- **Paragraf 266a StGB**: Vorenthalten und Veruntreuen von Arbeitsentgelt (Beitragshinterziehung) — Freiheitsstrafe bis 5 Jahre
+
+## 6) Sondervetorecht — Beispiel
+
+### Gestaltungs-Variante
+
+```
+Gesellschafter A haelt 35 % der Anteile und ist
+Geschaeftsfuehrer.
+
+Im Gesellschaftsvertrag wird Folgendes festgelegt:
+- Beschluesse mit weniger als 75 % Mehrheit sind
+  unwirksam (qualifizierte Mehrheit).
+- Damit kann A mit 35 % jeden Beschluss verhindern,
+  da Mehrheit > 75 % erforderlich ist und A allein
+  > 25 % haelt -> Sperrminoritaet.
+- Im Anstellungsvertrag ist die Weisungsfreiheit
+  ausdruecklich verankert.
+```
+
+### BSG-Linie
+
+BSG NJW 2016, 1990 / BSG B 12 R 19/14: Eine Sperrminoritaet von 50 % oder mehr bei Mehrheitserfordernis schafft echte Mitbestimmung -> SV-frei. Bei einfacher Mehrheit aber Sperrminoritaet > 25 % alleine reicht nicht.
+
+## 7) Vermeidung haeufiger Fehler
+
+### Familien-GmbH
+
+- Sehr haeufig: Vater Mehrheits-Gesellschafter, Sohn Minderheits-GF (25-49 %)
+- Sohn als GF aus dem Familien-Umfeld weisungsabhaengig
+- **Empfehlung**: explizite Weisungsfreiheits-Klausel im Anstellungsvertrag, Sondervetorechte in Satzung
+
+### Investor-Konstellation
+
+- Investor haelt 30 %, Gruender 70 %
+- Gruender ist GF — meist SV-frei
+- Bei spaeterer Verwaesserung auf < 50 %: SV-Status neu pruefen
+
+### Sole-Gesellschafter-GF
+
+- 100 % Anteile, GF — eindeutig SV-frei
+
+### Co-GF mit gleichen Anteilen
+
+- 50/50-Konstellation
+- Sondervetorechte vereinbart -> meist SV-frei
+- Ohne Vetorechte: strittig, Statusfeststellung dringend
+
+## 8) Kosten der Sozialversicherung
+
+### Arbeitgeber-Anteil
+
+- Renten: 9,3 %
+- Arbeitslosen: 1,3 %
+- Kranken: ca. 7,3 %
+- Pflege: ca. 1,7 %
+- BG-Umlage: 0,5-2,5 % je Gefahrentarif
+- **Gesamt: ca. 20-22 % auf Brutto**
+
+### Arbeitnehmer-Anteil
+
+- Aequivalent (ca. 20-22 %)
+- Wird vom Brutto-Gehalt abgezogen
+
+### Bei SV-Pflichtigkeit
+
+- 100.000 EUR Brutto -> ca. 122.000 EUR Lohnkosten Gesellschaft
+- GF erhaelt ca. 60.000 EUR Netto (je nach Steuerklasse)
+
+### Bei SV-Freiheit
+
+- 100.000 EUR Brutto -> ca. 100.000 EUR Lohnkosten Gesellschaft
+- GF erhaelt ca. 70.000 EUR Netto
+- Privatversicherung erforderlich (Kranken, Renten, ggf. AV freiwillig)
+
+## 9) Privatversicherung bei SV-Freiheit
+
+### Krankenversicherung
+
+- Pflicht zur Krankenversicherung (Paragraf 193 III VVG)
+- PKV oder freiwillige GKV
+- Aufnahme-Voraussetzungen pruefen (Gesundheitspruefung)
+
+### Rentenversicherung
+
+- Freiwillige Versicherung in der DRV moeglich
+- Alternativ: privater Aufbau (Riester, Ruerup, betriebliche Altersversorgung)
+
+### Arbeitslosen-Versicherung
+
+- Freiwillig moeglich (Paragraf 28a SGB III)
+- Bei Existenzgruendern empfohlen
+- Antrag bei Bundesagentur fuer Arbeit binnen 3 Monaten nach Aufnahme
+
+## 10) Praktische Empfehlung
+
+- **Statusfeststellung Paragraf 7a SGB IV** bei jedem neuen GF — auch wenn „klar" SV-frei
+- **Wenn SV-Status erst spaeter geklaert wird**: rueckwirkende Forderung droht
+- **Bei strukturellen Aenderungen** (Anteilswechsel, neue Vetorechte): erneute Pruefung
+- **Anstellungsvertrag** klar formulieren: Weisungsfreiheit, eigene Verantwortung
+- **D&O-Versicherung** ungeachtet SV-Status
+
+## Anschluss
+
+- `gesellschaftsgruender-geschaeftsfuehrervertrag` — Anstellungsvertrag
+- `gesellschaftsgruender-share-classes-a-b-c` — Stimmrechts-Klassen
+- `gesellschaftsgruender-golden-share-und-vetorechte` — Vetorechte fuer SV-Status
+- `kanzlei-allgemein-lohn-sv` — laufende SV-Abwicklung

--- a/gesellschaftsgruender/skills/gesellschaftsgruender-golden-share-und-vetorechte/SKILL.md
+++ b/gesellschaftsgruender/skills/gesellschaftsgruender-golden-share-und-vetorechte/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: gesellschaftsgruender-golden-share-und-vetorechte
+description: "Golden Share Sperrminoritaet Sondervetorechte. Bei Restrukturierung StaRUG Insolvenzantrag Verkauf wesentlicher Aktiva Satzungsaenderung Liquidation. Stimmrechts-Konstellationen. Beispiel-Klauseln fuer Satzung. Innenverhaeltnis vs Aussenverhaeltnis. Typische Anwendungs-Konstellationen Family Office Gruender-Schutz Investor-Schutz."
+---
+
+# Golden Share und Sondervetorechte
+
+## Zweck
+
+Ein **Golden Share** (auf Deutsch oft „Goldene Aktie" oder „Vorzugsanteil mit Vetorechten") ist ein Anteil mit **besonderen Stimmrechten** oder **Veto-Rechten**, die der Inhaber **unabhaengig** von seiner sonstigen Anteilshoehe besitzt. Klassisch bei Privatisierungs-Transaktionen entstanden, heute oft in Gruender-Verhaeltnissen, Investor-Schutz und Family-Office-Strukturen.
+
+## 1) Konzept
+
+### Klassisches Beispiel
+
+- Eine natuerliche Person haelt 1 Goldenen Anteil
+- Mehrheits-Beschluesse sind nur wirksam, wenn die Inhaberin des Golden Share **zustimmt**
+- Damit kann eine einzelne Person bestimmte Geschaefte verhindern
+
+### Inhalt des Vetorechts
+
+Typisch geregelt:
+
+- Aenderung der Satzung
+- Aenderung des Geschaeftsgegenstands
+- Verkauf oder Verpfaendung wesentlicher Aktiva
+- Aufloesung der Gesellschaft
+- **Restrukturierung nach StaRUG oder Insolvenzantrag** (siehe unten)
+- Aufnahme neuer Investoren mit Vorzugsrechten
+
+## 2) Einsatz im StaRUG-/Insolvenz-Kontext
+
+### Konstellation
+
+- Geschaeftsfuehrung will **StaRUG-Restrukturierung** beginnen (Paragraf 31 StaRUG)
+- Bestimmte Gesellschafter wollen das **nicht** (z.B. weil sie ausgebootet werden koennten)
+- Golden Share mit Restrukturierungs-Vetorecht: ohne Zustimmung kein Antrag
+
+### Rechtsfrage
+
+- Im Aussenverhaeltnis: bindet die Geschaeftsfuehrung; Antrag ohne Zustimmung wirksam nach aussen?
+- BGH-Linie: GF ist im Innenverhaeltnis an Satzung gebunden, im Aussenverhaeltnis greift die Vertretungsmacht trotz Verstoss
+- Bei Pflichtverletzung: Haftung Paragraf 43 GmbHG; Abberufung Paragraf 38 GmbHG
+
+### Praktische Wirkung
+
+- GF wird ohne Zustimmung des Golden-Share-Inhabers den Antrag nicht stellen, um persoenliche Haftung zu vermeiden
+- Damit Golden Share **faktisch** wirksam
+
+## 3) Satzungs-Klausel — Beispiel
+
+```
+§ X Sondervetorecht (Golden Share)
+
+(1) Die Inhaberin des Golden Share, Anna Mueller,
+geb. ..., hat zusaetzlich zu den allgemeinen
+Stimmrechten ein Sondervetorecht. Folgende
+Beschluesse beduerfen ihrer Zustimmung:
+
+a) Aenderung der Satzung,
+b) Veraeusserung wesentlicher Aktiva
+   (Schwelle: 20 % des Bilanzvermoegens),
+c) Stellung eines Antrags auf Restrukturierungs-
+   verfahren nach StaRUG (Paragraf 31 StaRUG),
+d) Stellung eines Insolvenzantrags (Paragraf 15a
+   InsO bleibt unberuehrt — die Pflicht trifft die
+   Geschaeftsfuehrung, das Sondervetorecht entlastet
+   sie nicht),
+e) Aufloesung der Gesellschaft,
+f) Wesentliche AEnderungen des Geschaeftsgegenstands.
+
+(2) Das Sondervetorecht erlischt mit dem Tod oder
+der Unfaehigkeit der Inhaberin oder bei Uebertragung
+des Golden Share an einen Dritten.
+
+(3) Der Golden Share kann ausschliesslich an direkte
+Nachkommen erster Ordnung oder die Familienstiftung
+[Name] uebertragen werden, sonst loescht er sich
+in einen normalen Anteil um.
+```
+
+## 4) Wichtig: Paragraf 15a InsO Insolvenzantragspflicht
+
+### Pflicht der Geschaeftsfuehrung
+
+- Bei Zahlungsunfaehigkeit oder Ueberschuldung: **Antragspflicht binnen 3 Wochen**
+- **Strafbarkeit** Paragraf 15a IV InsO bei Versaeumnis
+- **Sondervetorecht** der Gesellschafter **entlastet nicht** den Geschaeftsfuehrer
+
+### Konsequenz
+
+- Bei Insolvenzreife muss GF antragstellen — auch gegen Veto
+- Anders bei **StaRUG**: hier besteht keine zwingende Antragspflicht (es ist freiwillig); Sondervetorecht greift voll
+
+## 5) Anwendungs-Konstellationen
+
+### Gruender-Schutz
+
+- Solo-Gruender mit Investoren-Eintritt
+- Gruender behaelt Vetorecht ueber Restrukturierung, Verkauf, Aufloesung
+- Schutz vor „Ausbootung" durch Mehrheits-Investor
+
+### Investor-Schutz
+
+- Lead-Investor mit hoher Liquidation Preference
+- Vetorecht gegen Restrukturierungs-Aktionen, die die Preference unterlaufen koennten
+
+### Family Office
+
+- Familien-Patriarch / -Matriarchin behaelt Sondervetorecht ueber strategische Entscheidungen
+- Nachfolge-Generation kann taegliches Geschaeft fuehren, aber nicht strategische Wenden ohne Familienkonsens
+
+### Strategische Investoren / Partner
+
+- Strategischer Investor mit kleinem Anteil, aber Veto gegen Konkurrenz-Aktionen (z.B. Verkauf an Wettbewerber)
+
+## 6) Grenzen des Vetorechts
+
+### Sittenwidrigkeit Paragraf 138 BGB
+
+- Zu weitgehende Vetorechte koennen sittenwidrig sein
+- Beispiel: Vetorecht gegen **alle** Beschluesse -> Gesellschaft funktionsunfaehig
+
+### Treuepflicht der Gesellschafter
+
+- Vetorecht muss nach Treu und Glauben Paragraf 242 BGB ausgeuebt werden
+- Missbraeuchliche Ausuebung (rein schaedigend, ohne legitimes Interesse) kann anfechtbar sein
+- BGH NJW 2007, 917 zur Treuepflicht in Kapitalgesellschaften
+
+### Stimmverbot Paragraf 47 IV GmbHG
+
+- Bei eigenen Angelegenheiten ist Stimmrecht ausgeschlossen
+- Golden Share kann das **nicht** umgehen — Stimmverbot greift auch fuer Golden-Share-Inhaber
+
+## 7) Stimmverpflichtung im SHA
+
+### Konzept
+
+In der **Gesellschaftervereinbarung (SHA)** koennen Gesellschafter sich verpflichten, **wie** sie in der Gesellschafterversammlung abstimmen. Dies bindet sie **schuldrechtlich**, aber nicht **gesellschaftsrechtlich** — der Beschluss bleibt wirksam, auch wenn jemand sich an die SHA-Verpflichtung nicht haelt. Folgen sind aber **Vertragsstrafen** oder **Schadensersatz**.
+
+→ `gesellschaftsgruender-sha-satzung-stimmverpflichtung`
+
+## 8) Streit ueber Vetorecht
+
+### Bei Konflikt
+
+- Veto wird ausgeuebt -> Beschluss nicht zustande gekommen
+- Gegenseitige Vorwuerfe: Veto rechtmaessig? Treuwidrig?
+- Klage auf Feststellung der Wirksamkeit / Unwirksamkeit eines Beschlusses (Paragrafen 246, 248 AktG analog)
+- Bei Streit oft einstweilige Verfuegung -> `gesellschaftsgruender-gesellschafterstreit-eilantraege`
+
+## 9) Eintragung im Handelsregister
+
+### Pflicht
+
+- Stimmrechts-Klauseln werden im Handelsregister hinterlegt (mit der Satzung)
+- Vetorecht ist publik
+- Bei Anteilsuebertragung: Vetorecht-Klausel bleibt im Anteil
+
+### Bei spaeterem Verkauf
+
+- Klausel zur Loeschung bei Verkauf ueblich (siehe Satzung Beispiel oben § 2)
+- Andernfalls: Investor erhaelt Golden Share, was meist nicht gewuenscht
+
+## 10) Praktische Empfehlung
+
+- **Bei Solo-Gruender mit absehbaren Investoren**: Golden Share fuer den Gruender mit klar definierten Vetorechten
+- **Bei Family Office**: Golden Share fuer aktives Familienmitglied
+- **NICHT** Pauschal-Vetorechte ueber alles — selektiv, mit klaren Schwellen
+- **Stimmverbot Paragraf 47 IV GmbHG beachten** — bei eigenen Angelegenheiten greift es
+- **In SHA Stimmverpflichtungen** als ergaenzendes Sicherungsnetz
+
+## Anschluss
+
+- `gesellschaftsgruender-share-classes-a-b-c` — Verbindung mit Klassen-Strukturen
+- `gesellschaftsgruender-sha-satzung-stimmverpflichtung` — Stimmverpflichtungs-Klauseln
+- `gesellschaftsgruender-gesellschafterstreit-eilantraege` — Konfliktfall
+- `gesellschaftsgruender-gesellschaftsvertrag-gmbh` — Satzungs-Gestaltung

--- a/gesellschaftsgruender/skills/gesellschaftsgruender-gruender-intake/SKILL.md
+++ b/gesellschaftsgruender/skills/gesellschaftsgruender-gruender-intake/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: gesellschaftsgruender-gruender-intake
+description: "Strukturierte Eingangsabfrage Gruender. Wer sind die Gruender natuerliche Personen Holding-GmbH. Wieviele Anteile pro Gruender absolut und prozentual. Class A B C Shares schon jetzt oder erst nach Seed. Geschaeftsmodell und Investor-Roadmap. Sitz Gegenstand Stammkapital. Mit Frageleitfaden Pflichtdaten optional-Daten Ausgabe-Vorlage Datenbasis fuer alle weiteren Skills."
+---
+
+# Gruender-Intake
+
+## Zweck
+
+Strukturierter Eingangs-Workflow, der **alle gruendungsrelevanten Daten** abfragt, bevor andere Skills (Satzung, SHA, Cap Table, Notar-Vorbereitung) angestossen werden. Vermeidet spaetere Nacharbeit durch fehlende Eckdaten.
+
+## Frageleitfaden
+
+### Block 1 — Gruender
+
+- Wieviele Gruender (natuerliche Personen)?
+- Pro Gruender:
+  - Vollstaendiger Name, Geburtsdatum, Anschrift
+  - Berufliche Funktion in der Gesellschaft (CEO, CTO, Investor, Stiller etc.)
+  - Wird der Gruender **persoenlich** halten oder ueber **Holding-GmbH**?
+  - Wenn Holding: existiert sie schon, oder ist sie noch zu gruenden?
+  - Bei Holding: Steuer-Vorteil Paragraf 8b KStG bei spaeterem Exit — `gesellschaftsgruender-rechtsformwahl` Falle 6
+
+### Block 2 — Anteilsverteilung
+
+- Stammkapital insgesamt (Mindest 25.000 EUR fuer GmbH, 1 EUR fuer UG)
+- Pro Gruender:
+  - Hoehe in EUR
+  - Anteil in Prozent
+- Schon jetzt **Class-Shares (A/B/C)** oder erst nach Seed-Runde?
+  - Empfehlung: bei Solo-/Paar-Gruendung erstmal **eine Klasse**, Class-Shares spaeter mit Investor einfuehren
+  - Bei Mehrgruender-Konstellation mit absehbarem Investor: schon Class-Shares vorsehen
+
+### Block 3 — Bewertung und Investor-Roadmap
+
+- Vorgesehene **Pre-Money-Bewertung** in absehbarer Zeit
+- **Geplante Finanzierungsrunden** (Seed, Series A, ...)?
+- Bereits Term Sheet mit Investor?
+- **Genehmigtes Kapital** (Paragraf 55a GmbHG) vorsehen? Erleichtert spaetere Runden
+- **Vesting** fuer Gruender? Cliff 12 Monate Standard
+
+### Block 4 — Geschaeftsmodell
+
+- Branche
+- B2B / B2C
+- Internationale Aktivitaet
+- Investoren-Tauglichkeit (Tech, Biotech, Greentech?)
+- Reputationsbeduerftig (B2B wenig vs. B2C oft)
+- Lizenz-/Genehmigungspflicht (BaFin? Glücksspiel? Apotheker? Bewachungsgewerbe?)
+
+### Block 5 — Firma und Sitz
+
+- Wunschfirma (mit Rechtsformzusatz)
+- Alternative Firmenvorschlaege fuer Fall der Beanstandung
+- Sitz (Stadt)
+- Geschaeftsadresse (kann abweichen)
+- Domain bereits gesichert? Marken-Suche durchgefuehrt? → `gesellschaftsgruender-firmenname-pruefung`
+
+### Block 6 — Geschaeftsfuehrung
+
+- Wieviele GF?
+- Einzel- oder Gesamtvertretung?
+- Pro GF: Gesellschafter oder Fremd-GF?
+- Sozialversicherungs-Status (Mehrheit / Minderheit / Fremd-GF) — `gesellschaftsgruender-gf-sozialversicherungs-status`
+- Anstellungsvertrag — Hoehe? Wettbewerbsverbot? Karenz? → `gesellschaftsgruender-geschaeftsfuehrervertrag`
+
+### Block 7 — Gesellschaftervereinbarung (SHA)
+
+- Vesting / Leaver-Regelungen? — `gesellschaftsgruender-gesellschaftervereinbarung`
+- Vorkaufsrechte
+- Drag-Along / Tag-Along
+- Pflicht-Korrespondenz SHA <-> Satzung — `gesellschaftsgruender-sha-satzung-stimmverpflichtung`
+
+### Block 8 — Beirat / Advisory Board
+
+- Beirat vorgesehen? → `gesellschaftsgruender-beirat-advisory-board`
+- Wenn ja: wieviele Mitglieder? Aufgaben? Pflicht-Themen?
+
+### Block 9 — Spezial-Themen
+
+- Golden Share / Restrukturierungs-Vetorecht? → `gesellschaftsgruender-golden-share-und-vetorechte`
+- Bilinguale Dokumente Deutsch/Englisch? → `gesellschaftsgruender-bilinguale-dokumente`
+- gGmbH (gemeinnuetzig)?
+
+## Ausgabe
+
+Am Ende des Intakes liegt vor:
+
+1. **Datenblatt Gruendung** mit allen Eckdaten
+2. **Cap Table** (initial) → `gesellschaftsgruender-cap-table`
+3. **Routen-Liste**: Welche Skills sollen als naechstes laufen?
+4. **Fristen-Vorschau**: Notar-Termin, Stammkapital-Einzahlung, Anmeldung
+5. **Stoppschilder-Liste**: Wann zwingend Anwalt / Steuerberater / Notar?
+
+## Typische Stolpersteine im Intake
+
+1. **Anteile ohne Begruendung**: 50/50 wirkt fair, ist aber Patt-Risiko -> entweder 51/49 oder asymmetrische A/B
+2. **Holding-Frage zu spaet**: Wer Steuer-Vorteil will, muss Holding **vor** der operativen GmbH gruenden
+3. **Investoren-Roadmap ignoriert**: Class-Shares jetzt vorgesehen erspart spaetere Satzungsaenderung
+4. **Firmenname nicht geprueft**: oft schon vergeben oder markenrechtlich kollidierend
+5. **Vesting vergessen**: Gruender ohne Vesting koennen nach 6 Monaten mit voller Anteilshoehe ausscheiden — Demotivation der Verbleibenden
+
+## Anschluss
+
+- `gesellschaftsgruender-cap-table` — Cap Table erzeugen
+- `gesellschaftsgruender-firmenname-pruefung` — Firma pruefen
+- `gesellschaftsgruender-rechtsformwahl` — falls Rechtsform offen
+- `gesellschaftsgruender-share-classes-a-b-c` — bei Class-Shares
+- `gesellschaftsgruender-kommandocenter` — Master-Workflow

--- a/gesellschaftsgruender/skills/gesellschaftsgruender-gv-einladung-tagesordnung/SKILL.md
+++ b/gesellschaftsgruender/skills/gesellschaftsgruender-gv-einladung-tagesordnung/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: gesellschaftsgruender-gv-einladung-tagesordnung
+description: "Einladung zur Gesellschafterversammlung GmbH UG. Frist und Form Paragraf 51 GmbHG einberufungsberechtigte Personen Tagesordnungspunkte. Ordentliche Versammlung Paragraf 42a GmbHG jaehrlich. Ausserordentliche Versammlung. Mit Tagesordnungsvorschlag Templates Beispiel-Beschlussvorlagen Bilingualitaet DE EN."
+---
+
+# Einladung zur Gesellschafterversammlung
+
+## Zweck
+
+Vorlagen und Pruefliste fuer die Einladung zur **Gesellschafterversammlung** der GmbH/UG nach Paragraf 51 GmbHG. Falsche Einladung fuehrt zu Anfechtbarkeit der Beschluesse.
+
+## 1) Rechtsgrundlagen
+
+- **Paragraf 49 I GmbHG**: Einberufung durch Geschaeftsfuehrer
+- **Paragraf 49 II GmbHG**: Pflichtversammlung bei Verlust der Haelfte des Stammkapitals → `gesellschaftsgruender-stammkapitalverlust-paragraf-49-gmbhg`
+- **Paragraf 50 GmbHG**: Einberufungsrecht der Gesellschafter mit mind. 10 % Anteilen
+- **Paragraf 51 GmbHG**: Form und Frist der Einberufung
+- **Paragraf 51a GmbHG**: Berichtspflicht der Geschaeftsfuehrer
+
+## 2) Form und Frist Paragraf 51 GmbHG
+
+### Form
+
+- **Schriftform** (Brief, Fax, E-Mail soweit Satzung zulaesst)
+- **Eingeschriebener Brief** in Praxis ueblich (Beweis der Zustellung)
+- **Bei elektronischer Form**: Satzung muss dies vorsehen (Paragraf 51 II GmbHG)
+
+### Frist
+
+- **Mindestens eine Woche** vor dem Termin (Paragraf 51 I GmbHG)
+- **Satzungs-Verlaengerung** moeglich (typisch 2-4 Wochen)
+- **Zustellungs-Wirkung**: bei Brief gilt die Einladung am 3. Tag nach Aufgabe als zugegangen (Paragraf 130 BGB)
+
+### Inhalt
+
+- Ort und Zeit der Versammlung
+- **Tagesordnung** mit allen zu beratenden Punkten
+- **Beschluss-Vorlagen** soweit moeglich
+- **Beifuegungs-Dokumente** (Jahresabschluss, Berichte, Satzungsaenderungs-Entwurf)
+
+## 3) Standard-Einladung — Ordentliche Versammlung
+
+```
+[Briefkopf der Gesellschaft]
+
+An die Gesellschafter der [Firma] GmbH
+
+Einladung zur ordentlichen Gesellschafterversammlung
+
+Sehr geehrte Damen und Herren,
+
+hiermit lade ich Sie gemaess Paragraf 49 I GmbHG
+und Paragraf [X] der Satzung der Gesellschaft zur
+
+ordentlichen Gesellschafterversammlung am
+
+[Tag, Datum], [Uhrzeit] Uhr,
+[Ort]
+
+ein.
+
+Tagesordnung:
+
+1. Begruessung, Feststellung der Beschlussfaehigkeit
+   und Wahl des Versammlungsleiters
+
+2. Feststellung des Jahresabschlusses zum [Datum]
+   und Beratung ueber die Gewinnverwendung
+   (Paragraf 42a GmbHG)
+
+3. Entlastung der Geschaeftsfuehrer fuer das
+   Geschaeftsjahr [Jahr]
+
+4. Sonstiges
+
+Beifuegung:
+- Jahresabschluss zum [Datum]
+- Lagebericht der Geschaeftsfuehrung
+- Vorschlag zur Gewinnverwendung
+
+Mit freundlichen Gruessen
+
+[Geschaeftsfuehrer]
+[Datum]
+```
+
+## 4) Aussergewoehnliche Versammlung
+
+```
+[Briefkopf]
+
+Einladung zur ausserordentlichen Gesellschafterversammlung
+
+Sehr geehrte Damen und Herren,
+
+aus dringendem Anlass lade ich Sie zur
+ausserordentlichen Gesellschafterversammlung am
+
+[Tag, Datum], [Uhrzeit] Uhr,
+[Ort],
+
+ein.
+
+Anlass: [konkrete Begruendung — z.B. Investor-Eintritt,
+Geschaeftsfuehrer-Bestellung, Satzungsaenderung]
+
+Tagesordnung:
+
+1. Begruessung, Feststellung der Beschlussfaehigkeit
+   und Wahl des Versammlungsleiters
+2. [konkreter Beschluss-Vorschlag]
+3. Sonstiges
+
+Beschluss-Vorschlag zu TOP 2:
+
+[Konkrete Beschluss-Formulierung — wichtig fuer
+Anfechtungs-Sicherheit; ueberfluessige Generalitaet
+vermeiden]
+
+Beifuegung:
+- [konkrete Dokumente]
+
+Mit freundlichen Gruessen
+
+[Geschaeftsfuehrer]
+```
+
+## 5) Tagesordnungs-Punkte korrekt formulieren
+
+### Allgemein-Punkte
+
+- „Sonstiges" oder „Verschiedenes" — gestattet, aber **nicht** beschlussfaehig fuer wesentliche Themen
+- Wesentliche Beschluesse muessen **konkret** in der Tagesordnung benannt sein (BGH NJW 2003, 3198)
+
+### Konkretes Formulieren
+
+❌ „Beschluesse zu Personal" — zu vage
+
+✅ „Beschluss ueber Bestellung von Herrn Frank Schmidt zum weiteren Geschaeftsfuehrer mit Wirkung zum [Datum]"
+
+### Bei Satzungsaenderung
+
+- **Wortlaut der Aenderung** muss in Tagesordnung erkennbar sein
+- Bei umfangreicher Aenderung: Entwurf als Anlage
+- Beschluss-Vorlage konkret
+
+## 6) Pflicht-Beratungs-Themen — Ordentliche GV (Paragrafen 42a GmbHG)
+
+### Pflicht-Inhalt der ordentlichen GV
+
+- Feststellung des Jahresabschlusses
+- Beschluss ueber Gewinnverwendung
+- Entlastung der Geschaeftsfuehrer (typisch)
+
+### Frist
+
+- Innerhalb der Frist Paragraf 264 HGB (Aufstellung 3 / Veroeffentlichung 12 Monate nach Geschaeftsjahresende)
+- Praktisch: Ordentliche GV typisch im 1. Halbjahr nach Jahresende
+
+## 7) Einladungs-Rechtsfehler
+
+| Fehler | Konsequenz |
+|---|---|
+| Frist nicht gewahrt | Anfechtbarkeit der Beschluesse |
+| Nicht alle Gesellschafter eingeladen | Beschluesse nichtig |
+| Tagesordnung unklar | Anfechtbarkeit |
+| Falscher Versammlungsort | bei Erschwerung Anfechtbarkeit |
+| Einberufung durch Unberechtigten | Beschluesse nichtig |
+
+### Heilung
+
+- **Vollversammlung** mit allen Gesellschaftern: heilt Form-Maengel (Paragraf 51 III GmbHG)
+- **Genehmigung** durch alle Gesellschafter nachtraeglich
+
+## 8) Bilinguale Einladung DE/EN
+
+Bei internationalen Investoren / Gesellschaftern aus Sprachgruenden bilingual:
+
+```
+[Header]
+
+Einladung zur Gesellschafterversammlung
+Invitation to the Shareholders' Meeting
+
+Sehr geehrte Damen und Herren,
+Dear Shareholders,
+
+[deutsch]
+[english]
+
+Bei Inkonsistenzen zwischen der deutschen und der
+englischen Fassung geht die deutsche Fassung vor
+(Paragraf 1 II Satzung).
+
+In case of inconsistencies between the German and
+the English version, the German version shall
+prevail (§ 1 II of the Articles of Association).
+
+Tagesordnung / Agenda:
+[bilingual]
+```
+
+→ `gesellschaftsgruender-bilinguale-dokumente`
+
+## 9) Bei Streit: Sicherungs-Vorkehrungen
+
+### Beweis-Sicherung
+
+- **Einschreiben mit Rueckschein** an alle Gesellschafter
+- **Tracking-Nummer** des Versandes dokumentiert
+- **E-Mail-Versand** mit Read Receipt (falls Satzung das zulaesst)
+- **Frist mit Puffer** (z.B. 14 Tage statt 7)
+
+### Bei Mitteilung an Auslandsgesellschafter
+
+- Apostille / Beglaubigung der Ausweisdokumente bei spaeterer Notar-Anfechtung
+- Notarielle Zustellungs-Bestaetigung (Paragraf 132 BGB)
+
+### Bei strittiger Versammlung
+
+- Zweite Einladung durch anderen einberufungsberechtigten Gesellschafter (Paragraf 50 GmbHG) als Sicherung
+- Notar-Anwesenheit bei der Versammlung (vorbeurkundete Beschluesse)
+- Videoaufzeichnung mit Einverstaendnis aller (Datenschutz beachten)
+
+→ `gesellschaftsgruender-gesellschafterstreit-eilantraege`
+
+## 10) Typische Einladungs-Fehler
+
+1. **Frist nur 5 Tage**. Gesetzliche Mindestfrist 1 Woche; Satzungs-Frist beachten.
+2. **„Sonstiges" als Ueberschrift fuer wesentlichen Beschluss**. Anfechtbar.
+3. **Falscher Versammlungsleiter-Vorschlag**. Wahl muss durch GV erfolgen.
+4. **Nicht alle Gesellschafter eingeladen**. Beschluesse nichtig.
+5. **Tagesordnung nicht beigefuegt**, sondern nur „Anlassbericht erhalten Sie spaeter". Pflichtgemaess in der Einladung.
+6. **Nach Einberufung Tagesordnung erweitert** ohne 1-Woche-Frist. Anfechtbar.
+7. **Bei elektronischem Versand** nicht der Satzung entsprechend. Anfechtbar.
+
+## Anschluss
+
+- `gesellschaftsgruender-gv-protokoll-und-versammlungsleiter` — Protokoll der GV
+- `gesellschaftsgruender-stammkapitalverlust-paragraf-49-gmbhg` — Pflichtversammlung
+- `gesellschaftsgruender-gesellschafterstreit-eilantraege` — bei Konfliktversammlung
+- `gesellschaftsgruender-bilinguale-dokumente` — DE/EN-Vorlagen

--- a/gesellschaftsgruender/skills/gesellschaftsgruender-gv-protokoll-und-versammlungsleiter/SKILL.md
+++ b/gesellschaftsgruender/skills/gesellschaftsgruender-gv-protokoll-und-versammlungsleiter/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: gesellschaftsgruender-gv-protokoll-und-versammlungsleiter
+description: "Protokoll der Gesellschafterversammlung. Wahl des Versammlungsleiters Wahl des Schriftfuehrers. Anwesenheits-Liste Stimmrechts-Pruefung. Beschluss-Wortlaut und Stimmrechts-Ergebnis Mehrheits-Berechnung. Notarielle Beurkundung bei Satzungsaenderung. Bei streitiger Versammlung mehrere Protokolle. Anfechtungs-Fristen Paragrafen 246 248 AktG analog."
+---
+
+# Protokoll der Gesellschafterversammlung
+
+## Zweck
+
+Das Protokoll dokumentiert Beschluesse der Gesellschafterversammlung. Es ist Beweismittel bei Streit und Voraussetzung fuer Anmeldungen beim Handelsregister.
+
+## 1) Pflicht-Inhalte des Protokolls
+
+### Formaler Teil
+
+- Datum, Ort, Beginn, Ende
+- Anwesenheits-Liste mit Anteilshoehen und Stimmrechten
+- Wahl des Versammlungsleiters
+- Wahl des Schriftfuehrers
+- Feststellung der ordnungsgemaessen Ladung und der Beschlussfaehigkeit
+- Tagesordnung
+
+### Pro Tagesordnungspunkt
+
+- Beschluss-Vorlage im Wortlaut
+- Diskussion (knappe Zusammenfassung)
+- Beschluss im **endgueltigen Wortlaut**
+- Stimm-Ergebnis: Ja-Stimmen, Nein-Stimmen, Enthaltungen — jeweils nach Anteilen und Personen
+
+### Schluss
+
+- Schluss der Versammlung
+- Unterschriften: Versammlungsleiter und Schriftfuehrer
+
+## 2) Wahl des Versammlungsleiters
+
+### Standard
+
+- Wahl durch die GV mit einfacher Mehrheit
+- Typisch der Geschaeftsfuehrer (der einberufen hat) oder ein Gesellschafter
+
+### Bei streitiger Versammlung
+
+- Verschiedene Gesellschafter koennen verschiedene Versammlungsleiter vorschlagen
+- Wahl durch GV — wer die einfache Mehrheit erhaelt, leitet
+- Bei **Patt**: keine wirksame Wahl -> Versammlung verschoben oder Eskalation
+
+### Befugnisse des Versammlungsleiters
+
+- Ordnungsmaecht in der Versammlung (Reihenfolge, Diskussionsdauer)
+- Feststellung der Beschluesse
+- Unterzeichnung des Protokolls
+- Bei Streit: stark umstritten, was er einseitig feststellen darf
+
+## 3) Stimmrechts-Berechnung
+
+### Standardregeln
+
+- Stimmrecht nach Anteilen (Paragraf 47 II GmbHG)
+- 1 EUR Geschaeftsanteil = 1 Stimme
+- Abweichungen in Satzung moeglich (Mehrstimmrecht, Sonderklassen) → `gesellschaftsgruender-share-classes-a-b-c`
+
+### Mehrheits-Erfordernisse
+
+| Beschluss | Mehrheit |
+|---|---|
+| Standard | einfache Mehrheit (>50 % der abgegebenen Stimmen) |
+| Geschaeftsfuehrer-Bestellung | einfache Mehrheit |
+| Geschaeftsfuehrer-Abberufung | einfache Mehrheit (Paragraf 38 GmbHG) |
+| Satzungsaenderung | 75 % der abgegebenen Stimmen (Paragraf 53 II GmbHG) |
+| Aufloesung | 75 % (Paragraf 60 I Nr. 2 GmbHG) |
+| Kapitalerhoehung | 75 % (Paragraf 53 II GmbHG) |
+| Verkauf wesentlicher Aktiva | abhaengig von Satzung |
+| Entlastung | einfache Mehrheit (typisch) |
+
+### Stimmverbot Paragraf 47 IV GmbHG
+
+Bei eigenen Angelegenheiten ausgeschlossen:
+
+- Entlastung des eigenen GF-Stellung
+- Befreiung von Verbindlichkeiten
+- Geltendmachung von Schadensersatzanspruechen gegen den Gesellschafter
+
+## 4) Notarielle Beurkundung bei bestimmten Beschluessen
+
+### Notar-Pflicht (Paragraf 53 GmbHG)
+
+- Satzungsaenderung
+- Erhoehung / Herabsetzung des Stammkapitals
+- Aufloesung der Gesellschaft
+- Verschmelzung / Spaltung (UmwG)
+
+### Praxis
+
+- Notar wird zur Versammlung eingeladen oder ad hoc bestellt
+- Notar beurkundet **gesamten Versammlungsverlauf** als Protokoll
+- Notar-Protokoll ersetzt das uebliche Protokoll
+
+### Wahl-Erfordernis
+
+- Wahl-Beschluesse (z.B. Geschaeftsfuehrer-Bestellung) **nicht** notarpflichtig, ausser Satzung sieht es vor
+- Schriftform genuegt
+
+## 5) Beispiel-Protokoll
+
+```
+PROTOKOLL der ausserordentlichen Gesellschafter-
+versammlung der [Firma] GmbH
+
+Datum:     [Datum]
+Ort:       [Ort]
+Beginn:    14:00 Uhr
+Ende:      15:30 Uhr
+
+Anwesend (Stimmrechte gemaess Satzung):
+- Anna Mueller         10.000 Anteile (40 %)
+- Bernd Schmidt        10.000 Anteile (40 %)
+- Investor I AG         5.000 Anteile (20 %, davon
+                       Class A mit Stimmrechts-
+                       Multiplikator 1,2)
+
+Stimmrechte gesamt:    25.000 Anteile + 1.000 Mehrstimm-
+                       rechte = 26.000 Stimmrechte
+
+Tagesordnung:
+1. Begruessung, Beschlussfaehigkeit, Versammlungsleiter
+2. Beschluss zur Bestellung eines weiteren Geschaefts-
+   fuehrers, Carla Wagner
+3. Sonstiges
+
+TOP 1 — Begruessung, Versammlungsleiter
+
+Es wird festgestellt:
+- Die Versammlung wurde fristgerecht (3 Wochen vor dem
+  Termin) durch Anna Mueller (Geschaeftsfuehrerin)
+  eingeladen.
+- Alle Gesellschafter sind anwesend.
+- Die Versammlung ist beschlussfaehig.
+
+Wahl des Versammlungsleiters: Anna Mueller
+Wahl des Schriftfuehrers: Bernd Schmidt
+
+Beschluss: einstimmig zustimmend
+
+TOP 2 — Bestellung Carla Wagner zur Geschaeftsfuehrerin
+
+Beschluss-Vorlage:
+„Carla Wagner, geboren am [Datum] in [Ort], wohnhaft
+[Adresse], wird mit Wirkung zum [Datum] zur weiteren
+Geschaeftsfuehrerin der Gesellschaft bestellt. Sie
+vertritt die Gesellschaft gemaess Paragraf [X] der
+Satzung gemeinschaftlich mit einer weiteren Geschaefts-
+fuehrerin. Befreiung von den Beschraenkungen des
+Paragraf 181 BGB wird erteilt."
+
+Diskussion: [knappe Zusammenfassung]
+
+Stimmen:
+- Anna Mueller (10.000 Anteile, 10.000 Stimmen): pro
+- Bernd Schmidt (10.000 Anteile, 10.000 Stimmen): pro
+- Investor I AG (5.000 Anteile, 6.000 Stimmen mit
+  Multiplikator): pro
+
+Beschluss: Bestellung Carla Wagner einstimmig
+zustimmend mit 26.000 von 26.000 abgegebenen Stimmen.
+
+TOP 3 — Sonstiges
+Keine weiteren Punkte.
+
+Schluss der Versammlung: 15:30 Uhr.
+
+Versammlungsleiterin:    _______________
+                         Anna Mueller
+
+Schriftfuehrer:          _______________
+                         Bernd Schmidt
+```
+
+## 6) Anfechtung von Beschluessen
+
+### Anfechtbarkeit (Paragrafen 246, 248 AktG analog)
+
+- Bei Verfahrensfehlern (Einladung, Mehrheits-Berechnung)
+- Bei Verstoss gegen Satzung
+- Bei Verstoss gegen Treuepflicht
+
+### Frist
+
+- Monatsfrist ab Beschlussfassung (BGH-Linie analog Paragraf 246 AktG)
+- Klage beim Landgericht der Gesellschafts-Sitz
+
+### Nichtigkeit (Paragrafen 241, 249 AktG analog)
+
+- Bei schweren Maengeln (z.B. nicht eingeladene Gesellschafter)
+- Keine Frist
+
+→ `gesellschaftsgruender-gesellschafterstreit-eilantraege`
+
+## 7) Bei streitiger Versammlung — Mehrere Protokolle
+
+### Konstellation
+
+- Gesellschafter A leitet Versammlung; Gesellschafter B widerspricht der Leitung; jeder erstellt eigenes Protokoll
+- Verschiedene Beschluss-Feststellungen
+
+### Loesung
+
+- Notar empfohlen — neutrale Beurkundung
+- Andernfalls: Anfechtungs-Klage zur Feststellung der wahren Beschluesse
+
+### Bei Anmeldung beim Handelsregister
+
+- Bei zweideutigen Protokollen wird das HR-Gericht beanstanden
+- Klage vor LG erforderlich, ggf. einstweilige Anmeldungs-Sperre (Paragraf 16 HGB analog)
+
+## 8) Aufbewahrung
+
+- Protokolle sind **mindestens 10 Jahre** aufzubewahren (Paragraf 257 HGB)
+- Idealerweise dauerhaft (z.B. fuer spaetere Due Diligence vor M&A)
+- Originale (mit Unterschriften) im Original-Archiv
+
+## 9) Typische Protokoll-Fehler
+
+1. **Anwesenheits-Liste unvollstaendig**. Bei Anfechtung schwer beweisbar, wer wirklich da war.
+2. **Stimm-Ergebnis nicht beschriftet**. „Beschluss ist einstimmig" reicht nicht — Anteile / Stimmen aufschluesseln.
+3. **Versammlungsleiter-Wahl vergessen** zu protokollieren. Anfechtungs-Argument.
+4. **Beschluss-Wortlaut unklar**. Bei spaeterer Anmeldung HR-Beanstandung.
+5. **Stimmverbot Paragraf 47 IV GmbHG nicht beruecksichtigt**. Stimmen muessen abgezogen werden.
+6. **Notar fehlt bei satzungsaendendem Beschluss**. Beschluss nichtig.
+
+## Anschluss
+
+- `gesellschaftsgruender-gv-einladung-tagesordnung` — Einladung
+- `gesellschaftsgruender-gesellschafterstreit-eilantraege` — bei Streit
+- `gesellschaftsgruender-stammkapitalverlust-paragraf-49-gmbhg` — Pflichtversammlung
+- `gesellschaftsgruender-share-classes-a-b-c` — Klassen-Stimmrechte

--- a/gesellschaftsgruender/skills/gesellschaftsgruender-kapitalerhoehung-bezugsrecht/SKILL.md
+++ b/gesellschaftsgruender/skills/gesellschaftsgruender-kapitalerhoehung-bezugsrecht/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: gesellschaftsgruender-kapitalerhoehung-bezugsrecht
+description: "Kapitalerhoehung Paragrafen 55 ff GmbHG. Bezugsrecht bestehender Gesellschafter Paragraf 55 II GmbHG. Bezugsrechtsausschluss Voraussetzungen sachliche Rechtfertigung Verhaeltnismaessigkeit. Verwaesserungs-Berechnung. Streit-Konstellationen bei nicht-mitziehenden Gesellschaftern. Eilantrag gegen Eintragung."
+---
+
+# Kapitalerhoehung und Bezugsrecht
+
+## Zweck
+
+Bei Erhoehung des Stammkapitals muessen die bestehenden Gesellschafter **Bezugsrechte** erhalten (Paragraf 55 II GmbHG). Ausschluss ist moeglich, aber begruendungsbeduerftig. Streit ueber Bezugsrecht / Bezugsrechtsausschluss ist klassischer Konflikt-Ausloeser.
+
+## 1) Rechtsgrundlagen
+
+- **Paragraf 55 GmbHG**: Erhoehung des Stammkapitals
+- **Paragraf 55 II GmbHG**: Bezugsrecht
+- **Paragraf 55 IV GmbHG**: Bezugsrechtsausschluss
+- **Paragraf 56 GmbHG**: Sacheinlage
+
+## 2) Bezugsrecht — Grundsatz
+
+### Pro-Rata-Recht
+
+- Jeder Gesellschafter hat das Recht, einen seiner Beteiligungsquote entsprechenden Teil der neuen Anteile zu erwerben
+- Vermeidet Verwaesserung
+
+### Beispiel
+
+```
+Vor Erhoehung:
+- Gruender A: 60 % (15.000 Anteile)
+- Gruender B: 40 % (10.000 Anteile)
+Stammkapital: 25.000 EUR
+
+Kapitalerhoehung: + 10.000 EUR (10.000 neue Anteile)
+
+Bezugsrecht:
+- Gruender A: 6.000 neue Anteile (60 %)
+- Gruender B: 4.000 neue Anteile (40 %)
+
+Nach Erhoehung (alle ziehen mit):
+- Gruender A: 21.000 / 35.000 = 60 %
+- Gruender B: 14.000 / 35.000 = 40 %
+-> Anteilsquoten unveraendert
+```
+
+## 3) Wenn nicht alle mitziehen
+
+### Konstellation
+
+- Gesellschafter B kann oder will nicht mitziehen
+- Gruender A zieht voll mit
+- Investor I AG nimmt die nicht-ausgeuebten Anteile
+
+### Auswirkung
+
+```
+Vor Erhoehung:
+- A: 15.000 (60 %)
+- B: 10.000 (40 %)
+
+Erhoehung 10.000 Anteile:
+- A nimmt 6.000 (Bezugsrecht voll)
+- B verzichtet
+- Investor I AG nimmt 4.000 (statt B)
+
+Nach Erhoehung:
+- A: 21.000 / 35.000 = 60 %
+- B: 10.000 / 35.000 = 28,57 % (verwaessert)
+- Investor I AG: 4.000 / 35.000 = 11,43 %
+```
+
+### Konsequenz fuer B
+
+- **Anteilsquote sinkt** von 40 % auf 28,57 %
+- **Stimmrechte sinken** entsprechend
+- Bei vorherigen Sondermehrheits-Schwellen: ggf. nicht mehr erreicht
+
+## 4) Bezugsrechtsausschluss Paragraf 55 IV GmbHG
+
+### Voraussetzungen
+
+- **75 %-Mehrheits-Beschluss** in GV (Paragraf 53 II GmbHG)
+- **Sachliche Rechtfertigung**
+- **Verhaeltnismaessigkeit**
+- **Angemessenheit**
+
+### Sachliche Rechtfertigung
+
+Bei Series-A-Investor:
+- Investor bringt strategisches Know-how oder Marktzugang
+- Kapital-Beduerfnis kann nicht durch bestehende Gesellschafter gedeckt werden
+- Investor verlangt Mindest-Anteil als Voraussetzung des Einstiegs
+
+Bei Mitarbeiter-Beteiligung:
+- ESOP-Programm zur Mitarbeiter-Bindung
+- Sachlich gerechtfertigt, wenn Pool angemessen (typisch 5-15 %)
+
+### Anfechtungsrisiko
+
+- Bezugsrechtsausschluss ohne sachliche Rechtfertigung: anfechtbar (BGH-Linie Kali+Salz)
+- BGH BGHZ 71, 40 — Kali+Salz-Entscheidung zur AG, analog auf GmbH
+
+## 5) Streit-Konstellation
+
+### Typisch
+
+- **Mehrheits-Gesellschafter** wollen Investor-Eintritt mit Bezugsrechtsausschluss
+- **Minderheits-Gesellschafter** lehnen ab — Verwaesserungs-Angst
+- **75 %-Beschluss** wird gefasst (Mehrheits-Gesellschafter haben 75 %)
+- **Minderheits-Gesellschafter** klagt auf Anfechtung des Beschlusses
+
+### Eilrechtsschutz
+
+- **Einstweilige Verfuegung** auf Anmeldungs-Sperre (Paragraf 16 II HGB)
+- Antrag beim **Landgericht** (Gesellschafts-Sitz)
+- Glaubhaftmachung von:
+  - Wahrscheinlichkeit der Anfechtbarkeit (sachliche Rechtfertigung fehlt)
+  - Eilbeduerftigkeit (Eintragung wuerde Verwaesserung unwiderruflich)
+
+→ `gesellschaftsgruender-gesellschafterstreit-eilantraege`
+
+## 6) Beschluss-Vorlage Bezugsrechtsausschluss
+
+```
+TOP X — Kapitalerhoehung um 10.000 EUR mit
+Bezugsrechtsausschluss
+
+Beschluss-Vorlage:
+„Die Gesellschafterversammlung beschliesst,
+
+a) das Stammkapital der Gesellschaft um 10.000 EUR
+   auf 35.000 EUR durch Ausgabe von 10.000 neuen
+   Geschaeftsanteilen der Class A zu erhoehen,
+
+b) das Bezugsrecht der bestehenden Gesellschafter
+   gemaess Paragraf 55 IV GmbHG ganz auszuschliessen,
+
+c) zur Uebernahme der neuen Anteile die Investor I AG
+   mit Sitz in [Ort], eingetragen im HR [HRB X], zu
+   ermaechtigen, gegen Bareinlage des
+   Nennwerts plus Aufgeld i.H.v. 90.000 EUR pro Anteil
+   (Gesamtbetrag 100.000 EUR pro Anteil),
+
+d) die naeheren Bedingungen folgen aus dem
+   Subscription Agreement zwischen der Gesellschaft
+   und Investor I AG vom [Datum].
+
+Sachliche Rechtfertigung des Bezugsrechtsausschlusses:
+- Investor I AG ist strategischer Investor mit
+  Marktzugang in Sektor X.
+- Der Eintritt des Investors ist Voraussetzung fuer
+  die Geschaeftsentwicklung in [Markt].
+- Die bestehenden Gesellschafter haben kein
+  vergleichbares strategisches Engagement.
+- Verwaesserung der bestehenden Gesellschafter
+  betraegt 22 %, was im Rahmen angemessen ist."
+```
+
+## 7) Bei Sondervetorecht / Golden Share
+
+### Konstellation
+
+- Bezugsrechtsausschluss verlangt 75 %-Mehrheit
+- Aber: Golden-Share-Inhaber hat Sondervetorecht
+- Auch bei 100 %-Zustimmung der anderen kann das Veto den Beschluss blockieren
+
+→ `gesellschaftsgruender-golden-share-und-vetorechte`
+
+## 8) Verwaesserungs-Schutz im SHA
+
+### Anti-Dilution-Klauseln
+
+Bei spaeterer Erhoehung zu niedrigerem Preis als Erstausgabe:
+
+- **Full Ratchet**: rueckwirkende Preisanpassung
+- **Weighted Average broad-based**: gewichteter Mittelwert
+
+→ `gesellschaftsgruender-gesellschaftervereinbarung`
+
+### Pflicht zur Mitteilung
+
+- Bezugsrechte muessen den Gesellschaftern **mit Frist** angeboten werden
+- Frist typisch 14-28 Tage
+- Bei Verstoss: Anfechtungs-Risiko
+
+## 9) Typische Erhoehungs-Fehler
+
+1. **Bezugsrecht nicht offeriert**, sondern automatisch ausgeschlossen ohne Beschluss. Anfechtbar.
+2. **Sachliche Rechtfertigung fehlt**. Anfechtbar.
+3. **Aufgeld zu niedrig** (Down Round ohne Anti-Dilution-Anpassung). Investor I AG koennte Anpassung verlangen.
+4. **75 %-Mehrheit knapp verfehlt** (z.B. durch Stimmverbot Paragraf 47 IV GmbHG). Beschluss unwirksam.
+5. **Sacheinlage ohne Werthaltigkeits-Nachweis**. Differenzhaftung.
+6. **Anmeldung HR ohne abgeschlossene Einzahlung**. HR beanstandet.
+
+## 10) Verfahrens-Ablauf
+
+| Schritt | Aktion |
+|---|---|
+| 1 | GV-Einladung mit Beschluss-Vorlage (Frist 1 Woche+) |
+| 2 | GV mit Beschluss (Notar bei Satzungsaenderung) |
+| 3 | Einzahlung Bareinlage (mind. 12.500 EUR vor Anmeldung) |
+| 4 | Anmeldung HR durch Notar |
+| 5 | Eintragung HR |
+| 6 | Aktualisierte Gesellschafterliste |
+| 7 | Transparenzregister-Update |
+| 8 | Aktualisierter Cap Table |
+
+## Anschluss
+
+- `gesellschaftsgruender-genehmigtes-kapital` — bei Vorratsbeschluss
+- `gesellschaftsgruender-gesellschafterstreit-eilantraege` — bei Streit
+- `gesellschaftsgruender-gv-protokoll-und-versammlungsleiter` — Protokoll
+- `gesellschaftsgruender-cap-table` — Verwaesserungs-Berechnung

--- a/gesellschaftsgruender/skills/gesellschaftsgruender-sha-satzung-stimmverpflichtung/SKILL.md
+++ b/gesellschaftsgruender/skills/gesellschaftsgruender-sha-satzung-stimmverpflichtung/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: gesellschaftsgruender-sha-satzung-stimmverpflichtung
+description: "Stimmverpflichtung im Gesellschaftervereinbarung SHA gegenueber der Satzung. Innenverhaeltnis schuldrechtlich Aussenverhaeltnis gesellschaftsrechtlich. Vertragsstrafen Poenalen Erfuellung. SHA-Vorrang oder Satzung-Vorrang. BGH-Linie zu schuldrechtlichen Stimmbindungen. Drittwirkung. Bei Anteilsuebertragung Joinder Agreement."
+---
+
+# Stimmverpflichtung SHA <-> Satzung
+
+## Zweck
+
+Die **Gesellschaftervereinbarung (Shareholder Agreement, SHA)** und die **Satzung** muessen zusammenpassen. Wo der SHA bestimmte Entscheidungen vorsieht, muessen die Gesellschafter **innerlich verpflichtet** sein, in der Gesellschafterversammlung **so** abzustimmen. Diese Stimmverpflichtung ist juristisch heikel.
+
+## 1) Konzept der Stimmverpflichtung
+
+### Was ist gemeint
+
+- SHA legt fest: „Bei Aenderung des Geschaeftsmodells sind alle Gesellschafter verpflichtet, ihrer Zustimmung zu verweigern, es sei denn 75 % der Common-Inhaber zuzustimmen."
+- In der Gesellschafterversammlung: Gesellschafter X stimmt **fuer** die AEnderung — entgegen der SHA-Pflicht.
+- **Rechtsfolgen**: gesellschaftsrechtlich ist die Stimme wirksam; im Innenverhaeltnis schuldet Gesellschafter X Schadensersatz oder Vertragsstrafe.
+
+### Schuldrechtlich vs. gesellschaftsrechtlich
+
+| Ebene | Wirkung |
+|---|---|
+| Schuldrechtlich (SHA) | bindet die Gesellschafter persoenlich |
+| Gesellschaftsrechtlich (Satzung) | bindet die Gesellschaft als Organ |
+| Beschlussfaehigkeit / Wirksamkeit | folgt der Satzung |
+| Schadensersatz / Pönale | folgt der SHA |
+
+### Folgen
+
+- Beschluss in der GV bleibt wirksam, auch wenn er gegen SHA verstoesst
+- Der vertragsbruchige Gesellschafter haftet aber persoenlich gegenueber den Mitgesellschaftern fuer die Folgen
+
+## 2) Typische SHA-Stimmverpflichtungs-Klauseln
+
+### Beispiel 1: Vorlage-Pflicht
+
+```
+Die Gesellschafter verpflichten sich, in der
+Gesellschafterversammlung in einer Art und Weise
+abzustimmen, dass die Beschluesse, die diesem
+Shareholder Agreement entsprechen, gefasst werden.
+Insbesondere verpflichten sie sich, ihre Zustimmung
+zu Aenderungen der Satzung zu erteilen, soweit dies
+zur Umsetzung dieses Shareholder Agreement
+erforderlich ist.
+```
+
+### Beispiel 2: Sondervetorecht-Korrespondenz
+
+```
+Soweit die Satzung der Gesellschaft fuer bestimmte
+Beschluesse besondere Mehrheiten oder Zustimmungen
+vorsieht, verpflichten sich die Gesellschafter,
+ihre Stimmrechte so auszuueben, dass die Beschluesse
+in Uebereinstimmung mit den Bestimmungen dieses
+Shareholder Agreement erfolgen.
+```
+
+### Beispiel 3: Pönale-Klausel
+
+```
+Bei Verstoss gegen die Stimmverpflichtungen aus
+diesem Shareholder Agreement schuldet der
+verstossende Gesellschafter den anderen Gesellschaftern
+eine Vertragsstrafe in Hoehe von 250.000 EUR
+pro Verstoss. Daneben besteht ein Anspruch auf
+Schadensersatz nach den allgemeinen Vorschriften.
+```
+
+## 3) BGH-Linie zu schuldrechtlichen Stimmbindungen
+
+- Schuldrechtliche Stimmbindung ist grundsaetzlich **zulaessig** (BGH BGHZ 48, 163; BGHZ 102, 172)
+- Sie kann **gegen die Gesellschaft selbst** unwirksam sein, wenn sie der Gesellschaft schadet
+- Im Innenverhaeltnis (Gesellschafter zu Gesellschafter) wirksam
+- Erfuellungsklage moeglich: Gesellschafter kann verlangen, dass anderer Gesellschafter so abstimmt wie versprochen
+
+## 4) Pflicht-Korrespondenz SHA-Satzung
+
+### Grundsatz: SHA praezisiert, Satzung bindet
+
+| Inhalt | Satzung | SHA |
+|---|---|---|
+| Class-Definitionen | + | (-) |
+| Stimmrechts-Multiplikatoren | + | (-) |
+| Liquidation Preference | + | + (Detail) |
+| Stimmverpflichtungs-Vereinbarungen | - | + |
+| Vesting / Leaver | - | + |
+| Vorkaufsrechte | + (Aussenwirkung) | + (Detail) |
+| Drag-/Tag-Along | + | + |
+| Pönalen | - | + |
+
+### Praxis-Tipp
+
+- Satzung schlank halten — nur was Aussenwirkung haben muss
+- SHA detailliert — alle Verpflichtungs- und Stimmverpflichtungs-Klauseln
+- Aenderungen synchron: Wenn Satzung geaendert wird (z.B. neue Anteilsklasse), muss SHA mitlaufen
+
+## 5) Drittwirkung — Joinder Agreement
+
+### Bei Anteilsuebertragung
+
+- SHA bindet nur Vertragspartner
+- Bei Anteilsuebertragung an Dritten muss neuer Anteilsinhaber **dem SHA beitreten**
+- Mechanismus: **Joinder Agreement**
+
+### Beispiel
+
+```
+Hiermit erklaert der unterzeichnete neue Anteilsinhaber,
+in das Shareholder Agreement vom [Datum] zwischen
+[urspruengliche Vertragspartner] einzutreten, alle
+Rechte und Pflichten aus dem Vertrag zu uebernehmen,
+und dabei den ausscheidenden Anteilsinhaber zu ersetzen.
+```
+
+### Bei Verweigerung
+
+- Anteilsuebertragung ohne Joinder kann durch Vinkulierungs-Klausel (Paragraf 15 V GmbHG) verhindert werden
+- Satzung sollte vorsehen: „Anteilsuebertragung nur mit Zustimmung der Gesellschafterversammlung; Zustimmung wird **nur** erteilt, wenn der Erwerber dem aktuell geltenden SHA beitritt."
+
+## 6) Streit ueber Stimmverpflichtungen
+
+### Schritt 1: Erfuellungsklage
+
+- Kläger: Mitgesellschafter
+- Beklagter: vertragsbruchiger Gesellschafter
+- Klagantrag: Verurteilung zur Abgabe einer bestimmten Stimmabgabe
+- Vollstreckung: durch fiktive Stimme im Wege der Zwangsvollstreckung Paragraf 894 ZPO
+
+### Schritt 2: Vertragsstrafe / Schadensersatz
+
+- Bei tatsaechlich abgegebener anderer Stimme
+- Geltend gemacht ueber Klage
+
+### Praktische Schwierigkeit
+
+- Stimmabgabe ist regelmaessig **bereits erfolgt**, Beschluss wirksam
+- Klage auf Schadensersatz ist die realistische Option
+
+## 7) Stimmverbot Paragraf 47 IV GmbHG
+
+### Wann gilt es
+
+- Bei Beschluss ueber **eigene Angelegenheiten** des Gesellschafters
+- Beispiel: Geschaeftsfuehrer-Bestellung des Gesellschafters X — er darf nicht mitstimmen
+
+### Konsequenz fuer SHA
+
+- Stimmverpflichtung kann das Stimmverbot **nicht** umgehen
+- Gegen das Stimmverbot stimmen verstoesst gegen die Satzung -> Beschluss anfechtbar
+
+## 8) Bei Class-Shares
+
+### Sondervetorechte als Stimmverpflichtungs-Spiegel
+
+- Wenn Class A Sondervetorechte hat (Satzung)
+- Im SHA wird die Ausuebung des Vetorechts an objektive Kriterien gebunden („Veto nur bei wesentlicher Verwaesserung")
+- Bindet die Class-A-Inhaber im Innenverhaeltnis
+
+## 9) Praktische Empfehlung
+
+- **Immer Stimmverpflichtungs-Klausel** im SHA aufnehmen — wo Inhalt der Satzung im Innenverhaeltnis prazisiert wird
+- **Pönalen substantiell** (mindestens 100.000 EUR) — sonst keine Abschreckung
+- **Joinder-Pflicht** bei jedem Anteilsuebergang
+- **Synchronisation** Satzung-SHA bei jeder Aenderung
+- **Stimmverbot Paragraf 47 IV GmbHG** beachten
+
+## Anschluss
+
+- `gesellschaftsgruender-gesellschaftervereinbarung` — SHA-Grundklauseln
+- `gesellschaftsgruender-share-classes-a-b-c` — Class-Korrespondenz
+- `gesellschaftsgruender-golden-share-und-vetorechte` — Golden Share
+- `gesellschaftsgruender-gesellschafterstreit-eilantraege` — Konfliktfall

--- a/gesellschaftsgruender/skills/gesellschaftsgruender-share-classes-a-b-c/SKILL.md
+++ b/gesellschaftsgruender/skills/gesellschaftsgruender-share-classes-a-b-c/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: gesellschaftsgruender-share-classes-a-b-c
+description: "Anteilsklassen A B C Common Stock Vorzugsanteile. Stimmrechts-Multiplikatoren Liquidation Preference per Class. Anti-Dilution per Class. Convertible Notes Wandlung in Anteile. Wann schon bei Gruendung wann erst spaeter. Satzungs-Klauseln fuer Class-Shares. Class-Streit Mehrheits-Schutz Minderheits-Schutz."
+---
+
+# Anteilsklassen A / B / C / Common
+
+## Zweck
+
+Bei Investor-Beteiligung werden typisch **Vorzugsanteile** (A, B, C, ...) eingefuehrt, die gegenueber den Gruender-Anteilen (Common) bestimmte Bevorzugungen geniessen: Stimmrechts-Vorrang, Liquidation Preference, Anti-Dilution, Sondervetorechte. Dieser Skill behandelt Konzept und Satzungs-Gestaltung.
+
+## 1) Klassen-Begriffe
+
+### Common Shares (Stammanteile)
+
+- Standard-Anteile der Gruender
+- Stimmrecht 1:1 (typisch)
+- Keine Liquidation Preference
+- Volle Bezugsrechte
+
+### Class A (Series A Preferred)
+
+- Erste externe Finanzierungsrunde
+- Liquidation Preference 1x non-participating Standard
+- Anti-Dilution (weighted average broad-based Standard)
+- Sondervetorechte fuer Investor
+
+### Class B (Series B Preferred)
+
+- Zweite Runde
+- Hoehere Bewertung
+- Praeferenz vor Class A (typisch), aber individuell verhandelt
+- Manchmal hoehere Liquidation Preference (1,5x oder 2x)
+
+### Class C und folgende
+
+- Spaetere Runden
+- Praeferenz-Stack: C vor B vor A vor Common
+
+### Stimmrechts-Klassen
+
+- Stimmrecht kann von wirtschaftlichem Anteil abweichen
+- Bei Mehrstimmrecht: Investor stimmt staerker als Quote
+- Bei Stimmrechtslosen Anteilen: nur Gewinn-Anteil, kein Stimmrecht (untypisch bei GmbH; bei AG ueblich)
+
+## 2) Wann schon bei Gruendung Class-Shares
+
+### Argumente dafuer
+
+- Bei absehbarem Investor: Vorbereitung
+- Bei Familien-/Holding-Strukturen mit Beirat-Praerogativen
+- Bei Mitarbeiter-Beteiligung mit Stimmrechts-Schutz
+
+### Argumente dagegen
+
+- Satzung wird komplexer, teurer beim Notar
+- Bei Solo-/Paar-Gruendung meist nicht erforderlich
+- Class-Shares spaeter durch Satzungsaenderung einfuehrbar
+
+### Empfehlung
+
+- **Solo-/Paar-Gruendung**: erst eine Klasse (Common). Class-Shares mit Investor einfuehren.
+- **Mehrgruender mit klarer Investor-Roadmap**: schon Class-Konzept in Satzung anlegen, auch wenn anfaenglich alle Common haben.
+- **Family-Office**: Class-Shares fuer Stimmrechts-Differenzierung sinnvoll.
+
+## 3) Pflicht-Satzungs-Klauseln bei Class-Shares
+
+### Klassen-Bezeichnung
+
+```
+Die Geschaeftsanteile der Gesellschaft werden in
+folgende Klassen unterteilt:
+- Class Common: Stammanteile der Gruender, Stimmrecht 1:1
+- Class A: Vorzugsanteile, Stimmrecht 1:1, Liquidation Preference 1x non-participating
+- Class B: Vorzugsanteile, Stimmrecht 1,2:1 (1 Anteil = 1,2 Stimmen),
+  Liquidation Preference 1,5x participating
+```
+
+### Stimmrechts-Klauseln
+
+```
+Bei Abstimmungen in der Gesellschafterversammlung
+gewaehren die Anteile der Class B je 1,2 Stimmen,
+alle anderen Klassen je 1 Stimme. Bei Beschluessen
+zu Aenderungen der Class-B-Rechte ist ein
+zusaetzlicher Mehrheitsbeschluss der Class-B-Inhaber
+mit einfacher Mehrheit erforderlich.
+```
+
+### Liquidation-Preference-Klausel
+
+```
+Bei Aufloesung der Gesellschaft, beim Exit (Trade Sale,
+Asset Sale, Liquidation) erhalten zunaechst die
+Inhaber der Class B Anteile ihren Erstausgabe-Preis
+multipliziert mit 1,5 (Liquidation Preference)
+zurueck. Danach werden die Inhaber der Class A
+Anteile mit ihrem Erstausgabe-Preis zurueckgegeben.
+Restbetrag wird anteilig auf alle Klassen verteilt.
+Bei Class B besteht zudem ein anteiliger Anspruch am
+Restbetrag (participating).
+```
+
+### Anti-Dilution-Klausel
+
+```
+Bei Kapitalerhoehungen mit Ausgabepreis unterhalb
+des Erstausgabe-Preises der Class A Anteile wird
+der Bezugspreis der Class A nachtraeglich nach der
+weighted-average-broad-based-Methode angepasst.
+```
+
+### Sondervetorechte
+
+```
+Folgende Beschluesse beduerfen der Zustimmung der
+Inhaber der Class A Anteile mit einfacher Mehrheit:
+1. Aenderung des Geschaeftsgegenstands
+2. Verkauf oder Verpfaendung wesentlicher Aktiva
+3. Aufnahme neuer Investoren mit gleichen oder
+   bessern Rechten als Class A
+4. Restrukturierung nach StaRUG oder Insolvenzantrag
+```
+
+## 4) Convertible Notes (Wandeldarlehen) -> Anteile
+
+### Konzept
+
+- Investor gibt Darlehen
+- Bei naechster Finanzierungsrunde wandelt sich Darlehen in Anteile der dann eingefuehrten Class
+- Bewertungs-Discount typisch 15-25 %
+- Bewertungs-Cap als Schutz
+
+### Vorteile
+
+- Schnelle Investment-Phase (kein langwieriger Notar-Termin)
+- Bewertung wird auf naechste Runde verschoben
+
+### Nachteile
+
+- Komplexe Wandlungs-Klauseln
+- Pflicht-Termin Notar bei Wandlung
+
+### Bei der Gesellschaftsgruendung
+
+Wandeldarlehen werden in **separatem Vertrag** (Convertible Loan Agreement) ausserhalb der Satzung geregelt — Satzung muss aber **genehmigtes Kapital** vorsehen, damit Wandlung ohne Satzungsaenderung erfolgen kann -> `gesellschaftsgruender-genehmigtes-kapital`.
+
+## 5) Mehrheits-/Minderheits-Schutz durch Klassen
+
+### Mehrheit der Common-Gruender (51-99 %)
+
+- Standard-Mehrheit fuer Geschaeftsfuehrer-Bestellung etc.
+- 75 %-Mehrheit fuer Satzungsaenderungen
+
+### Investor-Minderheit (20-30 % A)
+
+- Sondervetorecht ueber Class-A-Stimmen
+- Praktisch: Schutz vor Wertvernichtung durch Common-Mehrheit
+
+### Class-Class-Streit
+
+- Kann zu Patt-Situation fuehren
+- Loesungs-Mechanismen: Schlichtung, Beirat, Schiedsklauseln, ggf. Andienungsrechte
+
+## 6) Praktische Stoplsteine
+
+1. **Class-Bezeichnungen nicht eindeutig**: „Vorzugsanteile" reicht nicht; klar als „Class A" benennen.
+2. **Liquidation Preference doppelt im Stack**: Bei mehreren Klassen klar regeln, welche zuerst.
+3. **Stimmrechts-Multiplikator zu hoch**: Bei AG max. 1:1 (Paragraf 12 II AktG); bei GmbH zulaessig, aber praktisch problematisch jenseits 1:2.
+4. **Anti-Dilution full ratchet**: Bei Down Round wird Investor zu schmerzhaft viel kompensiert.
+5. **Sondervetorechte ueberzogen**: Wenn Investor 20 % haelt, aber 30 % der Themen vetorechtlich verlangt -> Lahmung der Gesellschaft.
+
+## 7) Bei der Notar-Sitzung
+
+- Klassen-Definitionen in der Satzung formuliert
+- Erstausgabe-Preise pro Klasse fixiert
+- Anteilsnummern eindeutig vergeben
+- Gesellschafterliste reflektiert Klassen-Struktur
+
+## Anschluss
+
+- `gesellschaftsgruender-cap-table` — Klassen-Verteilung
+- `gesellschaftsgruender-gesellschaftervereinbarung` — SHA-Klauseln je Klasse
+- `gesellschaftsgruender-genehmigtes-kapital` — fuer spaetere Wandlung
+- `gesellschaftsgruender-golden-share-und-vetorechte` — bei Golden Share

--- a/gesellschaftsgruender/skills/gesellschaftsgruender-stammkapitalverlust-paragraf-49-gmbhg/SKILL.md
+++ b/gesellschaftsgruender/skills/gesellschaftsgruender-stammkapitalverlust-paragraf-49-gmbhg/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: gesellschaftsgruender-stammkapitalverlust-paragraf-49-gmbhg
+description: "Pflichtversammlung bei Verlust der Haelfte des Stammkapitals Paragraf 49 III GmbHG. Aufzeigen der Lage Mass nahmen Vorschlaege Reaktionspflicht. Anzeigepflicht im Verlustfall. Insolvenzantragspflicht Paragraf 15a InsO bei Zahlungsunfaehigkeit oder Ueberschuldung. Geschaeftsfuehrer-Haftung. Schnittstelle zu StaRUG."
+---
+
+# Pflichtversammlung bei Stammkapital-Verlust (Paragraf 49 III GmbHG)
+
+## Zweck
+
+Wenn die Bilanz zeigt, dass das **Stammkapital zur Haelfte aufgebraucht** ist, muss die Geschaeftsfuehrung **unverzueglich** die Gesellschafterversammlung einberufen (Paragraf 49 III GmbHG). Pflicht zur Information und Beratung der Gesellschafter — Verstoss kann Haftung und Strafbarkeit ausloesen.
+
+## 1) Voraussetzungen
+
+### Verlust der Haelfte des Stammkapitals
+
+- Stammkapital z.B. 25.000 EUR -> Eigenkapital unter 12.500 EUR
+- Pruefung anhand der **Zwischen- oder Jahresbilanz** zu Verkehrswerten
+- **Stille Reserven** werden beruecksichtigt
+- **Pensionsverbindlichkeiten** und stille Lasten werden abgezogen
+
+### Pflicht zur Erkenntnis
+
+- Geschaeftsfuehrer hat Pflicht zu **laufender Liquiditaets- und Eigenkapital-Beobachtung**
+- Bei Anhaltspunkten: Zwischen-Bilanz erstellen
+
+## 2) Pflichten der Geschaeftsfuehrung
+
+### Unverzueglich
+
+- **Einberufung der Gesellschafterversammlung** (Paragraf 49 III GmbHG)
+- **Information** der Gesellschafter ueber die Lage
+- **Vorschlaege fuer Massnahmen** (Sanierung, Kapitalerhoehung, Restrukturierung)
+
+### Frist
+
+- „Unverzueglich" Paragraf 121 BGB
+- In Praxis: binnen 1-2 Wochen nach Erkenntnis
+
+### Form
+
+- Standard-Einladung Paragraf 51 GmbHG
+- **Tagesordnung explizit**: „Beratung ueber die Lage der Gesellschaft (Paragraf 49 III GmbHG)"
+
+## 3) Tagesordnungs-Vorschlag
+
+```
+1. Begruessung, Beschlussfaehigkeit, Versammlungsleiter
+2. Bericht der Geschaeftsfuehrung ueber den
+   Stammkapital-Verlust gemaess Paragraf 49 III GmbHG
+   - Bilanz-Auszug (vor/nach Bewertung)
+   - Ursachen des Verlustes
+3. Beratung ueber Massnahmen
+   - Variante A: Kapitalerhoehung
+   - Variante B: Sanierungs-Massnahmen ohne KE
+   - Variante C: Antrag StaRUG-Restrukturierungs-
+     verfahren (Paragraf 31 StaRUG)
+4. Beschluesse zu Massnahmen
+5. Sonstiges
+```
+
+## 4) Pruefung Zahlungsunfaehigkeit / Ueberschuldung Paragraf 15a InsO
+
+### Pflicht
+
+Bei Erkenntnis des Stammkapital-Verlustes hat GF auch zu pruefen:
+
+- **Zahlungsunfaehigkeit** Paragraf 17 InsO: ist die Gesellschaft nicht mehr in der Lage, faellige Verbindlichkeiten zu erfuellen?
+- **Ueberschuldung** Paragraf 19 InsO: liegen die Verbindlichkeiten ueber den verwertbaren Aktiva?
+
+### Falls ja
+
+- **Antragspflicht** binnen **3 Wochen** (Paragraf 15a I InsO)
+- **Strafbarkeit** Paragraf 15a IV InsO bei Versaeumnis
+- Pflicht trifft GF persoenlich
+
+### Pruefung
+
+- Insolvenz-Berater oder Wirtschaftspruefer zu Rate ziehen
+- Fortbestehensprognose pruefen (Paragraf 19 II InsO)
+- Bei positiver Fortbestehensprognose: keine Ueberschuldung im rechtlichen Sinne
+
+→ `fortbestehensprognose` (vorhandenes Plugin)
+
+## 5) Massnahmen-Optionen
+
+### A. Kapitalerhoehung
+
+- Einbringung weiterer Mittel durch Gesellschafter oder neuen Investor
+- Notar-Beurkundung (Paragraf 55 GmbHG)
+- Anmeldung beim Handelsregister
+
+→ `gesellschaftsgruender-kapitalerhoehung-bezugsrecht`
+
+### B. Sanierungs-Massnahmen
+
+- Forderungsverzicht von Gesellschafter-Darlehen
+- Sanierungs-Kredit
+- Verkauf nicht-betriebsnotwendiger Vermoegens
+- Personalkosten-Senkung
+
+### C. StaRUG-Restrukturierung
+
+- Antrag auf Restrukturierungs-Verfahren Paragraf 31 StaRUG
+- Stabilisierungs-Anordnung Paragraf 49 StaRUG
+- Eigenverwaltung mit Aufsicht des Restrukturierungs-Gerichts
+- Bei Golden Share / Vetorecht: Zustimmungs-Pflicht beachten
+
+→ `krisenfrueherkennung-starug`
+
+### D. Insolvenzantrag
+
+- Wenn Insolvenz-Reife
+- Paragraf 15a InsO Pflicht
+- Strafbar bei Versaeumnis
+
+→ `fortbestehensprognose`, `insolvenzplan-starug-planwerkstatt`
+
+## 6) Geschaeftsfuehrer-Haftung bei Versaeumnis
+
+### Paragraf 49 III GmbHG-Verletzung
+
+- Haftung gegenueber Gesellschaft Paragraf 43 GmbHG
+- Schadensersatz fuer entstandene Schaeden durch verspaetete Reaktion
+
+### Paragraf 15a InsO-Verletzung
+
+- Haftung fuer **Zahlungen nach Insolvenzreife** Paragraf 64 GmbHG (gegenueber Gesellschaft, Erstattungsanspruch)
+- **Persoenliche Haftung gegenueber Glaeubigern** fuer Schaeden durch verspaetete Insolvenzantragstellung Paragraf 823 II BGB iVm Paragraf 15a InsO
+- **Strafbarkeit** Paragraf 15a IV InsO Freiheitsstrafe bis 3 Jahre
+
+## 7) Anzeigepflicht im Insolvenzfall
+
+### Pflicht-Anzeigen
+
+- Insolvenzgericht: Antrag
+- Krankenkassen: Beitrags-Auszahlung
+- Banken: bei laufenden Konten
+- Berufsgenossenschaft
+- Finanzamt
+- Mitarbeiter: vertraglich abgesichert (typisch Insolvenzgeld)
+
+### Mit Insolvenzverwalter
+
+- Geschaeftsfuehrer-Befugnisse gehen ueber auf Insolvenzverwalter
+- Datenzugang fuer Aufklaerung
+
+## 8) Beispiel-Bericht der Geschaeftsfuehrung
+
+```
+Bericht zur Lage der Gesellschaft
+gemaess Paragraf 49 III GmbHG
+
+Bilanz-Auszug zum [Datum]:
+Aktiva:       250.000 EUR
+Passiva:      ./. 245.000 EUR
+Eigenkapital:    5.000 EUR
+
+Stammkapital:   25.000 EUR
+Verlust:        20.000 EUR (= 80 %)
+-> Mehr als die Haelfte des Stammkapitals
+   ist aufgebraucht.
+
+Ursachen:
+- Auftrags-Ausfall Kunde X (90.000 EUR Umsatz-Lücke)
+- Verzoegerter Geldeingang Kunde Y
+- Hoehere Personalkosten als geplant
+
+Liquiditaets-Status: angespannt
+- Cash on Hand: 12.000 EUR
+- Faellige Verbindlichkeiten naechste 14 Tage: 35.000 EUR
+- Erwartete Zahlungseingaenge: 28.000 EUR
+
+Zahlungsunfaehigkeit Paragraf 17 InsO:
+Pruefung erforderlich. Bei prognostiziertem Defizit
+in den naechsten 14 Tagen besteht Risiko.
+
+Ueberschuldung Paragraf 19 InsO:
+Pruefung erforderlich. Bei stillen Reserven (z.B.
+Markenwert, Patenten) ggf. nicht. Aktuell aber
+keine objektivierten stillen Reserven.
+
+Fortbestehensprognose:
+Auf Basis erwarteter Aufträge im naechsten Quartal
+... [Begruendung]
+
+Empfehlungen der Geschaeftsfuehrung:
+[A / B / C / D — siehe oben]
+```
+
+## 9) Streit-Konstellation: Welche Massnahme
+
+### Investor lehnt KE ab
+
+- KE bedeutet Verwaesserung oder Mehrkosten
+- Investor verlangt stattdessen StaRUG -> Restrukturierung mit Glaeubigerbeteiligung
+- Gruender wollen KE -> Streit
+
+### Gruender mit Class C lehnen StaRUG ab
+
+- Wenn Golden Share mit Restrukturierungs-Vetorecht
+- StaRUG nicht moeglich
+- KE oder Insolvenz als Ausweg
+
+→ `gesellschaftsgruender-gesellschafterstreit-eilantraege`
+
+## 10) Praktische Empfehlung
+
+- **Monatliche Liquiditaets-Beobachtung** (Cash-Bestand, Faelligkeiten, Erwartungen)
+- **Quartalsweise Bilanz-Auszug** mit EK-Pruefung
+- **Bei Anzeichen**: zwischen-Bilanz, Beratung Steuerberater + Insolvenz-Experte
+- **Bei Erkenntnis Paragraf 49 III GmbHG**: sofort GV einberufen
+- **Bei Insolvenzreife**: Paragraf 15a InsO innerhalb 3 Wochen — keine Zeit verlieren
+
+## Anschluss
+
+- `fortbestehensprognose` — bei Pruefung Ueberschuldung
+- `krisenfrueherkennung-starug` — bei Restrukturierungs-Option
+- `gesellschaftsgruender-kapitalerhoehung-bezugsrecht` — bei KE
+- `gesellschaftsgruender-gesellschafterstreit-eilantraege` — bei Streit ueber Massnahme

--- a/testakten/gesellschaftsgruender-streit-roeschen-tech/01_Satzung_Roeschen_Tech_GmbH.md
+++ b/testakten/gesellschaftsgruender-streit-roeschen-tech/01_Satzung_Roeschen_Tech_GmbH.md
@@ -1,0 +1,174 @@
+# Satzung der Roeschen Tech GmbH
+
+**Stand: 15.11.2025 — nach Series A**
+
+---
+
+## § 1 Firma, Sitz, Geschaeftsjahr
+
+(1) Die Gesellschaft fuehrt die Firma „**Roeschen Tech GmbH**".
+
+(2) Sitz der Gesellschaft ist Berlin.
+
+(3) Geschaeftsjahr ist das Kalenderjahr. Das erste Geschaeftsjahr ist ein Rumpfgeschaeftsjahr und endet am 31. Dezember 2024.
+
+---
+
+## § 2 Gegenstand des Unternehmens
+
+(1) Gegenstand des Unternehmens ist die Entwicklung, der Vertrieb und die Lizenzierung von Software-Produkten unter Einsatz von Methoden der Kuenstlichen Intelligenz, insbesondere im Bereich der Bild- und Sprach-Verarbeitung, sowie die Beratung und Schulung in diesen Bereichen.
+
+(2) Die Gesellschaft kann andere Unternehmen gruenden, sich an ihnen beteiligen, Zweigniederlassungen errichten und alle Geschaefte vornehmen, die diesem Unternehmensgegenstand foerderlich sind.
+
+---
+
+## § 3 Stammkapital und Geschaeftsanteile
+
+(1) Das Stammkapital der Gesellschaft betraegt **40.000,00 EUR** (in Worten: vierzigtausend Euro).
+
+(2) Es ist eingeteilt in 40.000 Geschaeftsanteile zu je 1,00 EUR Nennwert, gegliedert in folgende Klassen:
+
+| Klasse | Anteile | Nennwert | Bezeichnung |
+|---|---|---|---|
+| **Class Common** | 30.000 | 30.000 EUR | Stammanteile der Gruender |
+| **Class B** | 10.000 | 10.000 EUR | Vorzugsanteile Series A |
+
+(3) Vom Stammkapital halten:
+
+| Gesellschafter | Klasse | Anteile | % |
+|---|---|---|---|
+| Andrea Roesener | Common | 12.000 | 30 % |
+| Bert Schmid | Common | 12.000 | 30 % |
+| Christine Linnenbach | Common | 6.000 | 15 % |
+| Stahlauge Ventures AG | B | 10.000 | 25 % |
+
+(4) Die Stammeinlage ist von den Gesellschaftern in vollem Umfang in bar erbracht.
+
+---
+
+## § 4 Genehmigtes Kapital
+
+(1) Die Geschaeftsfuehrer sind ermaechtigt, das Stammkapital der Gesellschaft bis zum **30.11.2030** um insgesamt bis zu **20.000,00 EUR** (in Worten: zwanzigtausend Euro) durch Ausgabe neuer Geschaeftsanteile gegen Bareinlage oder Sacheinlage zu erhoehen (genehmigtes Kapital).
+
+(2) Die neuen Anteile koennen als Class Common, Class B oder Class C ausgegeben werden.
+
+(3) Die Geschaeftsfuehrer sind ermaechtigt, das Bezugsrecht der Gesellschafter mit Zustimmung der Gesellschafterversammlung mit einer Mehrheit von 75 % ganz oder teilweise auszuschliessen.
+
+(4) Naehere Bedingungen jeder Ausgabe werden durch die Gesellschafterversammlung mit einfacher Mehrheit beschlossen.
+
+---
+
+## § 5 Sondervetorechte der Class B
+
+(1) Folgende Beschluesse beduerfen zusaetzlich zu den allgemeinen Mehrheits-Erfordernissen der Zustimmung der Inhaberin der Class B mit einfacher Mehrheit der Class-B-Stimmen:
+
+a) Aenderung der Satzung,
+b) Veraeusserung wesentlicher Aktiva (Schwelle: 25 % der Bilanzsumme),
+c) Aufnahme weiterer Investoren mit Rechten, die den Class-B-Rechten gleichwertig oder ueberlegen sind,
+d) Antrag auf Restrukturierungsverfahren nach StaRUG (Paragraf 31 StaRUG),
+e) Antrag auf Eroeffnung eines Insolvenzverfahrens (Paragraf 15a InsO bleibt unberuehrt — die GF-Antragspflicht bei Insolvenzreife entfaellt nicht),
+f) Aufloesung der Gesellschaft.
+
+(2) Das Sondervetorecht erlischt, wenn die Class-B-Anteilshoehe unter 10 % des Stammkapitals faellt.
+
+---
+
+## § 6 Liquidationsvorrang (Liquidation Preference)
+
+(1) Bei Aufloesung der Gesellschaft, beim Exit (Trade Sale, Asset Sale, Liquidation, IPO) erhalten zunaechst die Inhaberin der Class B Anteile ihre **Erstausgabe-Investment** multipliziert mit **1,5** zurueck (1,5x Liquidation Preference).
+
+(2) Der nach Bedienung der Praeferenz verbleibende Betrag wird auf alle Klassen anteilig (pro rata zur Anteilshoehe) verteilt.
+
+(3) Die Inhaberin der Class B Anteile haben zusaetzlich Anspruch auf anteilige Beteiligung am Restbetrag (participating Liquidation Preference).
+
+---
+
+## § 7 Anti-Dilution-Schutz
+
+(1) Bei Kapitalerhoehungen unter Ausgabe neuer Anteile mit einem Ausgabepreis (Nennwert plus Aufgeld) **unterhalb** des Class-B-Ausgabepreises (10 EUR pro Anteil) wird die Anzahl der Class B Anteile nach der **weighted-average-broad-based**-Methode angepasst.
+
+(2) Die Anpassung erfolgt automatisch mit Eintragung der Kapitalerhoehung im Handelsregister.
+
+---
+
+## § 8 Geschaeftsfuehrung und Vertretung
+
+(1) Die Gesellschaft hat einen oder mehrere Geschaeftsfuehrer. Hat sie nur einen Geschaeftsfuehrer, vertritt er die Gesellschaft allein. Hat sie mehrere Geschaeftsfuehrer, wird sie durch zwei Geschaeftsfuehrer gemeinschaftlich oder durch einen Geschaeftsfuehrer in Gemeinschaft mit einem Prokuristen vertreten.
+
+(2) Den Geschaeftsfuehrern kann durch Gesellschafterbeschluss Einzelvertretungsmacht und Befreiung von den Beschraenkungen des Paragraf 181 BGB erteilt werden.
+
+(3) Die Geschaeftsfuehrer werden durch die Gesellschafterversammlung mit einfacher Mehrheit bestellt und abberufen.
+
+---
+
+## § 9 Vinkulierung
+
+(1) Die Uebertragung von Geschaeftsanteilen, die Belastung mit Niessbrauch oder Pfandrecht sowie die Verfuegung ueber Teile von Anteilen beduerfen zu ihrer Wirksamkeit der vorherigen Zustimmung der Gesellschafterversammlung mit einer Mehrheit von 75 % der abgegebenen Stimmen.
+
+(2) Die Zustimmung wird nur erteilt, wenn der Erwerber dem aktuell geltenden Shareholder Agreement beitritt (Joinder Agreement).
+
+---
+
+## § 10 Einziehung
+
+Die Einziehung von Geschaeftsanteilen ist zulaessig:
+
+a) mit Zustimmung des betroffenen Gesellschafters,
+b) ohne Zustimmung, wenn ueber sein Vermoegen ein Insolvenzverfahren eroeffnet wird oder dies mangels Masse abgelehnt wird,
+c) ohne Zustimmung bei schwerer und wiederholter Pflichtverletzung trotz schriftlicher Abmahnung.
+
+---
+
+## § 11 Gesellschafterversammlung
+
+(1) Die Gesellschafterversammlung wird durch die Geschaeftsfuehrer einberufen. Die Einladung erfolgt schriftlich (oder elektronisch nach gesonderter Zustimmung des Gesellschafters) unter Beifuegung der Tagesordnung mit einer Frist von mindestens **drei Wochen** zwischen Versand und Versammlungs-Termin.
+
+(2) Bei besonderer Eilbeduerftigkeit kann die Frist auf eine Woche verkuerzt werden.
+
+(3) Die Gesellschafterversammlung ist beschlussfaehig, wenn mehr als die Haelfte des Stammkapitals vertreten ist.
+
+(4) Beschluesse werden mit einfacher Mehrheit der abgegebenen Stimmen gefasst, soweit Gesetz oder Satzung nicht etwas anderes vorsehen.
+
+(5) Folgende Beschluesse beduerfen einer Mehrheit von 75 % der abgegebenen Stimmen:
+
+a) Satzungsaenderung,
+b) Kapitalerhoehung und Kapitalherabsetzung,
+c) Bezugsrechtsausschluss bei Kapitalerhoehung,
+d) Aufloesung der Gesellschaft.
+
+---
+
+## § 12 Geschaeftsordnung und Beirat
+
+(1) Die Gesellschaft hat einen Beirat. Er besteht aus 3 Mitgliedern.
+
+(2) Die Mitglieder des Beirats werden von der Gesellschafterversammlung mit einfacher Mehrheit fuer eine Amtszeit von 2 Jahren bestellt. Erneut-Bestellung ist zulaessig.
+
+(3) Der Beirat hat folgende Aufgaben:
+
+a) Beratung der Geschaeftsfuehrung in strategischen Fragen,
+b) Pruefung des Jahresabschlusses vor Vorlage in der Gesellschafterversammlung,
+c) **Schlichtung bei Konflikten zwischen Gesellschaftern** vor Klageerhebung,
+d) Empfehlungen zu Investitionen ueber 250.000 EUR.
+
+(4) Die naeheren Bestimmungen folgen aus der Beiratsordnung.
+
+---
+
+## § 13 Schlussbestimmungen
+
+(1) Diese Satzung ist in deutscher Sprache verbindlich. Eine englische Uebersetzung wird als Anlage gefuehrt; bei Inkonsistenzen geht die deutsche Fassung vor.
+
+(2) Bekanntmachungen der Gesellschaft erfolgen ausschliesslich im Bundesanzeiger.
+
+(3) Aenderungen dieser Satzung beduerfen einer Mehrheit von 75 % der abgegebenen Stimmen sowie der Zustimmung der Inhaberin der Class B gemaess § 5.
+
+---
+
+Berlin, den 15.11.2025
+
+Gegruendet beurkundet vor Notar Dr. Wolfgang Sturm, Berlin, Az. UR-Nr. 1245/2025
+
+---
+
+*Diese Satzung ist eine fiktive Schulungsvorlage. Alle Personen und Firmen sind frei erfunden.*

--- a/testakten/gesellschaftsgruender-streit-roeschen-tech/02_Shareholder_Agreement.md
+++ b/testakten/gesellschaftsgruender-streit-roeschen-tech/02_Shareholder_Agreement.md
@@ -1,0 +1,194 @@
+# Shareholder Agreement (Gesellschaftervereinbarung)
+
+**Roeschen Tech GmbH**
+
+**Datum: 15.11.2025**
+
+---
+
+## Parteien
+
+1. Frau **Andrea Roesener**, geb. 12.05.1988, wohnhaft Pappelallee 23, 10437 Berlin — („Andrea")
+
+2. Herr **Bert Schmid**, geb. 03.09.1985, wohnhaft Schoenhauser Allee 144, 10437 Berlin — („Bert")
+
+3. Frau **Christine Linnenbach**, geb. 21.11.1991, wohnhaft Greifswalder Strasse 78, 10405 Berlin — („Christine")
+
+4. **Stahlauge Ventures AG**, eingetragen im HR Muenchen unter HRB 234567, vertreten durch ihren Vorstand Dr. Felix Stahlauge — („Stahlauge")
+
+(Andrea, Bert, Christine zusammen „Gruender"; Stahlauge ist „Investor"; Gruender und Investor zusammen „Gesellschafter".)
+
+---
+
+## Praeambel
+
+Die Gesellschafter sind die Gesellschafter der Roeschen Tech GmbH („Gesellschaft"). Im Zuge der Series-A-Finanzierung vom 15.11.2025 wurden zur Class B 10.000 neue Geschaeftsanteile mit Investment-Volumen 5.000.000 EUR (Pre-Money 15 Mio., Post-Money 20 Mio.) ausgegeben. Stahlauge zeichnete saemtliche Class B Anteile.
+
+Die Gesellschafter regeln in dieser Vereinbarung ihre Beziehungen ueber die Satzung hinaus.
+
+---
+
+## § 1 Vesting
+
+(1) Die Anteile der Gruender unterliegen einem Vesting wie folgt:
+
+- **Vesting-Periode**: 4 Jahre ab dem 1. Maerz 2024 (Gruendung)
+- **Cliff-Periode**: 12 Monate (bis 28. Februar 2025); bei Ausscheiden vor Ablauf des Cliff vesten 0 Anteile
+- Nach Ablauf des Cliff vesten **25 % der Gruender-Anteile**
+- Danach **monatlich 1/48** der Gruender-Anteile zusaetzlich
+- Nach 48 Monaten vested: 100 %
+
+(2) Vested-Stand am 18.06.2026: ca. 33/48 = 68,75 % der Gruender-Anteile sind vested (gerundet).
+
+---
+
+## § 2 Leaver-Bestimmungen
+
+### Good Leaver
+
+(1) Ein Gruender ist „Good Leaver", wenn er aus folgenden Gruenden ausscheidet:
+
+a) Tod oder dauerhafte Erwerbsunfaehigkeit,
+b) Aufhebungs-/Renten-Eintritt im Einvernehmen,
+c) Kuendigung durch die Gesellschaft ohne wichtigen Grund,
+d) Eigene Kuendigung nach mehr als 4 Jahren Taetigkeit.
+
+(2) Ein Good Leaver behaelt seine bis dahin vested Anteile. Nicht-vested Anteile werden zum Verkehrswert zurueckgekauft.
+
+### Bad Leaver
+
+(3) Ein Gruender ist „Bad Leaver", wenn er aus folgenden Gruenden ausscheidet:
+
+a) Eigene Kuendigung vor 4 Jahren ohne wichtigen Grund,
+b) Schwerwiegende und wiederholte Pflichtverletzung trotz Abmahnung,
+c) Verstoss gegen Wettbewerbsverbot waehrend Beteiligung,
+d) Veraeusserung von Anteilen ohne Zustimmung (Verstoss gegen Vinkulierung).
+
+(4) Ein Bad Leaver verliert non-vested Anteile zum **Nennwert**. Vested Anteile werden zum **75 % des Verkehrswertes** zurueckgekauft.
+
+---
+
+## § 3 Vorkaufsrechte
+
+(1) Bei beabsichtigter Veraeusserung von Anteilen an einen Dritten haben die uebrigen Gesellschafter ein Vorkaufsrecht.
+
+(2) Der veraeusserungswillige Gesellschafter teilt den uebrigen Gesellschaftern das Dritt-Angebot mit. Die uebrigen Gesellschafter haben innerhalb von **30 Tagen** das Recht, anteilig zu denselben Bedingungen zu erwerben.
+
+---
+
+## § 4 Drag-Along
+
+(1) Stimmen Gesellschafter, die zusammen mehr als **75 % der Stimmrechte** halten, einem Verkauf saemtlicher Anteile an der Gesellschaft an einen Dritten zu, koennen sie die uebrigen Gesellschafter verpflichten, ihre Anteile zu denselben Bedingungen mitzuveraeussern (Drag-Along-Obligation).
+
+(2) Die Drag-Along-Obligation gilt nur, wenn:
+
+a) der Verkaufspreis pro Anteil gleichbleibend fuer alle Anteilsklassen ist, und
+b) keiner der Gesellschafter durch den Verkauf bewusst benachteiligt wird.
+
+---
+
+## § 5 Tag-Along
+
+(1) Beim Verkauf von mehr als 50 % der Anteile haben die uebrigen Gesellschafter ein **Mitveraeusserungs-Recht** (Tag-Along).
+
+(2) Sie koennen ihre Anteile zu denselben Bedingungen mitveraeussern und werden vom Mehrheits-Verkaeufer gleichbehandelt.
+
+---
+
+## § 6 Stimmverpflichtung (Stimmvertrag)
+
+(1) Die Gesellschafter verpflichten sich, in der Gesellschafterversammlung in einer Art und Weise abzustimmen, dass die Beschluesse, die diesem Shareholder Agreement entsprechen, gefasst werden.
+
+(2) Insbesondere verpflichten sie sich:
+
+a) bei Kapitalerhoehungen ihrer Zustimmung gemaess den Bestimmungen dieser Vereinbarung zu erteilen,
+b) bei Anteilsuebertragungen ihre Zustimmung zu erteilen, soweit der Erwerber dem Shareholder Agreement beitritt,
+c) bei Drag-Along-Beschluessen ihre Zustimmung zur Mitveraeusserung zu erteilen,
+d) **Stahlauge-Sondervetorechte** gemaess § 5 der Satzung zu respektieren.
+
+(3) Bei Verstoss gegen die Stimmverpflichtungen schuldet der verstossende Gesellschafter den anderen Gesellschaftern eine Vertragsstrafe in Hoehe von **500.000 EUR pro Verstoss**. Daneben bleibt der Anspruch auf Schadensersatz unberuehrt.
+
+---
+
+## § 7 Liquidation Preference Waterfall
+
+(1) Bei Exit der Gesellschaft (Trade Sale, IPO, Liquidation):
+
+**Schritt 1**: Stahlauge (Class B) erhaelt 1,5 × 5.000.000 EUR = **7.500.000 EUR** vorab (Liquidation Preference).
+
+**Schritt 2**: Der nach Bedienung der Praeferenz verbleibende Betrag wird **anteilig** auf alle Klassen verteilt (nach Anteilshoehe).
+
+**Schritt 3**: Stahlauge erhaelt zusaetzlich anteiligen Anteil am Restbetrag (participating).
+
+(2) Beispielrechnung: Exit zu 30 Mio. EUR
+
+- Class B erhaelt 7,5 Mio. (Preference)
+- Restbetrag: 22,5 Mio.
+- Anteilig (25 % B, 75 % Common): Class B erhaelt zusaetzlich 5,625 Mio., Common erhaelt 16,875 Mio.
+- Class B gesamt: 13,125 Mio.
+- Common gesamt: 16,875 Mio. (verteilt nach Anteilen: Andrea 6,75, Bert 6,75, Christine 3,375)
+
+---
+
+## § 8 Berichtspflichten gegenueber Investor
+
+(1) Die Gesellschaft uebermittelt Stahlauge folgende Berichte:
+
+a) **Monatlich**: Cash-Burn, Runway, KPIs (binnen 10 Tagen nach Monatsende),
+b) **Quartalsweise**: P&L, Bilanz-Auszug, Plan-Ist-Vergleich,
+c) **Jaehrlich**: Jahresabschluss und Lagebericht (binnen 3 Monaten nach Geschaeftsjahresende).
+
+(2) Bei wesentlichen Ereignissen (Verlust > 20 % der Liquiditaet, Kuendigung Schluessel-Mitarbeiter, drohende Klagen): unverzueglich Mitteilung.
+
+---
+
+## § 9 Wettbewerbsverbot
+
+(1) Die Gruender verpflichten sich, waehrend ihrer Beteiligung und 12 Monate ueber das Ende der Beteiligung hinaus keine konkurrierenden Geschaefte zu betreiben.
+
+(2) Bei Verstoss: Vertragsstrafe 250.000 EUR pro Verstoss.
+
+(3) Bei nachvertraglichem Wettbewerbsverbot: Karenzentschaedigung gemaess separatem Geschaeftsfuehrervertrag.
+
+---
+
+## § 10 Sprache und Vorrang
+
+(1) Diese Vereinbarung wird in deutscher und englischer Sprache abgefasst.
+
+(2) Bei Inkonsistenzen geht die **deutsche** Fassung vor.
+
+---
+
+## § 11 Streit-Beilegung
+
+(1) **Vor Klageerhebung** muss zunaechst der Beirat der Gesellschaft angerufen werden (siehe Beiratsordnung).
+
+(2) Bei Versaeumnis: Anrufung des Beirats kann durch Einrede der Unzulaessigkeit der Klage gefordert werden.
+
+(3) Schiedsklausel: alle Streitigkeiten werden nach der Schiedsgerichtsordnung der DIS (Deutsche Institution fuer Schiedsgerichtsbarkeit) endgueltig entschieden. Schiedsort: Berlin. Schiedssprache: Deutsch.
+
+---
+
+## § 12 Joinder Agreement
+
+Bei jeder Anteilsuebertragung muss der Erwerber dieser Vereinbarung beitreten. Der ausscheidende Gesellschafter wird durch den neuen ersetzt.
+
+---
+
+## § 13 Schlussbestimmungen
+
+(1) Sollte eine Bestimmung dieser Vereinbarung unwirksam sein, bleiben die uebrigen Bestimmungen davon unberuehrt.
+
+(2) Aenderungen dieser Vereinbarung beduerfen der Zustimmung aller Vertragspartner.
+
+---
+
+Berlin, den 15.11.2025
+
+Unterschriften:
+
+_______________ Andrea Roesener
+_______________ Bert Schmid
+_______________ Christine Linnenbach
+_______________ Stahlauge Ventures AG (vertreten durch Vorstand Dr. Felix Stahlauge)

--- a/testakten/gesellschaftsgruender-streit-roeschen-tech/03_Cap_Table_Vor_und_Nach_KE.md
+++ b/testakten/gesellschaftsgruender-streit-roeschen-tech/03_Cap_Table_Vor_und_Nach_KE.md
@@ -1,0 +1,139 @@
+# Cap Table — Roeschen Tech GmbH
+
+## Stand 1 — Bei Gruendung (1. Maerz 2024)
+
+| Gesellschafter | Klasse | Anteile | Nennwert | % | Stimmen | Vesting |
+|---|---|---|---|---|---|---|
+| Andrea Roesener (CEO) | Common | 12.000 | 12.000 EUR | 40 % | 40 % | 0/48 (Cliff bis 28.02.2025) |
+| Bert Schmid (CTO) | Common | 12.000 | 12.000 EUR | 40 % | 40 % | 0/48 (Cliff bis 28.02.2025) |
+| Christine Linnenbach (COO) | Common | 6.000 | 6.000 EUR | 20 % | 20 % | 0/48 (Cliff bis 28.02.2025) |
+| **Gesamt** | | **30.000** | **30.000 EUR** | **100 %** | **100 %** | |
+
+Bewertung: Pre-Money 0 EUR (Gruendung mit reinem Stammkapital), Post-Money 30.000 EUR.
+
+---
+
+## Stand 2 — Nach Series A (15. November 2025)
+
+| Gesellschafter | Klasse | Anteile | Nennwert | % | Stimmen | Vesting | Investment | Liquidation Preference |
+|---|---|---|---|---|---|---|---|---|
+| Andrea Roesener | Common | 12.000 | 12.000 EUR | 30,0 % | 30,0 % | 20/48 vested (~42 %) | - | - |
+| Bert Schmid | Common | 12.000 | 12.000 EUR | 30,0 % | 30,0 % | 20/48 vested | - | - |
+| Christine Linnenbach | Common | 6.000 | 6.000 EUR | 15,0 % | 15,0 % | 20/48 vested | - | - |
+| Stahlauge Ventures AG | **B** | 10.000 | 10.000 EUR | 25,0 % | 25,0 % | - | 5.000.000 EUR (Aufgeld 4.990.000 EUR) | 1,5x participating |
+| **Gesamt** | | **40.000** | **40.000 EUR** | **100,0 %** | **100,0 %** | | | |
+
+### Series A Daten
+
+- Investment-Volumen: 5.000.000 EUR
+- Pre-Money: 15.000.000 EUR
+- Post-Money: 20.000.000 EUR
+- Stahlauge-Anteil: 25 %
+- Verwaesserung Gruender: 100 % -> 75 %
+
+### Verteilung Gruender-Verwaesserung
+
+- Andrea: 40 % -> 30 % (Verwaesserung 25 %)
+- Bert: 40 % -> 30 % (Verwaesserung 25 %)
+- Christine: 20 % -> 15 % (Verwaesserung 25 %)
+
+---
+
+## Stand 3 — Nach geplanter 2. KE (Beschluss 18.06.2026; Eintragung beantragt; Streit anhaengig)
+
+| Gesellschafter | Klasse | Anteile | % | Stimmen | Investment |
+|---|---|---|---|---|---|
+| Andrea Roesener | Common | 12.000 | 23,53 % | 23,53 % | - |
+| Bert Schmid | Common | 12.000 | 23,53 % | 23,53 % | - |
+| Christine Linnenbach | Common | 6.000 | 11,76 % | 11,76 % | - |
+| Stahlauge Ventures AG | B | 10.000 | 19,61 % | 19,61 % | - (anteilig bestehend) |
+| **Pi Mu Holding GmbH** (geplant) | **C** | 12.500 | 24,51 % | 24,51 % | 12.500.000 EUR |
+| **Gesamt** | | **51.000** | **100,00 %** | **100,00 %** | |
+
+### 2. KE Daten
+
+- Kapitalerhoehung: + 12.500 EUR (Pi Mu Holding GmbH zeichnet Class C)
+- Bezugsrechtsausschluss der bestehenden Gesellschafter
+- Investment-Volumen Pi Mu: 12.500.000 EUR (Aufgeld 12.487.500 EUR)
+- Pre-Money: 38.500.000 EUR
+- Post-Money: 51.000.000 EUR
+- Pi Mu-Anteil: 24,51 %
+
+### Verwaesserung Christine
+
+- Stand 2 (Series A): 15 % der Stimmen
+- Stand 3 (Pi Mu): 11,76 % der Stimmen
+
+**Verwaesserung absolut**: 3,24 Prozentpunkte (= 21,6 % relativ)
+
+### Verwaesserung Andrea und Bert
+
+- Je 30 % -> 23,53 % (= 21,6 % relativ)
+
+### Wert-Verlust Christine
+
+- Stand 2: 15 % von 20 Mio. = 3 Mio. EUR Anteilswert
+- Stand 3: 11,76 % von 51 Mio. = 6 Mio. EUR Anteilswert
+
+Im **Buchwert** gewinnt Christine — von 3 Mio. auf 6 Mio. EUR. **Realwirtschaftlich** verliert sie aber **Stimmrechts-Anteil** und damit **Kontroll-Einfluss**.
+
+---
+
+## Stand 4 — Hypothetisch, wenn Bezugsrecht nicht ausgeschlossen (Vergleichs-Szenario)
+
+| Gesellschafter | Klasse | Anteile | % |
+|---|---|---|---|
+| Andrea Roesener | Common | 14.875 | 29,17 % (Bezugsrecht ausgeuebt anteilig) |
+| Bert Schmid | Common | 14.875 | 29,17 % |
+| Christine Linnenbach | Common | 7.438 | 14,58 % |
+| Stahlauge Ventures AG | B | 12.500 | 24,51 % (Bezugsrecht ausgeuebt) |
+| Restbetrag fuer Pi Mu | C | 1.312 | 2,57 % |
+| **Gesamt** | | **51.000** | **100 %** |
+
+In diesem Szenario haetten alle bestehenden Gesellschafter ihre Anteile anteilig durch Bareinlage erhalten koennen, und Pi Mu haette nur den Restbetrag bekommen.
+
+**Kosten fuer Christine**: 15 % × 12,5 Mio. = 1,875 Mio. EUR Bareinlage erforderlich gewesen.
+
+**Streitfrage**: hat Christine wirtschaftlich diese Kapazitaet? Stahlauge und Gruender behaupten, nein.
+
+---
+
+## Liquidation-Waterfall — Beispielrechnungen
+
+### Szenario A: Exit zu 30 Mio. EUR (in 5 Jahren) bei aktuellem Stand 2
+
+- Class B (Stahlauge): 1,5 × 5 Mio. = 7,5 Mio. (Preference)
+- Restbetrag: 22,5 Mio. (anteilig auf Anteile)
+- Andrea (30 %): 6,75 Mio.
+- Bert (30 %): 6,75 Mio.
+- Christine (15 %): 3,375 Mio.
+- Stahlauge zusaetzlich (25 % anteilig, participating): 5,625 Mio.
+- **Stahlauge gesamt: 13,125 Mio.** (= 2,625x Investment)
+- **Andrea gesamt: 6,75 Mio.**
+- **Bert gesamt: 6,75 Mio.**
+- **Christine gesamt: 3,375 Mio.**
+
+### Szenario B: Exit zu 30 Mio. EUR bei Stand 3 (nach 2. KE)
+
+- Class C (Pi Mu, Liquidation Preference noch zu vereinbaren — angenommen 1x non-participating): 12,5 Mio. (Preference)
+- Class B (Stahlauge): 1,5 × 5 Mio. = 7,5 Mio. (Preference)
+- Restbetrag: 30 - 12,5 - 7,5 = 10 Mio.
+- Andrea (23,53 %): 2,353 Mio.
+- Bert (23,53 %): 2,353 Mio.
+- Christine (11,76 %): 1,176 Mio.
+- Stahlauge zusaetzlich (19,61 % participating): 1,961 Mio.
+- Pi Mu zusaetzlich (24,51 % non-participating — keine zusaetzliche Beteiligung): 0
+
+- **Christine gesamt: 1,176 Mio.** (vorher 3,375 Mio. ohne 2. KE)
+
+**Verlust Christine durch 2. KE**: 2,2 Mio. EUR im 30-Mio.-Exit-Szenario.
+
+---
+
+## Streit-Anlass aus Christines Sicht
+
+1. Verwaesserung von 15 % auf 11,76 % (relativ -21,6 %)
+2. Stimmrechts-Verlust unter 12 % -> bei vielen Mehrheits-Schwellen nicht mehr relevant
+3. Im Liquidation-Waterfall: Verlust von 2,2 Mio. EUR in mittleren Exit-Szenarien
+4. Sachliche Rechtfertigung des Bezugsrechtsausschlusses fraglich (Pi Mu bringt **keine** offenkundige strategische Expertise — sondern nur Kapital)
+5. Christine haette anteiliges Bezugsrecht ausueben wollen (zumindest fuer kleineren Betrag) — wurde nicht angefragt

--- a/testakten/gesellschaftsgruender-streit-roeschen-tech/04_Einladung_GV_18-06-2026.md
+++ b/testakten/gesellschaftsgruender-streit-roeschen-tech/04_Einladung_GV_18-06-2026.md
@@ -1,0 +1,105 @@
+# Einladung zur ausserordentlichen Gesellschafterversammlung
+
+**Roeschen Tech GmbH**, Berlin
+Pappelallee 23, 10437 Berlin
+HRB 245.678 B
+
+---
+
+Berlin, den 27. Mai 2026
+
+An die Gesellschafter der Roeschen Tech GmbH:
+- Frau Andrea Roesener, Pappelallee 23, 10437 Berlin
+- Herrn Bert Schmid, Schoenhauser Allee 144, 10437 Berlin
+- Frau Christine Linnenbach, Greifswalder Strasse 78, 10405 Berlin
+- Stahlauge Ventures AG, Theatinerstrasse 15, 80333 Muenchen, vertreten durch Vorstand Dr. Felix Stahlauge
+
+—
+
+## Einladung zur ausserordentlichen Gesellschafterversammlung
+
+Sehr geehrte Damen und Herren,
+
+hiermit lade ich Sie gemaess § 11 der Satzung der Roeschen Tech GmbH und Paragraf 49 GmbHG zur
+
+**ausserordentlichen Gesellschafterversammlung**
+
+am
+
+**Donnerstag, den 18. Juni 2026, 14:00 Uhr**
+
+**Ort**: Geschaeftssitz der Gesellschaft, Pappelallee 23, 10437 Berlin, Konferenzraum 3. OG
+
+ein.
+
+---
+
+## Tagesordnung
+
+### TOP 1 — Begruessung, Feststellung der Beschlussfaehigkeit, Wahl des Versammlungsleiters und Schriftfuehrers
+
+### TOP 2 — Bericht der Geschaeftsfuehrung ueber Investor-Verhandlungen
+
+Bericht ueber die Series-B-Verhandlungen mit der Pi Mu Holding GmbH ueber eine Beteiligung mit Investment-Volumen 12.500.000 EUR auf Basis Pre-Money-Bewertung 38.500.000 EUR.
+
+### TOP 3 — Beschluss ueber die Kapitalerhoehung um 12.500 EUR mit Bezugsrechtsausschluss
+
+**Beschluss-Vorlage**:
+
+„Die Gesellschafterversammlung beschliesst:
+
+a) Das Stammkapital der Gesellschaft wird gemaess § 4 der Satzung aus dem genehmigten Kapital um 12.500 EUR auf 51.000 EUR durch Ausgabe von 12.500 neuen Geschaeftsanteilen der **Class C** im Nennwert von je 1 EUR erhoeht.
+
+b) Das Bezugsrecht der bestehenden Gesellschafter wird gemaess Paragraf 55 IV GmbHG und § 4 (3) der Satzung **vollstaendig ausgeschlossen**.
+
+c) Zur Uebernahme der neuen Class-C-Anteile wird die **Pi Mu Holding GmbH** (eingetragen im HR Frankfurt unter HRB 567.890) ermaechtigt, gegen Bareinlage des Nennwerts plus Aufgeld i.H.v. **999 EUR pro Anteil** (Gesamt-Aufgeld 12.487.500 EUR), zu zeichnen.
+
+d) Die Class C Anteile werden mit folgenden Rechten ausgestattet:
+   - 1x non-participating Liquidation Preference
+   - Stimmrecht 1:1
+   - Anti-Dilution: broad-based weighted average
+   - Sondervetorecht bei Aenderung der Satzung
+   - Sondervetorecht bei Aufnahme weiterer Investoren
+
+e) Die naeheren Bedingungen folgen aus dem **Subscription Agreement** zwischen der Gesellschaft und Pi Mu Holding GmbH vom 25. Mai 2026 (Anlage zur Einladung).
+
+**Sachliche Rechtfertigung des Bezugsrechtsausschlusses (Paragraf 55 IV GmbHG iVm § 4 (3) der Satzung)**:
+
+- Pi Mu Holding GmbH ist ein strategischer Investor mit Marktzugang in den Sektor „Industrielle KI-Anwendungen", in dem die Gesellschaft expandieren moechte.
+- Pi Mu Holding GmbH verfuegt ueber ein Portfolio an Beteiligungen mit Synergien zum Geschaeftsmodell der Gesellschaft.
+- Der Eintritt der Pi Mu Holding GmbH ist Voraussetzung fuer die Geschaeftsentwicklung in Industrie-Maerkten.
+- Die bestehenden Gesellschafter haben kein vergleichbares strategisches Engagement.
+- Die Verwaesserung der bestehenden Gesellschafter um 21,6 % (relativ) ist im Vergleich zur Series A (25 % Verwaesserung) angemessen.
+- Die Geschaeftsfuehrung hat alternative Finanzierungsformen geprueft (Bankkredit, weitere Bareinlagen der Gesellschafter); diese sind entweder nicht verfuegbar oder unverhaeltnismaessig teuer."
+
+### TOP 4 — Beschluss zur Aenderung der Geschaeftsordnung der Geschaeftsfuehrung
+
+Aktualisierung der Geschaeftsordnung um die Berichtspflichten gegenueber Pi Mu Holding GmbH.
+
+### TOP 5 — Sonstiges
+
+---
+
+## Beifuegungen zur Einladung
+
+- Subscription Agreement Pi Mu Holding GmbH vom 25.05.2026 (Entwurf, Anlage 1)
+- Term Sheet mit Pi Mu Holding GmbH vom 03.05.2026 (Anlage 2)
+- Cap Table vor und nach der KE (Anlage 3)
+- Geaenderte Geschaeftsordnung der GF (Anlage 4)
+
+---
+
+## Hinweis
+
+Bei Verhinderung bitten wir um schriftliche Vertretungs-Vollmacht spaetestens 48 Stunden vor dem Termin.
+
+Mit freundlichen Gruessen
+
+Andrea Roesener
+Geschaeftsfuehrerin
+
+—
+
+Diese Einladung wurde versandt:
+- per beA an die Bevollmaechtigten der Gesellschafter (Anwaelte)
+- per Einschreiben mit Rueckschein an alle Gesellschafter persoenlich

--- a/testakten/gesellschaftsgruender-streit-roeschen-tech/05_GV_Protokoll_18-06-2026_streitig.md
+++ b/testakten/gesellschaftsgruender-streit-roeschen-tech/05_GV_Protokoll_18-06-2026_streitig.md
@@ -1,0 +1,148 @@
+# PROTOKOLL der ausserordentlichen Gesellschafterversammlung
+
+**Roeschen Tech GmbH**
+
+**Datum**: Donnerstag, 18. Juni 2026
+
+**Beginn**: 14:00 Uhr
+**Ende**: 17:45 Uhr
+**Ort**: Geschaeftssitz der Gesellschaft, Pappelallee 23, 10437 Berlin
+
+---
+
+## Anwesende und Stimmrechte
+
+| Gesellschafter | Anteile | Stimmen | Klasse |
+|---|---|---|---|
+| Andrea Roesener (anwesend, persoenlich) | 12.000 | 12.000 | Common |
+| Bert Schmid (anwesend, persoenlich) | 12.000 | 12.000 | Common |
+| Christine Linnenbach (anwesend, persoenlich; mit Anwalt RA Dr. Meurer) | 6.000 | 6.000 | Common |
+| Stahlauge Ventures AG (vertreten durch Vorstand Dr. Felix Stahlauge) | 10.000 | 10.000 | B |
+| **Gesamt** | **40.000** | **40.000** | |
+
+Stimmrechte gemaess § 11 (3) der Satzung: vertreten sind 100 % der Anteile -> Beschlussfaehigkeit gegeben.
+
+---
+
+## TOP 1 — Begruessung, Beschlussfaehigkeit, Wahl des Versammlungsleiters
+
+Andrea Roesener eroeffnet die Versammlung und stellt fest:
+
+- Die Einladung erfolgte fristgerecht (gemaess § 11 der Satzung mit 3 Wochen Frist) am 27. Mai 2026.
+- Alle Gesellschafter sind vertreten.
+- Die Versammlung ist beschlussfaehig.
+
+### Wahl des Versammlungsleiters
+
+**Andrea Roesener** schlaegt sich selbst als Versammlungsleiterin vor.
+
+**Christine Linnenbach** schlaegt **RA Dr. Meurer** als externen, neutralen Versammlungsleiter vor, mit Hinweis auf die anstehende strittige Beschlussfassung.
+
+Diskussion: Stahlauge unterstuetzt Andrea Roesener; Bert Schmid auch.
+
+Abstimmung Versammlungsleiter:
+
+| Vorschlag | Andrea Roesener | RA Dr. Meurer |
+|---|---|---|
+| Stimmen Andrea | 12.000 | - |
+| Stimmen Bert | 12.000 | - |
+| Stimmen Christine | - | 6.000 |
+| Stimmen Stahlauge | 10.000 | - |
+| **Gesamt** | **34.000 (85 %)** | **6.000 (15 %)** |
+
+**Beschluss**: Andrea Roesener wird mit 85 % Mehrheit zur Versammlungsleiterin gewaehlt.
+
+Christine erhebt **Vorbehalt** gegen die Wahl, da die Versammlungsleiterin Mitprofiteur der zu beschliessenden Kapitalerhoehung ist (Verwaesserung Christine 21,6 %, kein eigener Vermoegensschaden bei Andrea).
+
+Schriftfuehrer: Bert Schmid, einstimmig.
+
+---
+
+## TOP 2 — Bericht der Geschaeftsfuehrung
+
+Andrea berichtet ueber den Stand der Series-B-Verhandlungen mit Pi Mu Holding GmbH:
+
+- Pre-Money-Bewertung: 38,5 Mio. EUR (gegenueber 20 Mio. Series A vor 7 Monaten — also Steigerung um 92,5 %)
+- Investment-Volumen: 12,5 Mio. EUR
+- Liquidation Preference: 1x non-participating
+- Sondervetorechte: bei Aenderung Satzung, Aufnahme weiterer Investoren
+- Strategische Beitraege: Markt-Zugang Industrie, technologische Synergien mit Portfolio
+
+Christine kritisiert: „Pi Mu Holding hat **keine** echten strategischen Beitraege. Das Portfolio von Pi Mu enthaelt nur Finanzinvestments, keine industriellen Beteiligungen. Der Vorwand „strategischer Investor" dient nur dazu, das Bezugsrecht der Minderheits-Gesellschafter auszuhebeln."
+
+Diskussion: Andrea und Stahlauge widersprechen.
+
+---
+
+## TOP 3 — Beschluss zur Kapitalerhoehung mit Bezugsrechtsausschluss
+
+Beschluss-Vorlage gemaess Einladung wird vorgelesen.
+
+Andrea erlaeutert die sachliche Rechtfertigung.
+
+Christine erhebt folgende **Einwendungen**:
+
+1. Die sachliche Rechtfertigung des Bezugsrechtsausschlusses ist nicht hinreichend dargetan. Pi Mu Holding ist Finanzinvestor, kein strategischer Investor.
+2. Es wurde nicht versucht, eine anteilige Bezugsmoeglichkeit der bestehenden Gesellschafter zu eroeffnen.
+3. Die Bewertung von 38,5 Mio. Pre-Money ist nicht durch ein unabhaengiges Bewertungsgutachten unterlegt.
+4. Christine erklaert ihre Bereitschaft, ihren anteiligen Bezugsanteil (15 % * 12,5 Mio. = ca. 1,875 Mio. EUR) durch Bareinlage zu erbringen, sofern sie 30 Tage Zeit erhaelt.
+
+Andrea entgegnet, dass Christines Bezugs-Wille nicht innerhalb der Einladung-Frist substantiiert wurde und Pi Mu Holding auf vollstaendige Aufnahme der 12,5 Mio. besteht.
+
+### Abstimmung Beschluss zur Kapitalerhoehung
+
+Andrea ruft die Abstimmung auf. Christine widerspricht und verlangt Vertagung.
+
+Versammlungsleiterin Andrea Roesener stellt fest: keine Vertagung — Abstimmung wird durchgefuehrt.
+
+| Stimmen | pro | contra | Enthaltung |
+|---|---|---|---|
+| Andrea Roesener (12.000 Common) | 12.000 | - | - |
+| Bert Schmid (12.000 Common) | 12.000 | - | - |
+| Christine Linnenbach (6.000 Common) | - | 6.000 | - |
+| Stahlauge Ventures AG (10.000 B) | 10.000 | - | - |
+| **Gesamt** | **34.000 (85 %)** | **6.000 (15 %)** | **0** |
+
+Versammlungsleiterin Andrea Roesener stellt fest:
+
+**Beschluss gefasst**: mit 85 % Mehrheit zustimmend.
+
+Die nach § 11 (5) Satzung erforderliche 75 %-Mehrheit (fuer Kapitalerhoehung und Bezugsrechtsausschluss) ist ueberschritten.
+
+Christine erhebt **Anfechtungsvorbehalt**:
+
+„Ich erhebe hiermit Anfechtungsvorbehalt gegen den vorstehenden Beschluss und behalte mir vor, binnen Monatsfrist Anfechtungsklage zu erheben. Begruendung:
+
+a) Sachliche Rechtfertigung des Bezugsrechtsausschlusses fehlt (Paragraf 55 IV GmbHG, BGH-Linie Kali+Salz, BGHZ 71, 40).
+b) Verstoss gegen die Treuepflicht der Mitgesellschafter (Paragraf 242 BGB).
+c) Eine sachgerechte Anhoerung Christines war durch die Versammlungsleiterin verhindert."
+
+---
+
+## TOP 4 — Beschluss zur Aenderung der Geschaeftsordnung der Geschaeftsfuehrung
+
+Aktualisierung um Berichtspflichten gegenueber Pi Mu.
+
+**Beschluss**: einstimmig mit 100 % zustimmend.
+
+---
+
+## TOP 5 — Sonstiges
+
+Christine erklaert, dass sie die Versammlung unter Vorbehalt verlaesst und die Beschluesse anfechten wird.
+
+---
+
+## Schluss der Versammlung
+
+Ende: 17:45 Uhr
+
+**Versammlungsleiterin**:    _______________
+                              Andrea Roesener
+
+**Schriftfuehrer**:           _______________
+                              Bert Schmid
+
+---
+
+**Vermerk**: Christine Linnenbach hat das Protokoll **nicht** unterzeichnet und hat erklaert, dass sie das Protokoll fuer fehlerhaft haelt (insbesondere bezueglich der angeblichen Sachverhalts-Darstellung zu Pi Mu). RA Dr. Meurer hat ein eigenes Notiz-Protokoll erstellt und kuendigt rechtliche Schritte an.

--- a/testakten/gesellschaftsgruender-streit-roeschen-tech/06_Anfechtungsklage_Christine.md
+++ b/testakten/gesellschaftsgruender-streit-roeschen-tech/06_Anfechtungsklage_Christine.md
@@ -1,0 +1,186 @@
+# Anfechtungsklage
+
+**Landgericht Berlin — Kammer fuer Handelssachen**
+
+**Klaegerin**:
+Christine Linnenbach
+Greifswalder Strasse 78, 10405 Berlin
+
+**Prozessbevollmaechtigter**:
+RA Dr. Markus Meurer, Litzowufer 24, 10785 Berlin
+
+**Beklagte**:
+Roeschen Tech GmbH
+Pappelallee 23, 10437 Berlin
+HRB 245.678 B
+vertreten durch die Geschaeftsfuehrer Andrea Roesener und Bert Schmid
+
+---
+
+**Streitwert**: 6.000.000 EUR (geschaetzter wirtschaftlicher Wert der Anfechtung)
+
+**Az.**: (wird zugeteilt)
+
+---
+
+## Klagschrift
+
+In dem Rechtsstreit
+
+**Christine Linnenbach** gegen **Roeschen Tech GmbH**
+
+erhebe ich Klage und werde beantragen:
+
+---
+
+### Antraege
+
+1. Es wird **festgestellt**, dass der von der Gesellschafterversammlung der Beklagten am 18. Juni 2026 unter TOP 3 gefasste Beschluss zur Kapitalerhoehung um 12.500 EUR mit Bezugsrechtsausschluss zugunsten der **Pi Mu Holding GmbH** **nichtig** ist, hilfsweise: dass der Beschluss **aufgehoben** wird (Anfechtung).
+
+2. Die Beklagte traegt die Kosten des Rechtsstreits.
+
+3. Die einstweilige Verfuegung wird gleichzeitig in einem separaten Verfahren beantragt (siehe Anlage K8).
+
+---
+
+### Sachverhalt
+
+#### A. Gesellschaftliche Stellung der Klaegerin
+
+Die Klaegerin ist Mitgruenderin und seit der Gruendung der Beklagten im Maerz 2024 Gesellschafterin. Sie haelt 6.000 von 40.000 Anteilen (= 15 %) der Class Common.
+
+Die Beklagte ist eine GmbH, die im Bereich KI-gestuetzter Software-Entwicklung taetig ist.
+
+#### B. Series-A-Finanzierung November 2025
+
+Im November 2025 wurde im Rahmen einer Series-A-Finanzierung die Stahlauge Ventures AG aufgenommen, die seither 25 % der Anteile (Class B) haelt. Bei dieser Kapitalerhoehung wurden die Bezugsrechte der bestehenden Gesellschafter ausgeschlossen. Die Klaegerin hat dieser Erhoehung zugestimmt, da Stahlauge tatsaechlich strategische Beitraege erbrachte.
+
+#### C. Geplante 2. Kapitalerhoehung Juni 2026
+
+Im Mai 2026 verkuendete die Geschaeftsfuehrung Plaene fuer eine **zweite Kapitalerhoehung** im Volumen von 12,5 Mio. EUR. Investor sollte die **Pi Mu Holding GmbH** sein.
+
+Die Klaegerin hat sich gegen die geplante Konstruktion gewendet:
+
+- Pi Mu Holding ist **kein** strategischer Investor, sondern ein **Finanzinvestor**.
+- Pi Mu Holding hat **keine** Beteiligungen in der Industrie-KI-Branche.
+- Pi Mu Holding bringt keine strategischen Synergien.
+
+Die Klaegerin hat darauf bestanden, dass die 2. Kapitalerhoehung **mit Bezugsrechten** der bestehenden Gesellschafter zu erfolgen hat — gegebenenfalls anteilig, sofern sie persoenlich nicht den vollen Bezugsanteil erbringen kann.
+
+#### D. Gesellschafterversammlung 18. Juni 2026
+
+In der Gesellschafterversammlung am 18.06.2026 wurde der Beschluss zur Kapitalerhoehung mit Bezugsrechtsausschluss zugunsten Pi Mu Holding GmbH **mit 85 % der Stimmen** (Andrea Roesener, Bert Schmid, Stahlauge Ventures AG) gegen die Stimme der Klaegerin (15 %) gefasst.
+
+Die formelle Mehrheit von 75 % wurde damit erreicht.
+
+#### E. Auswirkungen auf die Klaegerin
+
+- Verwaesserung von 15 % auf 11,76 % (= 21,6 % relativ)
+- Stimmrechts-Verlust unter wesentliche Schwellen
+- Bewertungs-Verlust in mittleren Exit-Szenarien (siehe Cap Table Anlage K3)
+- Wirtschaftlich besser gestellt waeren die Gruender und Stahlauge — Verwaesserung war fuer sie strategisch waehrend Christine als „Lasttier" der Streckung diente
+
+---
+
+### Rechtliche Beurteilung
+
+#### I. Nichtigkeit / Anfechtbarkeit des Beschlusses
+
+##### 1. Verstoss gegen Paragraf 55 IV GmbHG
+
+Paragraf 55 IV GmbHG verlangt fuer den Bezugsrechtsausschluss eine **sachliche Rechtfertigung**. Dabei traegt der Mehrheits-Beschluss zwingend die Begruendungs- und Beweislast.
+
+Die BGH-Linie ist eindeutig (BGH BGHZ 71, 40 — Kali+Salz-Entscheidung, vertieft in BGH NJW 2005, 985 — Macrotron, und in BGH NJW 2011, 1144 — Faktura):
+
+> „Der Bezugsrechtsausschluss ist nur zulaessig, wenn er
+> (a) durch einen sachlichen Grund gerechtfertigt ist,
+> (b) zur Erreichung des Zwecks geeignet,
+> (c) erforderlich, und
+> (d) angemessen ist."
+
+Im vorliegenden Fall fehlt es bereits am **sachlichen Grund**:
+
+- **Pi Mu Holding GmbH** ist nach den oeffentlich zugaenglichen Registerdaten und eigenen Angaben ein Finanzinvestor, kein strategischer Investor.
+- Die behaupteten „industriellen Synergien" sind nicht substantiiert.
+- Die Behauptung, Pi Mu Holding bringe **Markt-Zugang Industrie**, ist nicht belegt.
+
+Auch die **Erforderlichkeit** fehlt:
+
+- Alternative Finanzierungs-Optionen wurden nicht ernsthaft geprueft.
+- Insbesondere wurden den bestehenden Gesellschaftern **keine** Bezugsrechte mit ausreichender Frist angeboten.
+- Die Klaegerin hat ausdruecklich ihre Bereitschaft erklaert, einen anteiligen Bezug von 1,875 Mio. EUR zu uebernehmen.
+
+##### 2. Verstoss gegen Treuepflicht (Paragraf 242 BGB analog)
+
+Die Mehrheits-Gesellschafter unterliegen einer **Treuepflicht** gegenueber den Minderheits-Gesellschaftern (BGH NJW 2007, 917; BGH NJW 2018, 1233).
+
+Diese verbietet:
+
+- Beschluesse, die die Mitgesellschafter wirtschaftlich gezielt schaedigen, ohne dass es objektiv erforderlich ist
+- Stimm-Ausuebung zu Lasten Minderheits-Gesellschafter ohne legitimes Mehrheits-Interesse
+
+Im vorliegenden Fall wurden:
+
+- Andrea und Bert verwasserten **gleichmaessig** (jeweils von 30 % auf 23,53 %)
+- Christine verwasserte **gleichmaessig** in absoluten Prozentpunkten, aber wegen ihrer kleineren Ausgangsposition relativ haerter betroffen
+- Stahlauge profitierte zusaetzlich durch ihre B-Sondervetorechte (kein Stimm-Verlust)
+
+Vor allem aber: Die Gruender Andrea und Bert sind gleichzeitig Geschaeftsfuehrer. Sie haben ein **eigenes Interesse** an der Beschleunigung der Series B (z.B. wegen geplantem Exit in 2 Jahren). Die Klaegerin ist **nicht in der GF**.
+
+##### 3. Verstoss gegen sachgerechte Sachverhalts-Aufklaerung
+
+Die Versammlungsleiterin Andrea Roesener hat die Diskussion **abgekuerzt**, ohne der Klaegerin ausreichend Gelegenheit zur Stellungnahme zu geben. Auch dies ist Anfechtungsgrund.
+
+#### II. Hilfsweise: Anfechtung
+
+Sofern Nichtigkeit nicht zu bejahen ist, wird hilfsweise die **Anfechtung** des Beschlusses gemaess Paragrafen 246, 248 AktG analog erklaert. Die Klagefrist (1 Monat ab Beschluss) ist gewahrt: Beschluss vom 18.06.2026, Klage vom 14.07.2026.
+
+---
+
+### Beweisangebot
+
+Zeugen:
+
+1. **RA Dr. Markus Meurer**, Litzowufer 24, 10785 Berlin (anwesend in der GV)
+2. **Dr. Felix Stahlauge**, Vorstand Stahlauge Ventures AG, Theatinerstrasse 15, 80333 Muenchen
+
+Urkunden (siehe Anlagen):
+
+- K1: Einladung zur GV vom 27.05.2026
+- K2: Protokoll der GV vom 18.06.2026
+- K3: Cap Table vor und nach KE
+- K4: Subscription Agreement Pi Mu Holding GmbH (Entwurf)
+- K5: HR-Auszug Pi Mu Holding GmbH (zeigt: Finanz-Holding-Struktur)
+- K6: E-Mail-Verkehr zwischen Klaegerin und Geschaeftsfuehrung 28.05.-15.06.2026
+- K7: Eigene eidesstattliche Versicherung der Klaegerin
+- K8: Antrag auf einstweilige Verfuegung
+
+Sachverstaendiger:
+
+- **Wirtschaftspruefer fuer Bewertung** der Pi-Mu-Synergien wird bei Bedarf benannt.
+
+---
+
+### Anlagen-Verzeichnis
+
+K1 — K8 (wie oben aufgefuehrt)
+
+---
+
+### Erklaerungen
+
+Die Klaegerin erklaert:
+
+- Die in der Klagschrift erhobenen Behauptungen entsprechen ihrem Kenntnisstand.
+- Sie ist in der Lage, die Klagekosten zu tragen.
+
+---
+
+Berlin, den 14. Juli 2026
+
+_______________
+RA Dr. Markus Meurer
+Prozessbevollmaechtigter
+
+_______________
+Christine Linnenbach

--- a/testakten/gesellschaftsgruender-streit-roeschen-tech/07_Eilantrag_LG_und_Registergericht.md
+++ b/testakten/gesellschaftsgruender-streit-roeschen-tech/07_Eilantrag_LG_und_Registergericht.md
@@ -1,0 +1,146 @@
+# Antraege auf einstweilige Verfuegung und Anmeldungs-Sperre
+
+---
+
+## Teil 1 — Antrag auf einstweilige Verfuegung beim Landgericht Berlin
+
+**Landgericht Berlin — Kammer fuer Handelssachen**
+
+**Verfuegungsklaegerin**:
+Christine Linnenbach
+Greifswalder Strasse 78, 10405 Berlin
+
+**Prozessbevollmaechtigter**:
+RA Dr. Markus Meurer, Litzowufer 24, 10785 Berlin
+
+**Verfuegungsbeklagte**:
+Roeschen Tech GmbH
+Pappelallee 23, 10437 Berlin
+HRB 245.678 B
+vertreten durch die Geschaeftsfuehrer Andrea Roesener und Bert Schmid
+
+---
+
+**Streitwert** (Eilverfahren): 3.000.000 EUR
+**Az.**: (wird zugeteilt)
+
+---
+
+### Antrag
+
+Es wird beantragt, im Wege der einstweiligen Verfuegung
+
+der Verfuegungsbeklagten zu **untersagen**,
+
+die mit Beschluss der Gesellschafterversammlung vom 18.06.2026 (TOP 3) beschlossene Kapitalerhoehung um 12.500 EUR mit Bezugsrechtsausschluss zugunsten der Pi Mu Holding GmbH
+
+**beim Handelsregister zur Eintragung anzumelden**,
+
+bis zur rechtskraeftigen Entscheidung des in der Hauptsache anhaengigen Anfechtungsverfahrens (LG Berlin Az. [...]).
+
+Hilfsweise: Es wird beantragt, die Verfuegungsbeklagte unter Festsetzung eines Ordnungsgeldes zu **verpflichten**, die bereits eingereichte Anmeldung zurueckzuziehen.
+
+---
+
+### Verfuegungsanspruch
+
+1. **Hohe Wahrscheinlichkeit der Anfechtbarkeit / Nichtigkeit** des Beschlusses gemaess Paragraf 55 IV GmbHG iVm Paragraf 138 BGB:
+
+   - Bezugsrechtsausschluss ohne sachliche Rechtfertigung (BGH Kali+Salz)
+   - Verstoss gegen Treuepflicht (Paragraf 242 BGB)
+   - Sachverhaltsaufklaerung in der GV mangelhaft
+
+   Im Einzelnen wird auf die Anfechtungsklage in der Hauptsache verwiesen (LG Berlin Az. [...]).
+
+2. **Schadens-Schwere bei Eintragung**:
+
+   - Bei Eintragung wuerde die Kapitalerhoehung **konstitutiv wirken** (Paragraf 11 GmbHG)
+   - Spaetere Rueckabwicklung waere wirtschaftlich aufwendig und ungewiss
+   - Die Anteilshoehe von Pi Mu Holding wuerde im Handelsregister erscheinen und Vertrauensschutz Dritter (Paragraf 16 HGB analog) ausloesen
+
+### Verfuegungsgrund (Eilbeduerftigkeit)
+
+- Die Anmeldung beim Handelsregister wurde laut Mitteilung der GF bereits eingereicht (siehe Anlage E1)
+- Die Eintragung droht innerhalb von 5-10 Werktagen
+- Nach Eintragung waere die Wirkung des Beschlusses **unwiderruflich**
+- Im Hauptverfahren wuerde die Rueckabwicklung nur durch zusaetzliche Klagen und Rueckueberweisungen moeglich, mit unklaren Erfolgs-Aussichten
+
+### Glaubhaftmachung
+
+- Eigene eidesstattliche Versicherung der Verfuegungsklaegerin (Anlage E2)
+- Eidesstattliche Versicherung des Prozessbevollmaechtigten RA Dr. Meurer (Anlage E3)
+- Anlagen K1-K7 aus der Hauptverfahrens-Klage (in Bezug genommen)
+
+### Sicherheits-Leistung
+
+Falls erforderlich wird Sicherheits-Leistung in Hoehe von **50.000 EUR** durch Bankbuergschaft angeboten.
+
+---
+
+Berlin, den 14. Juli 2026
+
+_______________
+RA Dr. Markus Meurer
+
+---
+
+---
+
+## Teil 2 — Antrag auf Anmeldungs-Sperre beim Amtsgericht Charlottenburg
+
+**Amtsgericht Charlottenburg — Registergericht**
+
+HRB 245.678 B
+Roeschen Tech GmbH
+
+**Antragstellerin**:
+Christine Linnenbach
+Greifswalder Strasse 78, 10405 Berlin
+
+**Prozessbevollmaechtigter**:
+RA Dr. Markus Meurer, Litzowufer 24, 10785 Berlin
+
+---
+
+### Antrag
+
+Es wird beantragt,
+
+das Registergericht moege gemaess Paragraf 16 II HGB analog iVm Paragrafen 374, 391 FamFG **anordnen**,
+
+dass die Eintragung der mit Beschluss der Gesellschafterversammlung der Roeschen Tech GmbH vom 18.06.2026 (TOP 3) beschlossenen Kapitalerhoehung um 12.500 EUR mit Bezugsrechtsausschluss zugunsten der Pi Mu Holding GmbH **bis zur rechtskraeftigen Entscheidung** des in der Hauptsache anhaengigen Anfechtungsverfahrens (LG Berlin Az. [...]) **nicht erfolgt**.
+
+### Begruendung
+
+Es wird auf die Klagschrift in der Hauptsache (LG Berlin Az. [...]) und den parallelen Antrag auf einstweilige Verfuegung beim LG Berlin verwiesen. Soweit das Registergericht selbst pruefen kann, lassen sich die Anfechtungs-/Nichtigkeitsgruende aus den vorliegenden Unterlagen erkennen.
+
+#### Eilbeduerftigkeit
+
+- Anmeldung wurde am 24.06.2026 durch Notar Dr. Sturm eingereicht.
+- Eintragung droht innerhalb der naechsten 5-10 Werktage.
+- Nach Eintragung waere die Kapitalerhoehung konstitutiv wirksam.
+
+#### Hohe Wahrscheinlichkeit der Anfechtbarkeit
+
+- Bezugsrechtsausschluss ohne sachliche Rechtfertigung
+- Verstoss gegen Treuepflicht
+
+### Verfahrens-Hinweis
+
+Sollte das Registergericht den Antrag fuer unzulaessig halten (weil die Pruefung allein beim LG erfolgen soll), wird hilfsweise gebeten, die Anmeldung bis zur Entscheidung des LG ueber den parallelen Antrag auf einstweilige Verfuegung **vorlaeufig auszusetzen**.
+
+---
+
+Berlin, den 14. Juli 2026
+
+_______________
+RA Dr. Markus Meurer
+
+---
+
+## Anlagen (zu beiden Antraegen)
+
+- E1: Mitteilung der Geschaeftsfuehrung vom 22.06.2026 ueber Einreichung der Anmeldung
+- E2: Eidesstattliche Versicherung Christine Linnenbach
+- E3: Eidesstattliche Versicherung RA Dr. Markus Meurer
+- K1-K7: Anlagen der Anfechtungsklage in der Hauptsache (in Bezug genommen)

--- a/testakten/gesellschaftsgruender-streit-roeschen-tech/08_Beirat_Schlichtungs_Empfehlung.md
+++ b/testakten/gesellschaftsgruender-streit-roeschen-tech/08_Beirat_Schlichtungs_Empfehlung.md
@@ -1,0 +1,108 @@
+# Beirat-Schlichtungs-Empfehlung
+
+**Roeschen Tech GmbH**
+
+**Beirat** der Roeschen Tech GmbH:
+
+- Prof. Dr. Hannelore Bornhardt-Wiese (Vorsitzende, unabhaengig, Wirtschaftspruefer im Ruhestand)
+- Dipl.-Ing. Klaus Eitelfried (Branchen-Experte KI, ehemaliger CTO XYZ AG)
+- Dr. Sabine Wiedemann (Anwaeltin, unabhaengig)
+
+**Datum**: 28. Juli 2026
+
+---
+
+## An die Gesellschafter der Roeschen Tech GmbH
+
+Sehr geehrte Damen und Herren,
+
+aufgrund der Anrufung des Beirats durch die Gesellschafterin Christine Linnenbach gemaess § 12 (3) c) der Satzung und § 11 (1) des Shareholder Agreement (Schlichtungsklausel) hat sich der Beirat in einer Sondersitzung am 28. Juli 2026 mit dem Streit ueber die Kapitalerhoehung vom 18. Juni 2026 befasst.
+
+Der Beirat hat:
+
+- die schriftlichen Unterlagen ausgewertet (Satzung, SHA, Subscription Agreement, GV-Protokoll, Klageschrift, Eilantrag)
+- die Beteiligten muendlich angehoert (Christine Linnenbach, Andrea Roesener, Bert Schmid, Vorstand Stahlauge AG, Vertreter Pi Mu Holding GmbH)
+
+---
+
+## Bewertung des Beirats
+
+### 1. Sachliche Rechtfertigung des Bezugsrechtsausschlusses
+
+Der Beirat erkennt **gemischte Befunde**:
+
+- Pi Mu Holding ist tatsaechlich ueberwiegend Finanzinvestor.
+- Allerdings: Pi Mu Holding bringt Zugang zum Industrie-KI-Markt durch ein neueres Beteiligungs-Portfolio in den Jahren 2024-2026.
+- Die Bewertung 38,5 Mio. Pre-Money ist im Marktvergleich **angemessen** (Beirat hat Vergleichs-Transaktionen geprueft).
+- Die strategischen Beitraege sind **vorhanden, aber nicht so stark wie behauptet**.
+
+Der Beirat ist der Auffassung, dass die sachliche Rechtfertigung **knapp gegeben** ist — aber nicht ohne weiteres. Die Geschaeftsfuehrung haette transparenter argumentieren muessen.
+
+### 2. Treuepflicht der Mehrheits-Gesellschafter
+
+Der Beirat sieht **Verbesserungs-Bedarf**:
+
+- Die Klaegerin Christine hatte explizit ihre Bezugs-Bereitschaft fuer einen anteiligen Beitrag erklaert.
+- Diese Moeglichkeit wurde nicht ernsthaft geprueft.
+- Eine Mischvariante (Pi Mu zeichnet **anteilig** + Christine zeichnet **anteilig** + Andrea und Bert nehmen Vorzug auf nicht-ausgeuebte Bezugsrechte) waere moeglich gewesen.
+
+### 3. Vorlaeufige Empfehlung
+
+Der Beirat empfiehlt **Vergleich** auf folgender Basis:
+
+#### Vergleichs-Vorschlag
+
+a) **Pi Mu Holding GmbH zeichnet 10.000 Anteile** statt 12.500 Anteile (Investment 10 Mio. statt 12,5 Mio.; Pre-Money bleibt 38,5 Mio.; Post-Money sinkt auf 48,5 Mio.)
+
+b) **Christine Linnenbach zeichnet 2.500 Anteile** durch Bareinlage 2.500 EUR Nennwert + Aufgeld auf gleichem Preisniveau wie Pi Mu (999 EUR/Anteil) = Gesamtinvestment 2,5 Mio. EUR
+
+c) Die Anteilshoehen nach Vergleich:
+
+| Gesellschafter | Anteile | % |
+|---|---|---|
+| Andrea | 12.000 | 23,53 % |
+| Bert | 12.000 | 23,53 % |
+| Christine | 8.500 | 16,67 % (statt 11,76 %) |
+| Stahlauge | 10.000 | 19,61 % |
+| Pi Mu | 10.000 | 19,61 % |
+| **Gesamt** | **51.000** | **100 %** |
+
+d) **Erleichterung fuer Christine**: Bareinlage erfolgt in zwei Raten:
+   - 1. Mio. binnen 30 Tagen
+   - 1,5 Mio. binnen 90 Tagen
+
+e) **Anfechtungsklage und Eilantrag werden zurueckgenommen** nach Eintragung der neuen Anteilskonstellation.
+
+f) **Klare Kommunikations-Richtlinien** fuer kuenftige Kapitalerhoehungen: explizite Anfrage an Minderheits-Gesellschafter mit Frist und Bezugs-Optionen.
+
+---
+
+## Konsequenz bei Ablehnung des Vergleichs
+
+Falls die Gesellschafter den Vergleich nicht innerhalb von **14 Tagen** annehmen, wird der Beirat eine **abschliessende Stellungnahme** formulieren, die das Hauptverfahren begleitet.
+
+Der Beirat weist ausdruecklich darauf hin, dass die Schlichtungs-Empfehlung **nicht bindend** ist (§ 12 (3) c) Satzung), aber die Pflicht zur Anrufung des Beirats vor Klageerhebung (§ 11 (1) SHA) bestand und gewahrt wurde.
+
+---
+
+## Hinweis
+
+Sollte der Streit weiter eskalieren, weist der Beirat auf folgende Risiken hin:
+
+- **Reputations-Risiko** fuer alle Beteiligten
+- **Verzoegerung der Pi-Mu-Investition** bei laufender Klage (Pi Mu hat „Material Adverse Change"-Klausel)
+- **Hohe Gerichtskosten** und Streitwert-Gebuehren
+- **Belastung der Geschaeftsfuehrer** durch Anfechtung der Beschluesse
+
+---
+
+Berlin, den 28. Juli 2026
+
+_______________ Prof. Dr. Hannelore Bornhardt-Wiese
+                Beiratsvorsitzende
+
+_______________ Dipl.-Ing. Klaus Eitelfried
+                Beiratsmitglied
+
+_______________ Dr. Sabine Wiedemann
+                Beiratsmitglied

--- a/testakten/gesellschaftsgruender-streit-roeschen-tech/09_Schulungsbegleiter.md
+++ b/testakten/gesellschaftsgruender-streit-roeschen-tech/09_Schulungsbegleiter.md
@@ -1,0 +1,162 @@
+# Schulungsbegleiter — Roeschen Tech GmbH
+
+## Lernziele
+
+Nach Bearbeitung dieser Schulungsakte:
+
+1. Verstehen, wie B-Shares mit Sondervetorechten funktionieren
+2. Liquidation-Preference-Waterfalls rechnen koennen
+3. Bezugsrechtsausschluss kritisch wuerdigen (BGH Kali+Salz)
+4. Treuepflicht-Argumentation entwickeln (BGH Treuepflicht-Linie)
+5. Eilrechtsschutz-Werkzeuge kennen (LG, Registergericht)
+6. Anfechtungsklage formulieren (Frist, Antraege, Begruendung)
+7. Beirat-Schlichtungsverfahren einbinden
+
+## Bearbeitungs-Schritte
+
+### Schritt 1 — Sachverhalts-Aufnahme
+
+Lesen Sie die Akte in chronologischer Reihenfolge:
+
+1. Satzung (01)
+2. Shareholder Agreement (02)
+3. Cap Table (03)
+4. Einladung GV (04)
+5. GV-Protokoll (05)
+6. Anfechtungsklage (06)
+7. Eilantrag LG + Registergericht (07)
+8. Beirat-Schlichtungsempfehlung (08)
+
+### Schritt 2 — Analyse der Vor-Series-A-Situation
+
+Aufgaben:
+
+- Wie wird die Liquidation Preference von Stahlauge funktioniert haben?
+- Wieso wurde der Bezugsrechtsausschluss bei Series A nicht angefochten?
+- Welche strategischen Beitraege haette Stahlauge erbracht?
+
+### Schritt 3 — Analyse der 2. Kapitalerhoehung
+
+Aufgaben:
+
+- Berechnen Sie die Verwaesserung von Christine konkret (siehe Cap Table)
+- Liquidation Preference: was passiert bei Exit 30 Mio. — Stand 2 vs. Stand 3?
+- Sachliche Rechtfertigung Bezugsrechtsausschluss: argumentieren Sie pro und kontra
+- Treuepflicht: wurde sie verletzt?
+
+### Schritt 4 — Bewertung der Klage und des Eilantrags
+
+Aufgaben:
+
+- Antrag auf einstweilige Verfuegung — bewerten Sie Erfolgsaussichten
+- Antrag auf Anmeldungs-Sperre — wurde der richtige Weg gewaehlt?
+- Was haetten Sie als Verfahrensbevollmaechtigter anders gemacht?
+
+### Schritt 5 — Beirat-Vergleichs-Vorschlag
+
+Aufgaben:
+
+- Bewerten Sie den Vergleichs-Vorschlag der Beirat
+- Wuerden Sie als Christine annehmen?
+- Wuerden Sie als Andrea / Bert / Stahlauge annehmen?
+- Welche zusaetzlichen Klauseln wuerden Sie verlangen?
+
+### Schritt 6 — Praeventive Mass nahmen
+
+Aufgaben:
+
+- Welche Klausel in der Satzung hatte Christine besser geschuetzt?
+- Welche Klausel im SHA hatte den Streit verhindert?
+- Welche operativen Mass nahmen waeren sinnvoll?
+
+## Lerninhalte je Phase
+
+### Phase A: Gruendung und Series-A-Aufnahme
+
+- Skill: `gesellschaftsgruender-rechtsformwahl` (warum GmbH, nicht UG)
+- Skill: `gesellschaftsgruender-gmbh-vorbereitung` (Bausteine)
+- Skill: `gesellschaftsgruender-share-classes-a-b-c` (B-Shares bei Series A)
+- Skill: `gesellschaftsgruender-gesellschaftervereinbarung` (SHA)
+- Skill: `gesellschaftsgruender-cap-table` (Verwaesserung Series A)
+
+### Phase B: 2. Kapitalerhoehung
+
+- Skill: `gesellschaftsgruender-kapitalerhoehung-bezugsrecht` (Bezugsrechtsausschluss)
+- Skill: `gesellschaftsgruender-genehmigtes-kapital` (Vorrats-Beschluss in der Satzung)
+- Skill: `gesellschaftsgruender-gv-einladung-tagesordnung` (Einladung Praxis)
+- Skill: `gesellschaftsgruender-gv-protokoll-und-versammlungsleiter` (Protokoll bei Streit)
+
+### Phase C: Eilrechtsschutz
+
+- Skill: `gesellschaftsgruender-gesellschafterstreit-eilantraege` (Werkzeuge)
+- Skill: `gesellschaftsgruender-sha-satzung-stimmverpflichtung` (Stimmverpflichtungen)
+
+### Phase D: Schlichtung
+
+- Skill: `gesellschaftsgruender-beirat-advisory-board` (Beirat als Schlichter)
+
+## Diskussions-Fragen (Sokratisch)
+
+1. **Wenn Sie Christine waren — was haetten Sie schon bei Series A anders gemacht?**
+
+   Hint: Vesting-Schutz im SHA, anti-dilution Klausel, Sondervetorecht...
+
+2. **Wenn Sie Andrea waren — was haetten Sie anders gemacht in der Pre-GV-Phase?**
+
+   Hint: Transparente Anfrage an Christine, Mischlosung anbieten, Beirat fruehzeitig einbinden...
+
+3. **Wenn Sie Stahlauge waren — wuerden Sie den Vergleichs-Vorschlag des Beirats unterstuetzen?**
+
+   Hint: Reduzierung des Pi-Mu-Anteils, dadurch eigene Verwaesserung weniger drastisch...
+
+4. **Wuerde ein gestaffeltes Vesting fuer Investor-Anteile (statt sofort vollvested) den Streit gemildert haben?**
+
+   Hint: Stahlauge haette weniger Stimmrecht bei spaeteren Beschluessen...
+
+5. **Sollte die Satzung Sondervetorechte fuer Minderheits-Gesellschafter (z.B. ab 15 % Anteile) vorsehen?**
+
+   Hint: Schutz vor Verwaesserung — aber riskiert Investor-Aufnahme...
+
+## Loesungs-Skizzen (knapp)
+
+### Sachliche Rechtfertigung Bezugsrechtsausschluss
+
+- BGH-Linie verlangt **konkrete strategische Beitraege**
+- Bei reinem Finanzinvestor ohne nachweisbare Synergien: **nicht ausreichend**
+- Christines Position ist juristisch **stark**
+
+### Treuepflicht
+
+- Mehrheits-Gesellschafter (zusammen mit Investor) muessen Minderheit nicht gezielt schaedigen
+- Hier: Verwaesserung haette teilweise durch Mischlosung vermieden werden koennen
+- BGH NJW 2007, 917 (Sanierung-fragwuerdig-Klausel) gibt Christine Stuetze
+
+### Eilrechtsschutz
+
+- Antrag auf einstweilige Verfuegung beim LG: **gute Aussichten**
+- Antrag Anmeldungs-Sperre beim Registergericht: **redundant**, aber als Sicherheit sinnvoll
+
+### Vergleichs-Vorschlag
+
+- Wirtschaftlich fuer Christine besser als Klage (Risiko der Niederlage)
+- Andererseits: bei Klage-Sieg mehr Anteile
+
+## Vergleichende Konstellationen aus der Praxis
+
+- BGH NJW 2005, 985 — Macrotron (Boersengang ohne Aktionaersinteresse): Bezugsrecht ohne sachlichen Grund nichtig
+- BGH NJW 2011, 1144 — Faktura: Sondervetorecht aus dem SHA bindet die Stimmabgabe
+- BGH NJW 2018, 1233 — Treuepflicht bei Mehrheits-Gesellschaftern
+
+## Anschluss-Skills
+
+Bei vertieftem Interesse:
+
+- `corporate-kanzlei` — fuer M&A-Themen
+- `gesellschaftsrecht` — fuer laufende Gesellschafts-Mandate
+- `fachanwalt-handels-gesellschaftsrecht` — Fachanwaltschafts-Vertiefung
+- `krisenfrueherkennung-starug` — bei wirtschaftlicher Krise zusaetzlich
+- `insolvenzplan-starug-planwerkstatt` — bei drohender Insolvenz
+
+## Hinweis zum Plagiats-Schutz
+
+Diese Schulungsakte ist ein Lernwerkzeug. Sie ist nicht zur direkten Verwendung in echten Mandaten gedacht. Personen und Firmen sind frei erfunden. Aehnlichkeiten mit echten Personen, Firmen oder Sachverhalten sind rein zufaellig.

--- a/testakten/gesellschaftsgruender-streit-roeschen-tech/README.md
+++ b/testakten/gesellschaftsgruender-streit-roeschen-tech/README.md
@@ -1,0 +1,102 @@
+# Schulungsakte „Roeschen Tech GmbH" — Gesellschaftsgruendung mit B-Shares und Streit-Eskalation
+
+## Szenario
+
+Die **Roeschen Tech GmbH** (fiktive Gesellschaft, alle Personen frei erfunden) wird im Maerz 2024 von **drei Gruendern** mit Sitz in Berlin gegruendet. Stammkapital 30.000 EUR. Geschaeftsmodell: KI-gestuetzte Software-Entwicklung.
+
+Im November 2025 tritt **Investor Stahlauge Ventures AG** (fiktiv) im Rahmen einer Series-A-Finanzierung ein. Es werden **B-Shares** mit Sondervetorechten und 1,5x Liquidation Preference ausgegeben. Das Stammkapital wird auf 40.000 EUR erhoeht; Bezugsrecht der Gruender ausgeschlossen.
+
+Im **Juni 2026** plant Stahlauge Ventures gemeinsam mit zwei Gruendern eine **zweite Kapitalerhoehung** um 12.500 EUR — wiederum mit Bezugsrechtsausschluss — zur Aufnahme eines strategischen Investors (Pi Mu Holding GmbH, fiktiv). Die dritte Gruenderin Christine **widerspricht**: sie sieht Verwaesserung von 19 % auf 14 % als unverhaeltnismaessig und nicht sachlich gerechtfertigt.
+
+In der **Gesellschafterversammlung vom 18.06.2026** wird die Kapitalerhoehung **mehrheitlich** beschlossen (zustimmend: Andrea, Bert, Stahlauge Ventures mit B-Sondervetorecht; ablehnend: Christine). Christine erhebt **Anfechtungsklage** und beantragt **einstweilige Verfuegung** beim Landgericht Berlin sowie **Anmeldungs-Sperre** beim Amtsgericht Charlottenburg.
+
+## Beteiligte
+
+| Person | Rolle | Anteilshoehe |
+|---|---|---|
+| Andrea Roesener (Gruenderin, CEO) | Class Common | 12.000 EUR (40 %) -> nach Series A 30 %, nach 2. KE 23,5 % |
+| Bert Schmid (Gruender, CTO) | Class Common | 12.000 EUR (40 %) -> nach Series A 30 %, nach 2. KE 23,5 % |
+| Christine Linnenbach (Gruenderin, COO) | Class Common | 6.000 EUR (20 %) -> nach Series A 15 %, nach 2. KE 11,8 % |
+| Stahlauge Ventures AG | Class B | 10.000 EUR (25 % nach Series A) -> nach 2. KE 19,6 % |
+| Pi Mu Holding GmbH (nach 2. KE) | Class C | 12.500 EUR (24,5 %) — geplant |
+
+## Lerninhalte dieser Akte
+
+1. **B-Shares mit Sondervetorechten**: wie sie funktionieren, wo Streit entsteht
+2. **Liquidation Preference 1,5x participating**: Auswirkungen bei Exit
+3. **Bezugsrechtsausschluss Paragraf 55 IV GmbHG**: sachliche Rechtfertigung, BGH-Linie Kali+Salz
+4. **Streit ueber Verwaesserung**: Klage-Werkzeuge fuer Minderheits-Gesellschafter
+5. **Eilrechtsschutz** beim LG und Registergericht
+6. **Anfechtungsklage Paragraf 246 AktG analog**: Monatsfrist
+7. **Versammlungsleitung bei streitiger GV**: Wahl, Befugnisse, Streit
+8. **Beirat als Schlichter**: Schlichtungs-Klausel und ihre Wirkung
+
+## Inhalt der Akte
+
+```
+01_Satzung_Roeschen_Tech_GmbH.md
+   - Vollstaendige Satzung nach Series A (mit B-Shares)
+   - Vorzugsklauseln, Vinkulierung, Vetorechte
+
+02_Shareholder_Agreement.md
+   - Gesellschaftervereinbarung mit Vesting, Drag-Along, Tag-Along
+   - Stimmverpflichtungen, Pönalen
+   - Liquidation-Preference-Waterfall
+
+03_Cap_Table_Vor_und_Nach_KE.md
+   - Cap Table initial, nach Series A, nach geplanter 2. KE
+   - Verwaesserungs-Berechnungen
+
+04_Einladung_GV_18-06-2026.md
+   - Einladung zur Gesellschafterversammlung mit Tagesordnung
+   - Beschluss-Vorlage zur Kapitalerhoehung mit Bezugsrechtsausschluss
+   - Sachliche Rechtfertigung gemaess Satzung
+
+05_GV_Protokoll_18-06-2026_streitig.md
+   - Protokoll der streitigen Versammlung
+   - Versammlungsleiter-Wahl
+   - Beschlussfassung mit Stimmenverhalten
+   - Christines Vorbehalte
+
+06_Anfechtungsklage_Christine.md
+   - Klagschrift Christines vor LG Berlin
+   - Klagantrag, Begruendung, Anlagen-Verzeichnis
+
+07_Eilantrag_LG_und_Registergericht.md
+   - Antrag auf einstweilige Verfuegung beim LG Berlin
+   - Antrag auf Anmeldungs-Sperre beim AG Charlottenburg
+   - Eidesstattliche Versicherung
+
+08_Beirat_Schlichtungs_Empfehlung.md
+   - Beirat-Schlichtungs-Empfehlung
+   - Vorschlag eines Kompromisses
+
+09_Schulungsbegleiter.md
+   - Hinweise zur Bearbeitung der Akte
+   - Aufgaben und Loesungs-Skizzen
+   - Lernziele
+```
+
+## Bearbeitungs-Hinweise
+
+### Variante A — Standardgruendung lernen
+
+1. Beginne mit `gesellschaftsgruender-rechtsformwahl` und `gesellschaftsgruender-gmbh-vorbereitung`.
+2. Lies die Satzung der Roeschen Tech GmbH.
+3. Vergleiche mit Standard-Musterprotokoll. Wo sind die Erweiterungen?
+
+### Variante B — Investor-Eintritt lernen
+
+1. `gesellschaftsgruender-share-classes-a-b-c` und `gesellschaftsgruender-gesellschaftervereinbarung`.
+2. Lies das SHA und die Class-B-Klauseln in der Satzung.
+3. Erstelle den Cap Table fuer Series A nach.
+
+### Variante C — Streit-Eskalation
+
+1. `gesellschaftsgruender-kapitalerhoehung-bezugsrecht`, `gesellschaftsgruender-gesellschafterstreit-eilantraege`.
+2. Lies das GV-Protokoll und die Klagschrift.
+3. Diskutiere: Ist der Bezugsrechtsausschluss sachlich gerechtfertigt? Wie ist der Eilantrag zu bewerten?
+
+## Verbotenes (Plagiats-Hinweis)
+
+Diese Akte ist eine **Schulungsakte**. Sie ist nicht zur Verwendung in echten Mandanten-Akten gedacht. Die Personen und Firmen sind frei erfunden; Aehnlichkeiten mit existierenden Personen oder Firmen sind rein zufaellig.


### PR DESCRIPTION
## Zusammenfassung

Massive Erweiterung des Plugins `gesellschaftsgruender` von 17 auf **34 Skills** plus eine vollstaendig ausgearbeitete Schulungsakte mit Gesellschafterstreit-Eskalation.

## Was wurde gewuenscht

Per Nutzer-Auftrag sollen abgefragt und gestaltet werden koennen:
- Gruender-Daten Anteile Class-A-B-C-Shares (jetzt oder spaeter)
- Gesellschaftervereinbarung **parallel** zur Satzung mit Stimmverpflichtung
- Geschaeftsordnung der Geschaeftsfuehrung
- Bilinguale Dokumente Deutsch/Englisch mit Vorrang-Klausel
- Tagesordnungen und Einladungen GF-Meeting und Gesellschafterversammlung
- Term Sheets, Cap Table, genehmigtes Kapital
- Beirat / Beiratsordnung / Advisory Board
- Golden Share mit Restrukturierungs-Vetorecht (StaRUG)
- GF-Sozialversicherungs-Status (Fremd-GF vs. Gesellschafter-GF)
- Firmenname-Pruefung (HR, Marken, Domain)
- Gesellschafterstreit-Eilantraege LG und Registergericht (FamFG, HGB)
- Schulungsakte mit Streit-Eskalation

## Was wurde geliefert

### 17 neue Skills

| Block | Skills |
|---|---|
| Workflow & Daten | `gruender-intake`, `cap-table` |
| Class-Shares & Veto | `share-classes-a-b-c`, `golden-share-und-vetorechte`, `sha-satzung-stimmverpflichtung` |
| GF & Beirat | `geschaeftsordnung-gf`, `gf-meeting-templates`, `gf-sozialversicherungs-status`, `beirat-advisory-board` |
| Internationalisierung | `bilinguale-dokumente` |
| Gesellschafterversammlung | `gv-einladung-tagesordnung`, `gv-protokoll-und-versammlungsleiter`, `stammkapitalverlust-paragraf-49-gmbhg` |
| Kapitalerhoehung & Streit | `genehmigtes-kapital`, `kapitalerhoehung-bezugsrecht`, `gesellschafterstreit-eilantraege` |
| Pruefung | `firmenname-pruefung` |

### Schulungsakte — `testakten/gesellschaftsgruender-streit-roeschen-tech/`

Fiktiver Fall „Roeschen Tech GmbH" mit vollstaendigem Streit-Szenario:

1. **README** — Szenario und Lerninhalte
2. **Satzung** — vollstaendig mit B-Shares, Vetorechten, Liquidation Preference, Anti-Dilution
3. **Shareholder Agreement** — Vesting, Drag/Tag, Stimmverpflichtungen, Pönalen
4. **Cap Table** — 4 Staende (Gruendung, nach Series A, nach 2. KE, hypothetisches Szenario mit Bezugsrechten); Liquidation-Waterfall-Beispiele
5. **Einladung GV 18.06.2026** — mit Beschluss-Vorlage zur Kapitalerhoehung mit Bezugsrechtsausschluss
6. **GV-Protokoll** — streitige Versammlung mit Wahl des Versammlungsleiters, Beschluss 85:15, Anfechtungsvorbehalt
7. **Anfechtungsklage** — vollstaendig formuliert (BGH Kali+Salz, Treuepflicht)
8. **Eilantrag LG + Registergericht** — Glaubhaftmachung, Eilbeduerftigkeit, Sicherheitsleistung
9. **Beirat-Schlichtungs-Empfehlung** — konkreter Vergleichs-Vorschlag mit Mischlosung
10. **Schulungsbegleiter** — Lernziele, Aufgaben, sokratische Diskussions-Fragen, Loesungs-Skizzen

## Beruecksichtigte Rechtsquellen

- **GmbHG** (Paragrafen 5, 5a, 7, 15, 34, 38, 40, 43, 46-51, 53-55a, 64)
- **HGB** (Paragrafen 16-18, 30, 106, 108, 161, 170, 257)
- **GwG** (Paragrafen 2-3, 10-12, 19-23, 43, 56)
- **InsO** (Paragrafen 15a, 17, 19)
- **StaRUG** (Paragrafen 1, 31, 49)
- **MoPeG / DiRUG / TraFinG**
- **BGB** (Paragrafen 134, 138, 181, 242, 705-721)
- **AktG** (Paragrafen 12, 23, 95, 186, 246, 248)
- **ZPO** (Paragrafen 935, 894; 1031, 1061-1064)
- **FamFG** (Paragrafen 374, 391)
- **SGB IV** (Paragrafen 7, 7a, 24-25)
- **SGB VII** (Paragraf 192)
- **BSG-Linie zu GF-SV-Status** (NJW 2012, 2310; NJW 2016, 1990; NJW 2017, 1056)
- **BGH-Linie Kali+Salz** (BGHZ 71, 40) und **Macrotron** (NJW 2005, 985)
- **BGH-Treuepflicht-Linie** (NJW 2007, 917; NJW 2018, 1233)

## Qualitaets-Mass

| Metrik | Wert |
|---|---|
| Skills im Plugin | 34 (vorher 17) |
| Woerter pro Skill | 637-1193 (Mittel ~850) |
| Stubs (<200 W) | 0 |
| Schulungsakte | 10 Dateien, ~50 KB Text |

## Validierung

- `scripts/validate-plugin-structure.mjs`: **gruen**
- 34 Skills mit YAML-Frontmatter `name` und `description`
- Description-Laenge unter 1024 Zeichen je Skill
- README aktualisiert mit Phasen-Struktur und Skill-Liste

## Test-Plan

- [ ] In Cowork installieren — Plugin erscheint im Marketplace mit 34 Skills
- [ ] `gesellschaftsgruender-gruender-intake` aufrufen — strukturierte Abfrage funktioniert
- [ ] `gesellschaftsgruender-cap-table` mit Test-Daten durchprobieren
- [ ] Schulungsakte oeffnen — Satzung, SHA, Klagschrift lesbar
- [ ] Eilantrags-Template fuer eigenes Mandat anpassen-tauglich

---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_