### PR TITLE
fix(sweep-reste): TTDSG + BGB-InfoV-Resttreffer aus PR #42 nachziehen

### DIFF
--- a/fachanwalt-bank-kapitalmarktrecht/skills/widerrufsjoker-immobiliendarlehen/SKILL.md
+++ b/fachanwalt-bank-kapitalmarktrecht/skills/widerrufsjoker-immobiliendarlehen/SKILL.md
@@ -213,6 +213,6 @@ Mit freundlichen Grüßen
 
 - BGB §§ 357 491 495 355
 - VerbrKrG (alt)
-- BGB-InfoV
+- BGB-InfoV (historisch — durch VRRL-UmsetzungsG zum 13.6.2014 abgeschafft, Anlagen heute zu §§ 312d ff. BGB / Art. 247 EGBGB; fuer Altvertraege weiter relevant)
 - BGH XI. Zivilsenat — Widerrufsjoker-Linie
 - Bülow/Artz Verbraucherkredit

--- a/produktrecht/skills/launch-pruefung/references/seven-category-framework.md
+++ b/produktrecht/skills/launch-pruefung/references/seven-category-framework.md
@@ -94,7 +94,7 @@ wenn Daten fließen, ist der Ausfall des Drittanbieters unser Problem (Verfügba
 
 Die einschlägigen Regulierungsregime für den Sektor des Produkts sind zu recherchieren (z. B.
 Gesundheit: ProdSichG/GPSR, MDR, ProdHaftG; Finanzdienstleistungen: KWG, WpHG, MiFIR; Kinder
-und Schüler: DSGVO Art. 8, § 11 TTDSG; Versicherungen: VAG; Telekommunikation: TKG; Arbeitsrecht:
+und Schüler: DSGVO Art. 8, § 11 TDDDG (vormals TTDSG, seit Mai 2024); Versicherungen: VAG; Telekommunikation: TKG; Arbeitsrecht:
 ArbSchG, ArbZG; Werbung: UWG, HWG, LMIV, Health-Claims-VO), Zielgruppe und Rechtsordnungen
 (Deutschland, EU-Mitgliedstaaten, UK und sonstige Regionen, die das Produkt erreicht). Außerdem
 Barrierefreiheit (BFSG, European Accessibility Act) und Ausfuhrkontrolle (AWV, Dual-Use-VO) prüfen,

--- a/references/rechtsgebiete-uebersicht.md
+++ b/references/rechtsgebiete-uebersicht.md
@@ -3,7 +3,7 @@
 | Verzeichnis | Inhalt | Wichtigste Normen |
 | --- | --- | --- |
 | `arbeitsrecht` | Individual- und kollektives Arbeitsrecht | BGB §§ 611a ff., KSchG, TzBfG, BUrlG, EFZG, AGG, BetrVG, ArbZG, MuSchG, BEEG, NachwG, AÜG |
-| `datenschutzrecht` | DSGVO, BDSG, TTDSG, Beschäftigtendatenschutz | DSGVO, BDSG, TTDSG, KUG |
+| `datenschutzrecht` | DSGVO, BDSG, TDDDG, Beschäftigtendatenschutz | DSGVO, BDSG, TDDDG (vormals TTDSG), KUG |
 | `gesellschaftsrecht` | GmbH, AG, GbR, OHG, KG, M&A | GmbHG, AktG, HGB, MoPeG, UmwG, WpÜG |
 | `gewerblicher-rechtsschutz` | Marken, Designs, Patente, Urheberrecht, Wettbewerb | MarkenG, DesignG, PatG, UrhG, UWG, GeschGehG |
 | `jurastudium` | Skills für Studium und Referendariat | – |


### PR DESCRIPTION
## Hintergrund

PR #42 (Norm-Aktualisierungs-Sweep) hat 23 Fixes gemacht, drei Stellen aber uebersehen. Nach Resttreffer-Suche behoben.

## Drei Resttreffer

| Datei | Vorher | Nachher |
|---|---|---|
| `produktrecht/launch-pruefung/.../seven-category-framework.md:97` | § 11 TTDSG | § 11 TDDDG (vormals TTDSG, seit Mai 2024) |
| `references/rechtsgebiete-uebersicht.md:6` | DSGVO, BDSG, TTDSG (2x) | DSGVO, BDSG, TDDDG (vormals TTDSG) |
| `fachanwalt-bank-kapitalmarktrecht/.../widerrufsjoker-immobiliendarlehen/SKILL.md:216` | BGB-InfoV | BGB-InfoV (historisch — VRRL 13.6.2014) |

## Bewusst NICHT geaendert

- `insolvenzrecht/skills/antragspflicht-15a-inso/SKILL.md:65` zitiert `§ 64 GmbHG a.F.` — "a.F." ist ausreichender Aufhebungs-Hinweis.
- 9 Treffer von `Mueller-Gloege` ohne neue Hrsg.-Klarstellung beziehen sich auf 24. Aufl. 2024 — laut Beck-Shop wird Mueller-Gloege auch in der 24. Aufl. weiterhin als Hrsg. (Mueller-Gloege/Preis/Gallner/Schmidt) gefuehrt, obwohl 2018 verstorben (uebliche Praxis bei grossen Kommentaren). Erst die 25. Aufl. 2025 wechselt zu Preis/Sittard/Kiel — das wurde in PR #42 fuer `rechtsberatungsstelle/recherche-start` bereits umgesetzt.

## Verifikation nach Fix

```
grep -rn 'TTDSG' --include='*.md' | grep -v 'TDDDG|vormals|ehem|aF'    -> leer
grep -rn 'BGB-InfoV' --include='*.md' | grep -v 'historisch|VRRL|aF'   -> leer
node scripts/validate-plugin-structure.mjs                              -> OK
```