### PR TITLE
fix(gesellschaftsgruender): plugin.json description auf 290 Zeichen

### DIFF
--- a/gesellschaftsgruender/.claude-plugin/plugin.json
+++ b/gesellschaftsgruender/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gesellschaftsgruender",
   "version": "6.1.0",
-  "description": "Gruendungsassistent fuer deutsche Gesellschaften. Fuehrt von Rechtsformwahl GmbH UG GbR OHG KG GmbH und Co KG PartG mbB gGmbH ueber Gesellschaftsvertrag und Geschaeftsfuehreranstellungsvertrag bis Notar Handelsregister Gewerbeamt Finanzamt Transparenzregister IHK Berufsgenossenschaft. MoPeG 2024 DiRUG Online-Gruendung GwG TraFinG. Erste-100-Tage-Pflichten fuer Geschaeftsfuehrer. Kein Ersatz fuer Notar- und Anwaltsberatung.",
+  "description": "Gruendungsassistent deutsche Gesellschaften (GmbH UG GbR OHG KG GmbH und Co KG PartG mbB gGmbH). Von Rechtsformwahl ueber Gesellschaftsvertrag und Geschaeftsfuehrervertrag bis Notar Handelsregister Gewerbeamt Finanzamt Transparenzregister. MoPeG DiRUG GwG. Kein Ersatz fuer Anwaltsberatung.",
   "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"


### PR DESCRIPTION
## Problem
Release-Workflow v6.1.0 ist gescheitert:
```
validate-release-zips failed: dist/gesellschaftsgruender.zip: manifest description has 426 chars; Cowork bevorzugt <= 300
```

## Fix
description in `gesellschaftsgruender/.claude-plugin/plugin.json` von 426 auf 290 Zeichen gekuerzt. Rechtsformkatalog, Workflow-Stationen und Haftungshinweis bleiben erhalten.

## Nachgang
Nach Merge: Tag v6.1.1 setzen, damit Release-Workflow die ZIPs erzeugt und unter `releases/latest/download/...` erreichbar macht.