### PR TITLE
Wave-1-Followup: WEG-Anfechtungsgruende + KostRMoG-Zitat (Codex P2/P3)

### DIFF
--- a/fachanwalt-erbrecht/skills/fachanwalt-erbrecht-testamentsentwurf/SKILL.md
+++ b/fachanwalt-erbrecht/skills/fachanwalt-erbrecht-testamentsentwurf/SKILL.md
@@ -70,5 +70,5 @@ Saemtliche Verfuegungen sind wechselbezueglich § 2270 BGB.
 
 - Bei Vermögen über Freibeträgen (Ehegatte 500 TEUR Kinder 400 TEUR § 16 ErbStG) Hinweis auf Schenkungs-/Erbschaftsteuerberatung.
 - Bei Unternehmensvermögen Nachfolgeregelung gesondert prüfen (Begünstigungen §§ 13a, 13b ErbStG).
-- Empfehlung Hinterlegung beim Amtsgericht (§ 2248 BGB) — Hinterlegungsgebühr nach GNotKG (KostO ist mit Wirkung zum 01.08.2013 außer Kraft getreten, Art. 9 2. KostRMoG).
+- Empfehlung Hinterlegung beim Amtsgericht (§ 2248 BGB) — Hinterlegungsgebühr nach GNotKG (KostO ist durch das 2. KostRMoG vom 23.07.2013, BGBl. I S. 2586, mit Wirkung zum 01.08.2013 ausser Kraft getreten).
 - Anschluss-Skill bei späterem Erbfall: `fachanwalt-erbrecht-erbschein-antrag`.

--- a/fachanwalt-miet-wohnungseigentumsrecht/skills/fachanwalt-miet-wohnungseigentumsrecht-weg-beschlussanfechtung/SKILL.md
+++ b/fachanwalt-miet-wohnungseigentumsrecht/skills/fachanwalt-miet-wohnungseigentumsrecht-weg-beschlussanfechtung/SKILL.md
@@ -16,10 +16,10 @@ description: Beschlussanfechtungsklage nach § 44 WEG. Klagefrist einen Monat ab
 
 ## Rechtsgrundlagen
 
-- **Beschlussfassung:** §§ 23, 25 WEG — Mehrheit der abgegebenen Stimmen § 25 Abs. 1 WEG; gesetzlicher Regelfall ist das Kopfstimmrecht § 25 Abs. 2 WEG (jeder Wohnungseigentuemer eine Stimme); abweichende Stimmrechtsmodelle (Wert- oder Objektprinzip) erfordern Vereinbarung in der Teilungserklaerung.
+- **Beschlussfassung:** §§ 23, 25 WEG — Mehrheit der abgegebenen Stimmen § 25 Abs. 1 WEG; gesetzlicher Regelfall ist das Kopfstimmrecht § 25 Abs. 2 WEG (jeder Wohnungseigentuemer eine Stimme); abweichende Stimmrechtsmodelle (Wert- oder Objektprinzip) erfordern eine Vereinbarung der Wohnungseigentuemer nach § 10 Abs. 1 S. 2 WEG (typischerweise in der Teilungserklaerung, aber auch durch spaetere Vereinbarung moeglich; fuer Wirkung gegen Sondernachfolger Grundbucheintragung § 10 Abs. 3 WEG).
 - **Anfechtungsklage:** § 44 WEG seit Reform 01.12.2020 — Klage gegen die Gemeinschaft der Wohnungseigentümer; vorher Klage gegen alle übrigen Eigentümer.
 - **Frist § 45 WEG:** Klage binnen eines Monats ab Beschlussfassung; Klagebegründung binnen weiterer zwei Monate.
-- **Anfechtungsgründe:** Verstoß gegen ordnungsmässige Verwaltung § 19 WEG, gegen das WEG selbst oder gegen Vereinbarungen § 10 Abs. 1 S. 2 WEG (Vereinbarungsbefugnis); fuer Wirkung gegen Sondernachfolger Grundbucheintragung § 10 Abs. 3 WEG.
+- **Anfechtungsgründe:** Verstoß gegen ordnungsmässige Verwaltung § 19 WEG, gegen das Gesetz (WEG und sonstiges zwingendes Recht, insb. BGB und einschlaegiges oeffentliches Recht mit Beschlussbezug) oder gegen Vereinbarungen § 10 Abs. 1 S. 2 WEG.
 - **Nichtigkeit:** Beschluss ohne Beschlusskompetenz, Verstoß gegen zwingendes Recht (§§ 134, 138 BGB analog), grobe Unbestimmtheit.
 - **Aktivlegitimation:** Jeder Wohnungseigentümer, der Eigentümer im Zeitpunkt der Beschlussfassung war (§ 44 Abs. 1 WEG).
 - **Passivlegitimation:** Gemeinschaft der Wohnungseigentümer als Beklagte, vertreten durch Verwalter § 9b WEG.


### PR DESCRIPTION
**Hintergrund:** Drei Codex-Hinweise auf den schon gemergten Wave-1-PRs #22 (WEG-Beschlussanfechtung) und #24 (Testamentsentwurf), die in den ursprünglichen PRs nicht mehr eingearbeitet wurden.

## PR #22 (WEG-Beschlussanfechtung)

**P2 — Anfechtungsgruende:**
Vorher: 'Verstoss gegen WEG selbst' verengt die Anfechtungsgruende
fälschlich auf das WEG. § 23 Abs. 4 WEG verlangt aber Verstoss
gegen 'Gesetz oder Vereinbarung'; das umfasst alles zwingende Recht.

Nachher: 'gegen das Gesetz (WEG und sonstiges zwingendes Recht,
insb. BGB und einschlaegiges oeffentliches Recht mit Beschlussbezug)'.

**P3 — Stimmrechtsmodelle:**
Vorher: 'erfordern Vereinbarung in der Teilungserklaerung' suggeriert,
abweichende Stimmrechtsmodelle muessten zwingend in der urspruenglichen
Teilungserklaerung stehen.

Nachher: 'erfordern eine Vereinbarung der Wohnungseigentuemer nach
§ 10 Abs. 1 S. 2 WEG (typischerweise in der Teilungserklaerung, aber
auch durch spaetere Vereinbarung moeglich; fuer Wirkung gegen Sonder-
nachfolger Grundbucheintragung § 10 Abs. 3 WEG)'.

## PR #24 (Testamentsentwurf)

**P2 — KostRMoG-Falschzitat:**
Vorher: 'Art. 9 2. KostRMoG' — Art. 9 betrifft das Graebergesetz,
nicht die KostO-Aufhebung.

Nachher: 'KostO ist durch das 2. KostRMoG vom 23.07.2013, BGBl. I
S. 2586, mit Wirkung zum 01.08.2013 ausser Kraft getreten' — ohne
Artikel-Verweis, mit BGBl.-Fundstelle.

**Validator:** validate-plugin-structure OK