### PR TITLE
fix: Slug-Verweis datenpanne-meldung in cyber-vorfall-skill

### DIFF
--- a/fachanwalt-it-recht/skills/fachanwalt-it-recht-cyber-vorfall-sofortmassnahmen/SKILL.md
+++ b/fachanwalt-it-recht/skills/fachanwalt-it-recht-cyber-vorfall-sofortmassnahmen/SKILL.md
@@ -202,5 +202,5 @@ Bei akutem Cyber-Vorfall (Ransomware, Datenleck, Hack): koordinierte rechtliche 
 ## Anschluss
 
 - `phishing-vorfall-pruefer` — bei Phishing-Vorfall
-- `datenschutzrecht/skills/datenpannenmeldung` — fuer formellen Antrag
+- `datenschutzrecht/skills/datenpanne-meldung` — fuer formellen Antrag
 - `fachanwalt-strafrecht-orientierung` — bei Strafanzeige


### PR DESCRIPTION
## Befund

Stichprobe der 72 neuen Fachanwalt-Skills (PR #48): Anschluss-Verweis in `fachanwalt-it-recht-cyber-vorfall-sofortmassnahmen` zeigt auf nicht-existierenden Slug `datenschutzrecht/skills/datenpannenmeldung`. Korrekter Slug ist `datenpanne-meldung` (mit Bindestrich).

## Fix

Eine Zeile in `SKILL.md` korrigiert.

## Test plan

- [x] `ls datenschutzrecht/skills/datenpanne-meldung` -> existiert
- [x] Keine weiteren stale References in der Stichprobe

https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL

---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_