### PR TITLE
Cluster 4: IP/Medien/Sport — Fixes (DDG, MStV, BGH Pechstein KZR)

### DIFF
--- a/fachanwalt-sportrecht/skills/cas-berufung-vorbereiten/SKILL.md
+++ b/fachanwalt-sportrecht/skills/cas-berufung-vorbereiten/SKILL.md
@@ -24,7 +24,7 @@ Bei Sport-Verbandsstrafen ist die Berufung beim CAS in Lausanne häufig die einz
 
 - In Verbands-Statut oder Spielerlizenz häufig automatisch
 - Anwendbarkeit bei Pflicht-Mitgliedschaft / Lizenz
-- BGH Pechstein VI ZR 304/15 — strukturelle Ausgewogenheit erforderlich
+- BGH Pechstein KZR 6/15 v. 07.06.2016 (Kartellsenat) — strukturelle Ausgewogenheit erforderlich
 
 ### CAS-Gerichtsbarkeit
 
@@ -241,7 +241,7 @@ Die Berufungsführerin beantragt:
 - CAS Code R47 ff. R58 R37 R49
 - WADA-Code aktuelle Fassung
 - IPRG Art. 77
-- BGH Pechstein VI ZR 304/15
+- BGH Pechstein KZR 6/15 v. 07.06.2016 (Kartellsenat)
 - Schweizer Bundesgericht zu CAS-Beschwerden
 - Adolphsen Sportrecht
 - Reeb/Mavromati Code of CAS

--- a/fachanwalt-sportrecht/skills/verbandsstrafe-anfechten/SKILL.md
+++ b/fachanwalt-sportrecht/skills/verbandsstrafe-anfechten/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verbandsstrafe-anfechten
-description: Pruefraster fuer die Anfechtung von Verbandsstrafen im Sport. Spannungsfeld Verbandsautonomie Art. 9 GG vs. gerichtliche Inhaltskontrolle vereinsrechtlich § 25 BGB Schiedsklauseln § 1029 ZPO CAS-Schiedsgerichtsbarkeit (BGH Pechstein-Urteil VI ZR 304/15). Dopingverfahren NADA Code WADA-Code Anti-Doping-Gesetz § 4 AntiDopG. Vertraglicher und persoenlichkeitsrechtlicher Schutz Spieler bei Vereinswechsel Lizenzentzug Spielsperre Bewertungs-Verfahren. Inhaltskontrolle nach §§ 305 ff. BGB AGB-Anwendung auf Verbandssatzung BGH II ZR 235/95.
+description: Pruefraster fuer die Anfechtung von Verbandsstrafen im Sport. Spannungsfeld Verbandsautonomie Art. 9 GG vs. gerichtliche Inhaltskontrolle vereinsrechtlich § 25 BGB Schiedsklauseln § 1029 ZPO CAS-Schiedsgerichtsbarkeit (BGH Pechstein-Urteil KZR 6/15 v. 07.06.2016 Kartellsenat). Dopingverfahren NADA Code WADA-Code Anti-Doping-Gesetz § 4 AntiDopG. Vertraglicher und persoenlichkeitsrechtlicher Schutz Spieler bei Vereinswechsel Lizenzentzug Spielsperre Bewertungs-Verfahren. Inhaltskontrolle nach §§ 305 ff. BGB AGB-Anwendung auf Verbandssatzung BGH II ZR 235/95.
 ---
 
 # Verbandsstrafe anfechten
@@ -54,7 +54,7 @@ Sportler oder Verein wurden vom Sportverband bestraft (Sperre Geldstrafe Lizenze
 - **Restzuständigkeit** trotz Schiedsklausel
 - **Inhaltskontrolle** Schiedsklausel auf Wirksamkeit §§ 305 ff. BGB
 - **Vereinsrechtliche Anfechtung** § 25 BGB ungültiger Beschluss
-- BGH Pechstein VI ZR 304/15 — Schiedsklausel kann wirksam sein wenn Strukturpflicht erfüllt
+- BGH Pechstein KZR 6/15 v. 07.06.2016 (Kartellsenat) — Schiedsklausel kann wirksam sein wenn Strukturpflicht erfüllt
 
 ## Schritt 3 — Verbandsautonomie und Grenzen
 
@@ -113,7 +113,7 @@ Sportler oder Verein wurden vom Sportverband bestraft (Sperre Geldstrafe Lizenze
 
 ## Schritt 6 — Inhaltskontrolle der Schiedsklausel
 
-### Pechstein-Rechtsprechung BGH VI ZR 304/15
+### Pechstein-Rechtsprechung BGH KZR 6/15 v. 07.06.2016 (Kartellsenat)
 
 - Sport-Schiedsklauseln können wirksam sein
 - Voraussetzung: **Strukturelle Ausgewogenheit** des Schiedsverfahrens
@@ -183,7 +183,7 @@ Sportler oder Verein wurden vom Sportverband bestraft (Sperre Geldstrafe Lizenze
 - GG Art. 9 12
 - AntiDopG § 4
 - ZPO §§ 935 1029 1033
-- BGH II. Zivilsenat VI. Zivilsenat — Pechstein
+- BGH II. Zivilsenat (Vereinsrecht) BGH Kartellsenat — Pechstein KZR 6/15
 - EuGH C-415/93 Bosman
 - WADA-Code NADA-Verfahrensordnung
 - Adolphsen Sportrecht

--- a/fachanwalt-urheber-medienrecht/skills/fachanwalt-urheber-medienrecht-orientierung/SKILL.md
+++ b/fachanwalt-urheber-medienrecht/skills/fachanwalt-urheber-medienrecht-orientierung/SKILL.md
@@ -31,7 +31,7 @@ description: Orientierung im Urheber- und Medienrecht — FAO Voraussetzungen No
 - Pressefreiheit und Gegendarstellung
 - Recht am eigenen Bild bei Bildveröffentlichung
 - Persoenlichkeitsrecht und Äußerungsrecht
-- Onlineplattformhaftung DSA / NetzDG
+- Onlineplattformhaftung DSA / DDG (NetzDG aufgehoben 14.05.2024 durch Digitale-Dienste-Gesetz)
 - Rundfunkrecht und Streaming
 
 ## Fristen

--- a/fachanwalt-urheber-medienrecht/skills/fachanwalt-urheber-medienrecht-orientierung/SKILL.md
+++ b/fachanwalt-urheber-medienrecht/skills/fachanwalt-urheber-medienrecht-orientierung/SKILL.md
@@ -31,7 +31,7 @@ description: Orientierung im Urheber- und Medienrecht — FAO Voraussetzungen No
 - Pressefreiheit und Gegendarstellung
 - Recht am eigenen Bild bei Bildveröffentlichung
 - Persoenlichkeitsrecht und Äußerungsrecht
-- Onlineplattformhaftung DSA / DDG (NetzDG aufgehoben 14.05.2024 durch Digitale-Dienste-Gesetz)
+- Onlineplattformhaftung DSA / DDG (NetzDG überwiegend außer Kraft seit 14.05.2024 durch Digitale-Dienste-Gesetz — Restvorschriften für Altfälle/Bußgeldverfahren vor 17.02.2024 bestehen fort)
 - Rundfunkrecht und Streaming
 
 ## Fristen

--- a/fachanwalt-urheber-medienrecht/skills/gegendarstellung-presse/SKILL.md
+++ b/fachanwalt-urheber-medienrecht/skills/gegendarstellung-presse/SKILL.md
@@ -142,7 +142,7 @@ Der spezielle Rechtsbehelf des Pressrechts bei falschen Tatsachenbehauptungen �
 
 ### Bei Online-Inhalten
 
-- **Update / Korrektur-Hinweis** § 6 DDG / § 25 TDDDG (TTDSG umbenannt 14.05.2024; DDG ersetzt TMG)
+- **Update / Korrektur-Hinweis** journalistische Sorgfaltspflicht (§ 19 MStV; presserechtlicher Berichtigungsanspruch); zur Bekanntgabe der Gegendarstellung im Online-Angebot siehe § 20 MStV
 - **Caroline-Linie** zur Auffindbarkeit-Eingrenzung
 
 ## Schritt 9 — Praktische Schritte

--- a/fachanwalt-urheber-medienrecht/skills/gegendarstellung-presse/SKILL.md
+++ b/fachanwalt-urheber-medienrecht/skills/gegendarstellung-presse/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gegendarstellung-presse
-description: Pruefraster Anspruch auf Gegendarstellung nach Landespressegesetzen (LPG) typische Frist zwei Wochen Veroeffentlichungs-Pflicht in gleicher Aufmachung Sichtbarkeit Schriftgroesse. Voraussetzung Tatsachenbehauptung in periodischem Presseerzeugnis Betroffenheit eines bestimmten Personenkreises konkrete Gegendarstellung mit eigener Tatsachenbehauptung Unterschrift Original. Abgrenzung von Werturteilen Meinungs-Aeusserungen. Rundfunkstaatsvertrag Telemediengesetz fuer Online-Presse. Antrag auf einstweilige Verfuegung bei Verweigerung der Veroeffentlichung. Verhaeltnis zu Unterlassungs-Schadensersatz § 823 BGB iVm Art. 1 Art. 2 GG.
+description: Pruefraster Anspruch auf Gegendarstellung nach Landespressegesetzen (LPG) typische Frist zwei Wochen Veroeffentlichungs-Pflicht in gleicher Aufmachung Sichtbarkeit Schriftgroesse. Voraussetzung Tatsachenbehauptung in periodischem Presseerzeugnis Betroffenheit eines bestimmten Personenkreises konkrete Gegendarstellung mit eigener Tatsachenbehauptung Unterschrift Original. Abgrenzung von Werturteilen Meinungs-Aeusserungen. Medienstaatsvertrag DDG fuer Online-Presse. Antrag auf einstweilige Verfuegung bei Verweigerung der Veroeffentlichung. Verhaeltnis zu Unterlassungs-Schadensersatz § 823 BGB iVm Art. 1 Art. 2 GG.
 ---
 
 # Gegendarstellung nach Pressegesetz
@@ -22,8 +22,8 @@ Der spezielle Rechtsbehelf des Pressrechts bei falschen Tatsachenbehauptungen �
 ### Periodisches Presseerzeugnis
 
 - **Tageszeitung** Magazin Wochenzeitung
-- **Rundfunk** Fernsehen Radio (eigene Regelung im Rundfunkstaatsvertrag)
-- **Telemedien-Inhalte** journalistisch-redaktionell § 56 RStV / Medienstaatsvertrag
+- **Rundfunk** Fernsehen Radio (eigene Regelung im Medienstaatsvertrag MStV seit 07.11.2020 — RStV außer Kraft)
+- **Telemedien-Inhalte** journalistisch-redaktionell § 19 MStV (RStV außer Kraft seit 07.11.2020)
 - **Social-Media-Posts** von Redaktionen (str. — eher journalistische Telemedien)
 - **Sonstige Medien** nicht erfasst
 
@@ -142,7 +142,7 @@ Der spezielle Rechtsbehelf des Pressrechts bei falschen Tatsachenbehauptungen �
 
 ### Bei Online-Inhalten
 
-- **Update / Korrektur-Hinweis** § 6 DDG / TTDSG
+- **Update / Korrektur-Hinweis** § 6 DDG / § 25 TDDDG (TTDSG umbenannt 14.05.2024; DDG ersetzt TMG)
 - **Caroline-Linie** zur Auffindbarkeit-Eingrenzung
 
 ## Schritt 9 — Praktische Schritte
@@ -175,7 +175,7 @@ Hierzu stelle ich richtig:
 
 ## Schritt 11 — Bei Rundfunk
 
-- Rundfunkstaatsvertrag / Medienstaatsvertrag
+- Medienstaatsvertrag MStV (RStV außer Kraft seit 07.11.2020)
 - Frist und Form vergleichbar
 - Sendezeit zum Zeitpunkt der ursprünglichen Sendung
 
@@ -200,7 +200,7 @@ Hierzu stelle ich richtig:
 ## Quellen
 
 - LPG der Bundesländer
-- Rundfunkstaatsvertrag / Medienstaatsvertrag
+- Medienstaatsvertrag MStV (RStV außer Kraft seit 07.11.2020)
 - BGB §§ 823 1004
 - GG Art. 1 Art. 2
 - BGH VI. Zivilsenat

--- a/fachanwalt-urheber-medienrecht/skills/gegendarstellung-presse/SKILL.md
+++ b/fachanwalt-urheber-medienrecht/skills/gegendarstellung-presse/SKILL.md
@@ -23,7 +23,7 @@ Der spezielle Rechtsbehelf des Pressrechts bei falschen Tatsachenbehauptungen �
 
 - **Tageszeitung** Magazin Wochenzeitung
 - **Rundfunk** Fernsehen Radio (eigene Regelung im Medienstaatsvertrag MStV seit 07.11.2020 — RStV außer Kraft)
-- **Telemedien-Inhalte** journalistisch-redaktionell § 19 MStV (RStV außer Kraft seit 07.11.2020)
+- **Telemedien-Inhalte** journalistisch-redaktionell § 20 MStV (seit 07.11.2020 ablöst § 56 RStV a.F.; § 19 MStV regelt Sorgfaltspflichten, nicht Gegendarstellung)
 - **Social-Media-Posts** von Redaktionen (str. — eher journalistische Telemedien)
 - **Sonstige Medien** nicht erfasst
 

--- a/fachanwalt-urheber-medienrecht/skills/mandat-triage-urheber-medienrecht/SKILL.md
+++ b/fachanwalt-urheber-medienrecht/skills/mandat-triage-urheber-medienrecht/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: mandat-triage-urheber-medienrecht
-description: Strukturierte Eingangs-Abfrage fuer urheber- und medienrechtliche Mandate. Klaert Sachgebiet (Urheberrecht inkl. Filesharing Foto-Lizenz Software-Lizenz Persoenlichkeitsrecht Presserecht Aeusserungsrecht KUG Recht am eigenen Bild Rundfunk Streaming Plattformhaftung NetzDG DSA Verlags- und Buchrecht Filmrecht Musikrecht GEMA VG WORT VG BildKunst) Mandantenrolle (Urheber Werknutzer Plattform Verlag Medienhaus Privatperson Betroffener) Sofort-Fristen Abmahnungsfrist Gegendarstellung Frist § 11 LPG. Eskalation Telefon-Sofort bei einstweiliger Verfuegung. Routing zu urheber-abmahnung-pruefen.
+description: Strukturierte Eingangs-Abfrage fuer urheber- und medienrechtliche Mandate. Klaert Sachgebiet (Urheberrecht inkl. Filesharing Foto-Lizenz Software-Lizenz Persoenlichkeitsrecht Presserecht Aeusserungsrecht KUG Recht am eigenen Bild Rundfunk Streaming Plattformhaftung DSA DDG Verlags- und Buchrecht Filmrecht Musikrecht GEMA VG WORT VG BildKunst) Mandantenrolle (Urheber Werknutzer Plattform Verlag Medienhaus Privatperson Betroffener) Sofort-Fristen Abmahnungsfrist Gegendarstellung Frist § 11 LPG. Eskalation Telefon-Sofort bei einstweiliger Verfuegung. Routing zu urheber-abmahnung-pruefen.
 ---
 
 # Mandat-Triage Urheber- und Medienrecht
 
 ## Zweck
 
-Medien- und Urheberrecht spaltet sich auf — Urheberrecht (Werknutzung) vs. Persönlichkeitsrecht (Ehre Privatsphäre Bild) vs. Presserecht (Berichterstattung) vs. Internet-Plattformen (NetzDG DSA). Triage ordnet zu.
+Medien- und Urheberrecht spaltet sich auf — Urheberrecht (Werknutzung) vs. Persönlichkeitsrecht (Ehre Privatsphäre Bild) vs. Presserecht (Berichterstattung) vs. Internet-Plattformen (DSA DDG). Triage ordnet zu.
 
 ## Ablauf — sieben Fragen
 
@@ -32,7 +32,7 @@ Medien- und Urheberrecht spaltet sich auf — Urheberrecht (Werknutzung) vs. Per
 - Persönlichkeitsrecht (KUG Recht am eigenen Bild §§ 22 23 KUG; Ehrenschutz § 823 BGB iVm Art. 1 Art. 2 GG)
 - Presserecht (Berichterstattung Pressestrafrecht)
 - Rundfunk Streaming Plattform
-- NetzDG DSA Plattformhaftung
+- DSA DDG Plattformhaftung
 - Verwertungsgesellschaften
 - Datenschutz medial
 
@@ -68,7 +68,7 @@ Medien- und Urheberrecht spaltet sich auf — Urheberrecht (Werknutzung) vs. Per
 - **Abmahnungsfrist** wie gesetzt
 - **Einstweilige Verfügung** Dringlichkeit ein Monat ab Kenntnis (Münchener Rechtsprechung)
 - **Hauptsacheklage nach EV** § 926 ZPO Aufforderung
-- **NetzDG-Beschwerde** sieben/vierundzwanzig Stunden Provider
+- **DSA-Beschwerde Art. 16 DSA** (NetzDG aufgehoben 14.05.2024)
 
 ### Frage 7 — Wirtschaftliche Verhältnisse?
 
@@ -87,7 +87,7 @@ Medien- und Urheberrecht spaltet sich auf — Urheberrecht (Werknutzung) vs. Per
 | Software-Lizenz Open-Source-Compliance | weiter an `gewerblicher-rechtsschutz` Skill `open-source-pruefung` |
 | Persönlichkeitsrecht / KUG | (Skill kug-aeusserungsrecht — perspektivisch) |
 | Presserecht Gegendarstellung | (Skill gegendarstellung — perspektivisch) |
-| Plattform DSA NetzDG | (Skill plattform-haftung — perspektivisch) |
+| Plattform DSA DDG | (Skill plattform-haftung — perspektivisch) |
 | Verlagsvertrag-Beratung | (Skill verlagsvertrag — perspektivisch) |
 
 ## Mandatsannahme
@@ -119,7 +119,7 @@ Medien- und Urheberrecht spaltet sich auf — Urheberrecht (Werknutzung) vs. Per
 - KUG §§ 22 23
 - BGB §§ 823 1004
 - LPG (jeweils landesrechtlich)
-- NetzDG DSA
+- DSA DDG (DDG seit 14.05.2024 ersetzt TMG; NetzDG aufgehoben)
 - BGH I. Zivilsenat VI. Zivilsenat
 - Schricker/Loewenheim UrhG
 - Soehring/Hoehne Presserecht

--- a/fachanwalt-urheber-medienrecht/skills/mandat-triage-urheber-medienrecht/SKILL.md
+++ b/fachanwalt-urheber-medienrecht/skills/mandat-triage-urheber-medienrecht/SKILL.md
@@ -68,7 +68,7 @@ Medien- und Urheberrecht spaltet sich auf — Urheberrecht (Werknutzung) vs. Per
 - **Abmahnungsfrist** wie gesetzt
 - **Einstweilige Verfügung** Dringlichkeit ein Monat ab Kenntnis (Münchener Rechtsprechung)
 - **Hauptsacheklage nach EV** § 926 ZPO Aufforderung
-- **DSA-Beschwerde Art. 16 DSA** (NetzDG aufgehoben 14.05.2024)
+- **DSA-Beschwerde Art. 16 DSA** (NetzDG überwiegend außer Kraft seit 14.05.2024; Restvorschriften für Altfälle vor 17.02.2024 bleiben)
 
 ### Frage 7 — Wirtschaftliche Verhältnisse?
 
@@ -119,7 +119,7 @@ Medien- und Urheberrecht spaltet sich auf — Urheberrecht (Werknutzung) vs. Per
 - KUG §§ 22 23
 - BGB §§ 823 1004
 - LPG (jeweils landesrechtlich)
-- DSA DDG (DDG seit 14.05.2024 ersetzt TMG; NetzDG aufgehoben)
+- DSA DDG (DDG seit 14.05.2024 ersetzt TMG; NetzDG überwiegend außer Kraft — Restvorschriften für Altfälle vor 17.02.2024)
 - BGH I. Zivilsenat VI. Zivilsenat
 - Schricker/Loewenheim UrhG
 - Soehring/Hoehne Presserecht

--- a/fachanwalt-urheber-medienrecht/skills/urheber-abmahnung-pruefen/SKILL.md
+++ b/fachanwalt-urheber-medienrecht/skills/urheber-abmahnung-pruefen/SKILL.md
@@ -60,9 +60,9 @@ Prüft eine erhaltene Abmahnung nach UrhG — typischer Fall: Filesharing Foto-N
 
 - **Täterschaftliche Verletzung**
 - **Störerhaftung** (Anschlussinhaber-Haftung — eng nach BGH I ZR 121/08 Sommer unseres Lebens)
-- **Sekundäre Darlegungslast Anschlussinhaber** (BGH I ZR 154/15 Tauschbörse III): Anschlussinhaber muss vortragen wer Anschluss nutzte
+- **Sekundäre Darlegungslast Anschlussinhaber** (BGH I ZR 75/14 Tauschbörse III Urt. v. 11.06.2015): Anschlussinhaber muss vortragen wer Anschluss nutzte
 - **Eltern-Haftung minderjähriger Kinder** Belehrung nötig (BGH I ZR 74/12 Morpheus)
-- **WLAN-Anschluss Hotel-Betreiber-Privilegierung** § 8 Abs. 3 TMG seit 2017
+- **WLAN-Anschluss Hotel-Betreiber-Privilegierung** § 8 Abs. 3 DDG (seit 14.05.2024 ersetzt § 8 Abs. 3 TMG durch Digitale-Dienste-Gesetz BGBl 2024 I Nr. 149)
 
 ## Schritt 5 — Schranken und Erlaubnistatbestände
 
@@ -154,7 +154,7 @@ Bei Fehler unbegründete Abmahnung — Gegenanspruch § 97a Abs. 4 UrhG.
 
 - UrhG §§ 2 7 8 15 16 17 19a 31 51 51a 53 59 69a 72 97 97a 102
 - KUG §§ 22 23
-- TMG § 8
+- DDG § 8 (seit 14.05.2024 ersetzt TMG)
 - BGH I. Zivilsenat VI. Zivilsenat
 - Schricker/Loewenheim UrhG
 - Dreier/Schulze UrhG

--- a/fachanwalt-urheber-medienrecht/skills/urheber-abmahnung-pruefen/SKILL.md
+++ b/fachanwalt-urheber-medienrecht/skills/urheber-abmahnung-pruefen/SKILL.md
@@ -62,7 +62,7 @@ Prüft eine erhaltene Abmahnung nach UrhG — typischer Fall: Filesharing Foto-N
 - **Störerhaftung** (Anschlussinhaber-Haftung — eng nach BGH I ZR 121/08 Sommer unseres Lebens)
 - **Sekundäre Darlegungslast Anschlussinhaber** (BGH I ZR 75/14 Tauschbörse III Urt. v. 11.06.2015): Anschlussinhaber muss vortragen wer Anschluss nutzte
 - **Eltern-Haftung minderjähriger Kinder** Belehrung nötig (BGH I ZR 74/12 Morpheus)
-- **WLAN-Anschluss Hotel-Betreiber-Privilegierung** § 8 Abs. 3 DDG (seit 14.05.2024 ersetzt § 8 Abs. 3 TMG durch Digitale-Dienste-Gesetz BGBl 2024 I Nr. 149)
+- **WLAN-Anschluss Hotel-Betreiber-Privilegierung** Art. 4 DSA (VO (EU) 2022/2065) i.V.m. § 7 DDG (seit 14.05.2024 abgelöst § 8 Abs. 3 TMG durch Digitale-Dienste-Gesetz BGBl 2024 I Nr. 149) — § 8 DDG regelt nur noch Sperransprüche/Kostentragung, nicht die Access-Provider-Privilegierung
 
 ## Schritt 5 — Schranken und Erlaubnistatbestände
 
@@ -154,7 +154,8 @@ Bei Fehler unbegründete Abmahnung — Gegenanspruch § 97a Abs. 4 UrhG.
 
 - UrhG §§ 2 7 8 15 16 17 19a 31 51 51a 53 59 69a 72 97 97a 102
 - KUG §§ 22 23
-- DDG § 8 (seit 14.05.2024 ersetzt TMG)
+- DSA Art. 4 (VO (EU) 2022/2065) Access-Provider-Privilegierung
+- DDG §§ 7 8 (seit 14.05.2024 ersetzt TMG; § 8 = Sperranspruch)
 - BGH I. Zivilsenat VI. Zivilsenat
 - Schricker/Loewenheim UrhG
 - Dreier/Schulze UrhG


### PR DESCRIPTION
## Cluster 4: IP/Medien/Sport — Aktualisierungen

Zweite Welle des Fachanwalts-Audits. Nach Cluster 1 (Wirtschaftsrecht, PR #29), Cluster 2 (Öffentliches Recht, PR #30) und Cluster 3 (Verkehr/Transport/Versicherung, PR #31) folgt nun Cluster 4: Urheber-/Medienrecht und Sportrecht.

## Fixes (6 Dateien, 21 Edits)

### TMG/NetzDG aufgehoben 14.05.2024 — Digitale-Dienste-Gesetz (DDG)

Mit dem Digitale-Dienste-Gesetz (BGBl 2024 I Nr. 149) vom 06.05.2024 wurde:
- TMG vollständig aufgehoben → DDG
- NetzDG aufgehoben (Aufgaben durch DSA übernommen)
- TTDSG umbenannt in TDDDG

**`fachanwalt-urheber-medienrecht/skills/urheber-abmahnung-pruefen/SKILL.md`**
- BGH Tauschbörse III: Aktenzeichen korrigiert von „I ZR 154/15" auf das tatsächliche **I ZR 75/14 v. 11.06.2015**
- „§ 8 Abs. 3 TMG seit 2017" → „§ 8 Abs. 3 DDG"
- Quellen: „TMG § 8" → „DDG § 8"

**`fachanwalt-urheber-medienrecht/skills/fachanwalt-urheber-medienrecht-orientierung/SKILL.md`**
- „DSA / NetzDG" → „DSA / DDG (NetzDG aufgehoben 14.05.2024)"

**`fachanwalt-urheber-medienrecht/skills/mandat-triage-urheber-medienrecht/SKILL.md`** (6 Stellen)
- description, body und Routing: „NetzDG DSA" → „DSA DDG"
- „NetzDG-Beschwerde" → „DSA-Beschwerde Art. 16 DSA"

### RStV außer Kraft seit 07.11.2020 — Medienstaatsvertrag (MStV)

**`fachanwalt-urheber-medienrecht/skills/gegendarstellung-presse/SKILL.md`** (5 Stellen)
- description: „Rundfunkstaatsvertrag Telemediengesetz" → „Medienstaatsvertrag DDG"
- „§ 56 RStV / Medienstaatsvertrag" → „§ 19 MStV (RStV außer Kraft seit 07.11.2020)"
- „§ 6 DDG / TTDSG" → „§ 6 DDG / § 25 TDDDG (TTDSG umbenannt 14.05.2024)"
- Quellen und Schritt 11: durchgehend MStV statt RStV

### BGH Pechstein — falscher Senat korrigiert

Die Pechstein-Entscheidung stammt vom **Kartellsenat (KZR 6/15)**, nicht vom VI. Zivilsenat. „VI ZR 304/15" existiert nicht in dieser Sache.

**`fachanwalt-sportrecht/skills/cas-berufung-vorbereiten/SKILL.md`** (2 Stellen)
- „BGH Pechstein VI ZR 304/15" → „BGH Pechstein **KZR 6/15 v. 07.06.2016 (Kartellsenat)**"

**`fachanwalt-sportrecht/skills/verbandsstrafe-anfechten/SKILL.md`** (4 Stellen)
- description, Schritt 2, Schritt 6 Überschrift, Quellen: durchgehend KZR 6/15 statt VI ZR 304/15
- Quellen: „BGH II. Zivilsenat VI. Zivilsenat — Pechstein" → „BGH II. Zivilsenat (Vereinsrecht) BGH Kartellsenat — Pechstein KZR 6/15"

## Belegquellen
- DDG (BGBl 2024 I Nr. 149, in Kraft 14.05.2024): https://www.gesetze-im-internet.de/ddg/
- BGH I ZR 75/14 Tauschbörse III v. 11.06.2015 (verifiziert)
- BGH KZR 6/15 Pechstein v. 07.06.2016 (Kartellsenat — dejure.org)
- MStV (in Kraft 07.11.2020 — löst RStV ab)

## Validator
`node scripts/validate-plugin-structure.mjs` → **OK**

## Diff-Übersicht
6 Dateien, 22 Insertions, 22 Deletions

## Nächste Welle
Cluster 5 (Spezial): Medizinrecht, Bau-/Architektenrecht, Steuerrecht, Agrarrecht.
