### PR TITLE
release: Versionsangaben auf v6.3.0

### DIFF
--- a/ASSET_INDEX.md
+++ b/ASSET_INDEX.md
@@ -2,7 +2,7 @@
 
 Übersicht aller Dateien, die der Release-Workflow (`.github/workflows/release-plugin-zips.yml`) pro Tag-Release `vX.Y.Z` an den GitHub-Release anhängt.
 
-**Stand:** v6.1.1
+**Stand:** v6.3.0
 
 ## Asset-Typen
 

--- a/INSTALLATION_EINFACH.md
+++ b/INSTALLATION_EINFACH.md
@@ -6,7 +6,7 @@
 
 ## Kurzfassung
 
-> 📆 **Hinweis Release vs. Entwicklungsstand:** Die ZIPs in der Releases-Seite entsprechen einem **getaggten, validierten Stand** (zur Zeit `v6.1.1`). Der `main`-Branch des Repos kann **neuer** sein — mit weiteren Fixes, kleinen Ergänzungen oder neuen Tests. Für stabile Tagung → ZIPs aus dem Release; für neueste Korrekturen → Marketplace-Sync über den GitHub-Pfad (siehe README.md, Weg 1).
+> 📆 **Hinweis Release vs. Entwicklungsstand:** Die ZIPs in der Releases-Seite entsprechen einem **getaggten, validierten Stand** (zur Zeit `v6.3.0`). Der `main`-Branch des Repos kann **neuer** sein — mit weiteren Fixes, kleinen Ergänzungen oder neuen Tests. Für stabile Tagung → ZIPs aus dem Release; für neueste Korrekturen → Marketplace-Sync über den GitHub-Pfad (siehe README.md, Weg 1).
 
 1. Auf [die Releases-Seite](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest) gehen.
 2. Pro gewünschtem Rechtsgebiet **eine ZIP-Datei** herunterladen, z. B. `liquiditaetsplanung.zip`.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Die Skills sind inzwischen deutlich verbessert und in verschiedenen Konstellatio
 
 Dieses Repository trifft **keine Aussage** zur Zulässigkeit eines Einsatzes im konkreten Mandat oder Unternehmen – insbesondere nicht zu §§ 203, 204 StGB, § 43e BRAO, § 2 BORA, § 53, § 97, § 160a StPO, DSGVO / BDSG (inkl. Drittlandtransfer), US-Cloud-Act / FISA, der KI-VO (VO (EU) 2024/1689) oder sonstigen berufsrechtlichen, datenschutzrechtlichen und regulatorischen Vorgaben. Ob und wie ihr diese Beispiele produktiv nutzen dürft, müsst ihr **eigenverantwortlich** prüfen und in eure bestehende Governance (Mandatsgeheimnis, AVV, TOMs, KI-Richtlinien, Betriebsvereinbarungen etc.) integrieren.
 
-## Überblick v6.1.1 auf einen Blick
+## Überblick v6.3.0 auf einen Blick
 
 | Kennzahl | Wert |
 |---|---|
@@ -27,7 +27,7 @@ Dieses Repository trifft **keine Aussage** zur Zulässigkeit eines Einsatzes im 
 | **Skills (SKILL.md)** | über 1500 |
 | **Testakten** | 44 |
 | **Fachanwalts-/-anwältinnen-Profile** | alle 24 |
-| **Letzter Release** | [v6.1.1](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/tag/v6.1.1) |
+| **Letzter Release** | [v6.3.0](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/tag/v6.3.0) |
 | **Marketplace-Definition** | [`.claude-plugin/marketplace.json`](./.claude-plugin/marketplace.json) |
 
 ### Inhaltliche Cluster
@@ -54,7 +54,7 @@ Die vollständige Plugin-Liste findest du in [`.claude-plugin/marketplace.json`]
 /plugin install <plugin-name>@claude-fuer-deutsches-recht
 ```
 
-Alternativ: über die Claude-Desktop-GUI unter **Customize → Skills** → ZIP aus dem [Release v6.1.1](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/tag/v6.1.1) hochladen. Schritt-für-Schritt unter [Schnellstart](#schnellstart) und [Für Einsteiger](#für-einsteiger-schritt-für-schritt-anleitung).
+Alternativ: über die Claude-Desktop-GUI unter **Customize → Skills** → ZIP aus dem [Release v6.3.0](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/tag/v6.3.0) hochladen. Schritt-für-Schritt unter [Schnellstart](#schnellstart) und [Für Einsteiger](#für-einsteiger-schritt-für-schritt-anleitung).
 
 ## 🚨 KEINE Aussage über Berufsrecht, Datenschutz, KI-VO oder Beschlagnahmeverbote
 
@@ -316,7 +316,7 @@ Für einen neuen Plugin gilt: L1 ist der akzeptable Start, L2 wird angestrebt, s
 
 Dieses Skill-Set lässt sich auf drei Wegen einbinden. Empfohlen ist **Weg 1** über die grafische Oberfläche; **Weg 2** für gezielten ZIP-Upload einer bestimmten Version; **Weg 3** für Claude Code im Terminal.
 
-> 📆 **Release- vs. main-Stand.** Der **letzte Release-Tag** ist [v6.1.1](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest). Über **Weg 1 (Marketplace-Sync)** und **Weg 3 (Marketplace-Kommando)** wird der `main`-Branch geladen — das ist meist **neuer** als der letzte Release-Tag (Zwischen-Commits mit Fixes, neuen Tests, kleinen Ergänzungen). Über **Weg 2 (ZIP-Upload aus Release)** bekommst du den **getaggten, validierten Stand**. Für Stabilität → Weg 2; für neueste Korrekturen → Weg 1/3.
+> 📆 **Release- vs. main-Stand.** Der **letzte Release-Tag** ist [v6.3.0](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest). Über **Weg 1 (Marketplace-Sync)** und **Weg 3 (Marketplace-Kommando)** wird der `main`-Branch geladen — das ist meist **neuer** als der letzte Release-Tag (Zwischen-Commits mit Fixes, neuen Tests, kleinen Ergänzungen). Über **Weg 2 (ZIP-Upload aus Release)** bekommst du den **getaggten, validierten Stand**. Für Stabilität → Weg 2; für neueste Korrekturen → Weg 1/3.
 
 > 💡 **Findest du in Cowork kein Feld für den GitHub-Pfad?** Dann ist in deiner Oberfläche der Marketplace-Weg vermutlich noch nicht freigeschaltet. Lade die Plugin-ZIPs einzeln aus dem [Release](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest) herunter und installiere sie über denselben Dialog, mit dem du z. B. „Legal Plugin" installierst. Schritt für Schritt erklärt: **[INSTALLATION_EINFACH.md](./INSTALLATION_EINFACH.md)**.
 
@@ -396,7 +396,7 @@ Dieses Repository ist vollständig auf das deutsche Recht und die Arbeitsweise d
 - Due Diligence läuft über Q&A, Datenraum und anwaltliche Sachverhaltsaufklärung.
 - Kündigungsschutz: Regelfall nach KSchG ab 6 Monate / mehr als 10 Arbeitnehmer.
 
-Stand v6.1.1: **99 Plugins, 1565 Skills, 44 Testakten**. Abgedeckt sind klassische Mandantenpraxis, alle 24 Fachanwaltschaften, Großkanzlei- und Mittelstandsformate sowie Spezialdisziplinen wie Insolvenzverwaltung, Zwangsverwaltung, Zwangsversteigerung, Markenrecht für Luxus-Fashion mit USPTO-Lanham-Act-Modul, betriebliche Altersversorgung in Konzernen mit Düsseldorf-Kyoto-Profil, StaRUG-Krisenfrüherkennung mit Vier-und-zwanzig-Monats-Horizont, Schriftform-/Textform-Workflow-Organisator nach BGH I ZR 202/25 und BGH VIII ZR 159/23, Wandeldarlehen-Lebenszyklus mit Cap-Table-Mechanik sowie generische Mechanik-Prüfer für Subsumtion, Bereicherungs-/Anfechtungsrecht und die KI-VO (Verordnung (EU) 2024/1689).
+Stand v6.3.0: **99 Plugins, 1565 Skills, 44 Testakten**. Abgedeckt sind klassische Mandantenpraxis, alle 24 Fachanwaltschaften, Großkanzlei- und Mittelstandsformate sowie Spezialdisziplinen wie Insolvenzverwaltung, Zwangsverwaltung, Zwangsversteigerung, Markenrecht für Luxus-Fashion mit USPTO-Lanham-Act-Modul, betriebliche Altersversorgung in Konzernen mit Düsseldorf-Kyoto-Profil, StaRUG-Krisenfrüherkennung mit Vier-und-zwanzig-Monats-Horizont, Schriftform-/Textform-Workflow-Organisator nach BGH I ZR 202/25 und BGH VIII ZR 159/23, Wandeldarlehen-Lebenszyklus mit Cap-Table-Mechanik sowie generische Mechanik-Prüfer für Subsumtion, Bereicherungs-/Anfechtungsrecht und die KI-VO (Verordnung (EU) 2024/1689).
 
 ### Materielle Rechtsgebiete
 


### PR DESCRIPTION
## Ziel
Vorbereitung Patch-Release **v6.3.0**. Bündelt alle Korrekturen seit v6.1.1 in einem neuen, getaggten Release mit frischen ZIP-Assets.

## Änderungen
- `README.md`: Überblick-Headline, Release-Tabellen-Zeile, GUI-Hinweis, Schnellstart-Hinweis und Stand-Absatz auf **v6.3.0**
- `ASSET_INDEX.md`: Stand-Zeile auf **v6.3.0**
- `INSTALLATION_EINFACH.md`: Release-vs-main-Hinweis auf **v6.3.0**

## Inhalt v6.3.0 ggü. v6.1.1
- Norm-Sweep: TTDSG→TDDDG, § 64 GmbHG aF → § 15b InsO, TMG → DDG, EuGVO → EuGVVO, KostO → GKG, BGB-InfoV-Hinweise, ErfK-Herausgeberangaben
- Plugin-README-Service-Updates für 10 Plugins: Direkt-Download-Links und Schritt-für-Schritt-Installation
- Konsistenz `marketplace.json` ↔ Repo (99/99 Plugins)

## Release-Plan
Nach Merge: Tag `v6.3.0` pushen → Release-Workflow erzeugt 143 Assets.
