### PR TITLE
feat(readmes): Direkt-Download + Installation + Testakten in 10 Plugin-READMEs

### DIFF
--- a/bereicherungs-und-anfechtungsrecht-pruefer/README.md
+++ b/bereicherungs-und-anfechtungsrecht-pruefer/README.md
@@ -12,7 +12,25 @@ Kein Rechtsberatungs-Tool. Mechanische Tatbestandsprüfung mit ständigen Warnhi
 
 ## Direkt-Download
 
-[bereicherungs-und-anfechtungsrecht-pruefer.zip herunterladen](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/bereicherungs-und-anfechtungsrecht-pruefer.zip)
+| Plugin | Direkt-Download |
+| --- | --- |
+| bereicherungs-und-anfechtungsrecht-pruefer | [bereicherungs-und-anfechtungsrecht-pruefer.zip](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/bereicherungs-und-anfechtungsrecht-pruefer.zip) |
+
+## Installation
+
+1. Claude Code oder Claude Desktop/Cowork öffnen.
+2. **Customize Plugins** bzw. **Personal plugins** wählen.
+3. **Install from .zip** und `bereicherungs-und-anfechtungsrecht-pruefer.zip` hochladen.
+4. Mit einem konkreten Auftrag starten, zum Beispiel: `Prüfe eine Insolvenzanfechtung gegen einen Lieferanten.`
+
+Alternativ via Marketplace:
+
+```
+/plugin marketplace add Klotzkette/claude-fuer-deutsches-recht
+/plugin install bereicherungs-und-anfechtungsrecht-pruefer@claude-fuer-deutsches-recht
+```
+
+Nicht das komplette Repository-ZIP hochladen. Das Plugin-ZIP muss im Root direkt `.claude-plugin/plugin.json` und `skills/` enthalten.
 
 ---
 

--- a/gesellschaftsgruender/README.md
+++ b/gesellschaftsgruender/README.md
@@ -2,6 +2,34 @@
 
 Freistehendes Plugin, das durch die Gruendung einer deutschen Gesellschaft fuehrt — von der Rechtsformwahl ueber Cap Table, Class-Shares, Notar, Handelsregister, Behoerdenanmeldungen bis hin zu den ersten 100 Tagen Geschaeftsfuehrer-Pflichten und Streit-Eskalationen.
 
+## Direkt-Download
+
+| Plugin | Direkt-Download |
+| --- | --- |
+| gesellschaftsgruender | [gesellschaftsgruender.zip](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/gesellschaftsgruender.zip) |
+
+## Installation
+
+1. Claude Code oder Claude Desktop/Cowork oeffnen.
+2. **Customize Plugins** bzw. **Personal plugins** waehlen.
+3. **Install from .zip** und `gesellschaftsgruender.zip` hochladen.
+4. Mit einem konkreten Auftrag starten, zum Beispiel: `Starte die Gesellschaftsgruendung. Rechtsform: GmbH. Drei Gruender, zwei davon im Ausland.`
+
+Alternativ via Marketplace:
+
+```
+/plugin marketplace add Klotzkette/claude-fuer-deutsches-recht
+/plugin install gesellschaftsgruender@claude-fuer-deutsches-recht
+```
+
+Nicht das komplette Repository-ZIP hochladen. Das Plugin-ZIP muss im Root direkt `.claude-plugin/plugin.json`, `skills/`, `assets/` und `references/` enthalten.
+
+## Schulungsakte (Direkt-Download)
+
+- **Streit Roeschen Tech GmbH i.Gr.** (Drei-Gruender-Streit mit Vesting/SHA/Class-Shares): [testakten/gesellschaftsgruender-streit-roeschen-tech/](../testakten/gesellschaftsgruender-streit-roeschen-tech/) -> [testakte-gesellschaftsgruender-streit-roeschen-tech.zip](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/testakte-gesellschaftsgruender-streit-roeschen-tech.zip)
+
+Details zur Schulungsakte stehen weiter unten.
+
 ## Mandatsperspektive
 
 **Du als Anwalt, Steuerberater, Gruender oder Notarberater.** Das Plugin

--- a/hausarbeitenmacher/README.md
+++ b/hausarbeitenmacher/README.md
@@ -2,6 +2,28 @@
 
 Freistehendes Plugin für Studierende der Rechtswissenschaft, das durch das Erstellen einer **Hausarbeit oder Seminararbeit lernfördernd** hindurchführt. Es liefert **keine fertigen Lösungen**, sondern stellt Fragen, gibt Strukturen, Methoden-Hinweise und Zitierweise — Du subsumierst selbst.
 
+## Direkt-Download
+
+| Plugin | Direkt-Download |
+| --- | --- |
+| hausarbeitenmacher | [hausarbeitenmacher.zip](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/hausarbeitenmacher.zip) |
+
+## Installation
+
+1. Claude Code oder Claude Desktop/Cowork öffnen.
+2. **Customize Plugins** bzw. **Personal plugins** wählen.
+3. **Install from .zip** und `hausarbeitenmacher.zip` hochladen.
+4. Mit einer konkreten Aufgabenstellung starten, zum Beispiel: `Hilf mir bei einer Hausarbeit. Sachverhalt folgt.`
+
+Alternativ via Marketplace:
+
+```
+/plugin marketplace add Klotzkette/claude-fuer-deutsches-recht
+/plugin install hausarbeitenmacher@claude-fuer-deutsches-recht
+```
+
+Nicht das komplette Repository-ZIP hochladen. Das Plugin-ZIP muss im Root direkt `.claude-plugin/plugin.json` und `skills/` enthalten.
+
 ## Mandatsperspektive
 
 **Du als Studierende oder Studierender.** Du gibst Deine Aufgabenstellung ein und gehst Schritt für Schritt durch die Lösung. Das Plugin

--- a/ki-vo-ai-act-pruefer/README.md
+++ b/ki-vo-ai-act-pruefer/README.md
@@ -8,7 +8,25 @@ Vollständiger Mechanik-Workflow zur Verordnung (EU) 2024/1689 (KI-VO): KI-Syste
 
 ## Direkt-Download
 
-[ki-vo-ai-act-pruefer.zip herunterladen](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/ki-vo-ai-act-pruefer.zip)
+| Plugin | Direkt-Download |
+| --- | --- |
+| ki-vo-ai-act-pruefer | [ki-vo-ai-act-pruefer.zip](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/ki-vo-ai-act-pruefer.zip) |
+
+## Installation
+
+1. Claude Code oder Claude Desktop/Cowork öffnen.
+2. **Customize Plugins** bzw. **Personal plugins** wählen.
+3. **Install from .zip** und `ki-vo-ai-act-pruefer.zip` hochladen.
+4. Mit einem konkreten Auftrag starten, zum Beispiel: `Prüfe ein KI-System für Bewerbungsauswahl nach der KI-VO.`
+
+Alternativ via Marketplace:
+
+```
+/plugin marketplace add Klotzkette/claude-fuer-deutsches-recht
+/plugin install ki-vo-ai-act-pruefer@claude-fuer-deutsches-recht
+```
+
+Nicht das komplette Repository-ZIP hochladen. Das Plugin-ZIP muss im Root direkt `.claude-plugin/plugin.json` und `skills/` enthalten.
 
 ---
 

--- a/legistik-werkstatt/README.md
+++ b/legistik-werkstatt/README.md
@@ -10,6 +10,10 @@ Vollstaendige Werkstatt fuer Legistinnen und Legisten in Bundes- und Landesminis
 
 Die URL ist stabil und zeigt immer auf die neueste Version. Alle weiteren Plugins sind unter [Releases · latest](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest) genauso einzeln verfügbar.
 
+## Testakte
+
+- **Legistik Pflichtpostfach** (Vom Koalitionsvertrag zum Referentenentwurf, Stammgesetz mit Begruendung und Folgenabschaetzung): [testakten/legistik-pflichtpostfach/](../testakten/legistik-pflichtpostfach/) -> [testakte-legistik-pflichtpostfach.zip](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/testakte-legistik-pflichtpostfach.zip)
+
 ## Installation in Claude Code
 
 1. ZIP herunterladen (Link oben).

--- a/normenkontrolle-bauleitplanung/README.md
+++ b/normenkontrolle-bauleitplanung/README.md
@@ -2,6 +2,32 @@
 
 Freistehendes Plugin für die Prüfung und gerichtliche Anfechtung von **Bebauungsplänen, Flächennutzungsplänen und örtlichen Bauvorschriften** im Normenkontrollverfahren nach § 47 VwGO vor dem **Bayerischen Verwaltungsgerichtshof (BayVGH)** und anderen Oberverwaltungsgerichten.
 
+## Direkt-Download
+
+| Plugin | Direkt-Download |
+| --- | --- |
+| normenkontrolle-bauleitplanung | [normenkontrolle-bauleitplanung.zip](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/normenkontrolle-bauleitplanung.zip) |
+
+## Installation
+
+1. Claude Code oder Claude Desktop/Cowork öffnen.
+2. **Customize Plugins** bzw. **Personal plugins** wählen.
+3. **Install from .zip** und `normenkontrolle-bauleitplanung.zip` hochladen.
+4. Mit einem konkreten Auftrag starten, zum Beispiel: `Prüfe diesen Bebauungsplan auf formelle und materielle Fehler.`
+
+Alternativ via Marketplace:
+
+```
+/plugin marketplace add Klotzkette/claude-fuer-deutsches-recht
+/plugin install normenkontrolle-bauleitplanung@claude-fuer-deutsches-recht
+```
+
+Nicht das komplette Repository-ZIP hochladen. Das Plugin-ZIP muss im Root direkt `.claude-plugin/plugin.json` und `skills/` enthalten.
+
+## Testakte
+
+- **Bebauungsplan Augsburg Bahnhofsareal** (Realer BayVGH-Mandantenstil mit Antragsbefugnis, Abwägungsfehler, Artenschutz): [testakten/bebauungsplan-augsburg-bahnhofsareal/](../testakten/bebauungsplan-augsburg-bahnhofsareal/) -> [testakte-bebauungsplan-augsburg-bahnhofsareal.zip](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/testakte-bebauungsplan-augsburg-bahnhofsareal.zip)
+
 ## Mandatsperspektive
 
 Anwältin der Antragstellerseite — Eigentümer, Nachbarn, anerkannte Naturschutzverbände, Gemeinden gegen übergeordnete Planung. Schwerpunkt: aus der angegriffenen Satzung die formellen und materiellen Fehler herausarbeiten und vor dem OVG/VGH zur Unwirksamkeitserklärung bringen.

--- a/urteilsbauer-relationsmacher/README.md
+++ b/urteilsbauer-relationsmacher/README.md
@@ -1,0 +1,72 @@
+# Urteilsbauer und Relationsmacher
+
+Technischer Plugin-Name: `urteilsbauer-relationsmacher`.
+
+Freistehendes Plugin fuer **Amts-, Land- und Familienrichter sowie Rechtspfleger**. Begleitet von der Aktenintake ueber die Relation und die Beweiswuerdigung mit Richter-Input bis zum fertigen Urteil oder Beschluss inklusive Tenor, Tatbestand, Entscheidungsgruenden, Kosten- und Rechtsmittelbelehrung. Erzeugt am Ende ein DOCX nach § 313 ZPO.
+
+## Direkt-Download
+
+| Plugin | Direkt-Download |
+| --- | --- |
+| urteilsbauer-relationsmacher | [urteilsbauer-relationsmacher.zip](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/urteilsbauer-relationsmacher.zip) |
+
+## Installation
+
+1. Claude Code oder Claude Desktop/Cowork oeffnen.
+2. **Customize Plugins** bzw. **Personal plugins** waehlen.
+3. **Install from .zip** und `urteilsbauer-relationsmacher.zip` hochladen.
+4. Mit einem konkreten Auftrag starten, zum Beispiel: `Starte die Relation fuer eine Werklohnklage. Akte liegt vor.`
+
+Alternativ via Marketplace:
+
+```
+/plugin marketplace add Klotzkette/claude-fuer-deutsches-recht
+/plugin install urteilsbauer-relationsmacher@claude-fuer-deutsches-recht
+```
+
+Nicht das komplette Repository-ZIP hochladen. Das Plugin-ZIP muss im Root direkt `.claude-plugin/plugin.json` und `skills/` enthalten.
+
+## Testakten
+
+- **Solis Vision X Smartglasses** (Produkthaftung und DSGVO bei smarter Brille, AG/LG-Zivil): [testakten/solis-vision-x-smartglasses/](../testakten/solis-vision-x-smartglasses/) -> [testakte-solis-vision-x-smartglasses.zip](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/testakte-solis-vision-x-smartglasses.zip)
+- **Schulungsakte Lumen Studios** (Insolvenz- und strafrechtliche Schnittstelle): [testakten/schulungsakte-lumen-studios-insolvenz-strafrecht/](../testakten/schulungsakte-lumen-studios-insolvenz-strafrecht/) -> [testakte-schulungsakte-lumen-studios-insolvenz-strafrecht.zip](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/testakte-schulungsakte-lumen-studios-insolvenz-strafrecht.zip)
+
+## Skill-Landkarte
+
+| Skill | Zweck |
+| --- | --- |
+| `aktenintake-zivil` | Erfasst Parteien, Antraege, Sachverhalt, Streitwert, Anlagen und Lage. |
+| `zulaessigkeit-pruefen` | Pruft Statthaftigkeit, Zustaendigkeit, Partei- und Prozessfaehigkeit, Rechtsschutzbeduerfnis. |
+| `relation-zivil` | Baut Relation aus Klagegrund und Verteidigung mit Streitstand und Beweislage. |
+| `vollrelation-langfassung` | Liefert die ausfuehrliche Vollrelation mit Hilfserwaegungen und Eventualbegruendung. |
+| `anspruchsgrundlagen-pruefen` | Identifiziert und subsumiert die einschlaegigen Anspruchsgrundlagen. |
+| `kollidierende-agb-pruefen` | Loest AGB-Konflikt nach Restguelitgkeits- und Knock-out-Doktrin. |
+| `cisg-pruefen` | Pruft CISG-Anwendbarkeit, Anspruechs- und Aufrechnungslage. |
+| `internationales-privatrecht` | Klaert anwendbares Recht nach Rom I/II und nationalem IPR. |
+| `incoterms-und-gefahruebergang` | Wendet Incoterms 2020 auf Gefahruebergang und Transportkosten an. |
+| `dsgvo-rechtswidriges-produkt` | Beurteilt DSGVO-Verstoesse durch Produkte mit Datenverarbeitung. |
+| `familienrichter-spezifika` | Familienrechtliche Besonderheiten: FamFG-Verfahren, Anhoerungspflicht, Vergleichsdruck. |
+| `beweisbeschluss-vorbereiten` | Formuliert Beweisthemen, Beweismittel und Beweisanordnung. |
+| `beweiswuerdigung-mit-richter-input` | Holt Richter-Input zu Glaubwuerdigkeit ein und baut Beweiswuerdigung. |
+| `tatbestand-zivil-schreiben` | Verfasst Tatbestand mit unstreitigem und streitigem Sachverhalt und Antraegen. |
+| `entscheidungsgruende-zivil-schreiben` | Baut Entscheidungsgruende mit Subsumtion und juristischer Begruendung. |
+| `tenor-bauen-zivil` | Erstellt Tenor mit Hauptsache, Kosten, vorlaeufiger Vollstreckbarkeit. |
+| `kostenentscheidung-bauen` | Berechnet Kostenquote nach §§ 91 ff. ZPO inklusive Vergleichswerten. |
+| `vorlaeufige-vollstreckbarkeit` | Setzt Sicherheitsleistung und Abwendungsbefugnis nach §§ 708 ff. ZPO. |
+| `rechtsmittelbelehrung-zivil` | Erzeugt korrekte Rechtsmittelbelehrung fuer Berufung, Beschwerde, Revision. |
+| `beschluss-bauen-zpo` | Baut Beschluesse statt Urteilen, etwa bei einstweiligem Rechtsschutz oder Streitwertfestsetzung. |
+| `berufungsfest-pruefen` | Pruft das Urteil auf Berufungsfestigkeit und typische Aufhebungsgruende. |
+| `revisionsfest-pruefen` | Pruft Urteil auf revisionsrechtliche Schwachstellen. |
+| `dokumente-rendern-urteil-docx` | Rendert das fertige Urteil als DOCX nach § 313 ZPO. |
+| `schulung-urteilsbauer` | Trainingsskill zur Einarbeitung neuer Richter und Rechtspfleger. |
+
+## Typische Workflows
+
+- Aktenintake -> Zulaessigkeit -> Relation -> Anspruchsgrundlagen -> Beweisbeschluss.
+- Beweiswuerdigung mit Richter-Input -> Tatbestand -> Entscheidungsgruende -> Tenor.
+- Kostenentscheidung -> Vorlaeufige Vollstreckbarkeit -> Rechtsmittelbelehrung.
+- Berufungs-/Revisionsfestigkeit -> DOCX-Rendering nach § 313 ZPO.
+
+## Haftung
+
+Dieses Plugin ist ein Arbeitswerkzeug fuer die richterliche Praxis. Es ersetzt keine eigene rechtliche Pruefung und keine Beratung durch zugelassene Rechtsanwaelte. Die Verantwortung fuer Tenor, Tatbestand und Entscheidungsgruende bleibt beim Spruchkoerper.

--- a/vertragsausfueller/README.md
+++ b/vertragsausfueller/README.md
@@ -4,11 +4,34 @@ Freistehendes Cowork-Plugin für workflowgestütztes Ausfüllen von Vertragsvorl
 
 Der BSAG-Mietvertrag und das Term Sheet Kiosk Huckelriede sind als Beispielakte eingebunden.
 
-## Direkt herunterladen
+## Direkt-Download
 
-- [Plugin-ZIP](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/vertragsausfueller.zip)
-- [BSAG-Beispielakte](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/testakte-vertragsausfueller-bsag-kiosk-huckelriede.zip)
+| Plugin | Direkt-Download |
+| --- | --- |
+| vertragsausfueller | [vertragsausfueller.zip](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/vertragsausfueller.zip) |
+
+Zusatzmaterial:
 - [Vorschau lokal öffnen](./assets/vorschau/index.html)
+
+## Installation
+
+1. Claude Code oder Claude Desktop/Cowork öffnen.
+2. **Customize Plugins** bzw. **Personal plugins** wählen.
+3. **Install from .zip** und `vertragsausfueller.zip` hochladen.
+4. Mit einem konkreten Auftrag starten, zum Beispiel: `Fülle diesen Mietvertrag mit den Daten aus dem Term Sheet aus.`
+
+Alternativ via Marketplace:
+
+```
+/plugin marketplace add Klotzkette/claude-fuer-deutsches-recht
+/plugin install vertragsausfueller@claude-fuer-deutsches-recht
+```
+
+Nicht das komplette Repository-ZIP hochladen. Das Plugin-ZIP muss im Root direkt `.claude-plugin/plugin.json`, `skills/` und `assets/` enthalten.
+
+## Beispielakte
+
+- **BSAG Mietvertrag Kiosk Huckelriede** (Word-Vorlage plus Term Sheet, Mapping auf Vertragsfelder): [testakten/vertragsausfueller-bsag-kiosk-huckelriede/](../testakten/vertragsausfueller-bsag-kiosk-huckelriede/) -> [testakte-vertragsausfueller-bsag-kiosk-huckelriede.zip](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/testakte-vertragsausfueller-bsag-kiosk-huckelriede.zip)
 
 ## Workflow
 


### PR DESCRIPTION
## Ziel

Anwaeltinnen und Anwaelte sollen aus dem Plugin-README direkt das Plugin laden und installieren koennen, und die Testakte mitnehmen. Bislang war das nur bei einigen Plugins der Fall (etwa zwangsverwaltung-zvg).

## Service-Pattern je README

- **Direkt-Download**-Tabelle mit Link auf `releases/latest/download/<plugin>.zip`
- **Installation**-Anleitung: ZIP-Upload-Weg plus Marketplace-Variante
- **Testakte** (wo vorhanden): Verzeichnis-Link plus Direkt-Download des Testakten-ZIPs

## Aenderungen im Detail

| Plugin | Vorher | Nachher |
|---|---|---|
| gesellschaftsgruender | nur Schulungsakte-Beschreibung | Download + Install + ZIP-Link zur Schulungsakte |
| hausarbeitenmacher | nichts | Download + Install |
| normenkontrolle-bauleitplanung | nichts | Download + Install + Augsburg-Testakte |
| urteilsbauer-relationsmacher | **kein README** | Komplett neuer Service-README mit Solis Vision + Lumen Studios |
| bereicherungs-und-anfechtungsrecht-pruefer | nur Download | Install-Sektion erganzt |
| ki-vo-ai-act-pruefer | nur Download | Install-Sektion erganzt |
| vertragsausfueller | Mini-Liste | Download-Tabelle + Install + Beispielakte-Block |
| legistik-werkstatt | Download + Install | Testakte Pflichtpostfach als ZIP verlinkt |

## Schon ok (keine Aenderung noetig)

- arbeitszeugnis-analyse
- subsumtions-pruefer

## Verify

- `node scripts/validate-plugin-structure.mjs` -> OK
- Release v6.1.1 enthaelt alle referenzierten ZIPs (143 Assets)