### PR TITLE
fix: Terminologie 'kongruent' (lat. congruens) wiederherstellen

### DIFF
--- a/bereicherungs-und-anfechtungsrecht-pruefer/README.md
+++ b/bereicherungs-und-anfechtungsrecht-pruefer/README.md
@@ -89,7 +89,7 @@ Nicht das komplette Repository-ZIP hochladen. Das Plugin-ZIP muss im Root direkt
 | `anfg-grundtatbestand-und-anfechtungsberechtigte` | § 2 AnfG: Titel, fällige Forderung, Fruchtlosigkeit |
 | `anfg-vorsatzanfechtung-3-i` | Benachteiligungsvorsatz und Kenntnis, zehn Jahre |
 | `anfg-unentgeltliche-leistung-4` | Unentgeltlichkeit, vier Jahre |
-| `anfg-mittelbare-benachteiligung-und-kongruenz` | Kongrünte und inkongrünte Deckung im AnfG |
+| `anfg-mittelbare-benachteiligung-und-kongruenz` | Kongruente und inkongruente Deckung im AnfG |
 | `anfg-fristen-und-anfechtungszeitraum` | Fristen §§ 3 und 4 AnfG, Verjährung |
 | `anfg-rechtsfolge-rueckgewaehr-11` | Duldungspflicht, Rückgewähr, Wertersatz |
 | `anfg-anfechtungsklage-prozessuales` | Zuständigkeit, Klageantrag, Streitwert, Vollstreckung |

--- a/bereicherungs-und-anfechtungsrecht-pruefer/skills/anfg-grundtatbestand-und-anfechtungsberechtigte/SKILL.md
+++ b/bereicherungs-und-anfechtungsrecht-pruefer/skills/anfg-grundtatbestand-und-anfechtungsberechtigte/SKILL.md
@@ -33,8 +33,8 @@ Anfechtungsgegner ist, wer die anfechtbare Rechtshandlung vorgenommen hat oder z
 - Übereignung von Grundstücken oder Sachen.
 - Abtretung von Forderungen.
 - Belastung mit Grundpfandrechten.
-- Zahlung auf eine Schuld (kongrünte Deckung).
-- Bestellung einer Sicherheit ohne entsprechende Vereinbarung (inkongrünte Deckung).
+- Zahlung auf eine Schuld (kongruente Deckung).
+- Bestellung einer Sicherheit ohne entsprechende Vereinbarung (inkongruente Deckung).
 
 ## Verfahren
 

--- a/bereicherungs-und-anfechtungsrecht-pruefer/skills/anfg-mittelbare-benachteiligung-und-kongruenz/SKILL.md
+++ b/bereicherungs-und-anfechtungsrecht-pruefer/skills/anfg-mittelbare-benachteiligung-und-kongruenz/SKILL.md
@@ -3,7 +3,7 @@ name: anfg-mittelbare-benachteiligung-und-kongruenz
 description: "Kongruente und inkongruente Deckung im AnfG-Kontext. Mittelbare Gläubigerbenachteiligung: wann genügt die abstrakte Möglichkeit? Abgrenzung zu unmittelbarer Benachteiligung."
 ---
 
-# Mittelbare Benachteiligung und Kongrünz — AnfG
+# Mittelbare Benachteiligung und Kongruenz — AnfG
 
 ## Gläubigerbenachteiligung als Voraussetzung
 
@@ -25,13 +25,13 @@ Die Benachteiligung tritt erst durch das Hinzutreten weiterer Umstände ein.
 
 **Relevanz für AnfG:** Mittelbare Benachteiligung kann ausreichen, wenn der Kausalzusammenhang zwischen Rechtshandlung und Gläubigerbenachteiligung feststeht.
 
-## Kongrünte Deckung
+## Kongruente Deckung
 
 **Definition:** Der Anfechtungsgegner erhält genau das, was ihm nach dem Vertrag und zur rechten Zeit zusteht.
 
-**Anfechtung kongrünter Deckung:** Nur über § 3 AnfG (Vorsatzanfechtung) möglich; höhere Anforderungen.
+**Anfechtung kongruenter Deckung:** Nur über § 3 AnfG (Vorsatzanfechtung) möglich; höhere Anforderungen.
 
-## Inkongrünte Deckung
+## Inkongruente Deckung
 
 **Definition:** Der Anfechtungsgegner erhält etwas, das er in dieser Art, zu diesem Zeitpunkt oder überhaupt nicht hätte beanspruchen können.
 
@@ -40,7 +40,7 @@ Die Benachteiligung tritt erst durch das Hinzutreten weiterer Umstände ein.
 - Vorzeitige Tilgung noch nicht fälliger Schulden.
 - Zahlung mit einem Gegenstand statt Geld (sofern nicht vereinbart).
 
-**Relevanz:** Inkongrünte Deckung ist ein starkes Indiz für Benachteiligungsvorsatz (§ 3 AnfG) und erleichtert den Beweis erheblich.
+**Relevanz:** Inkongruente Deckung ist ein starkes Indiz für Benachteiligungsvorsatz (§ 3 AnfG) und erleichtert den Beweis erheblich.
 ---
 
 Hinweis: Keine Rechtsberatung. Mechanische Prüfung anhand vom Nutzer behaupteter Tatsachen. Falsche Normwahl oder unvollständiger Sachverhalt kann das Ergebnis vollständig entwerten.

--- a/bereicherungs-und-anfechtungsrecht-pruefer/skills/anfg-vorsatzanfechtung-3-i/SKILL.md
+++ b/bereicherungs-und-anfechtungsrecht-pruefer/skills/anfg-vorsatzanfechtung-3-i/SKILL.md
@@ -21,7 +21,7 @@ Jedes rechtlich erhebliche Handeln oder Unterlassen des Schuldners. Auch Unterla
 
 **Indizien für Benachteiligungsvorsatz:**
 - Kenntnis der eigenen Zahlungsunfähigkeit.
-- Inkongrünte Leistung (Leistung auf nicht fällige oder nicht in dieser Art geschuldete Forderung).
+- Inkongruente Leistung (Leistung auf nicht fällige oder nicht in dieser Art geschuldete Forderung).
 - Verschleuderung von Vermögenswerten unter Wert.
 - Übertragung auf nahestehende Personen kurz vor Insolvenz.
 

--- a/bereicherungs-und-anfechtungsrecht-pruefer/skills/inso-bargeschaeft-142/SKILL.md
+++ b/bereicherungs-und-anfechtungsrecht-pruefer/skills/inso-bargeschaeft-142/SKILL.md
@@ -15,7 +15,7 @@ Das Bargeschäftsprivileg schützt Austauschgeschäfte, bei denen Leistung und G
 
 Die vom Schuldner empfangene Gegenleistung muss dem Wert der von ihm erbrachten Leistung entsprechen (objektiver Vergleich, keine bloß symbolische Gegenleistung).
 
-### 2. Unmittelbarer Zusammenhang (Kongrünz)
+### 2. Unmittelbarer Zusammenhang (Kongruenz)
 
 Leistung und Gegenleistung müssen in einem unmittelbaren zeitlichen Zusammenhang erbracht worden sein. Die Rechtsprechung toleriert regelmäßig einen Zeitraum von wenigen Tagen bis maximal zwei bis drei Wochen.
 

--- a/bereicherungs-und-anfechtungsrecht-pruefer/skills/inso-inkongruente-deckung-131/SKILL.md
+++ b/bereicherungs-und-anfechtungsrecht-pruefer/skills/inso-inkongruente-deckung-131/SKILL.md
@@ -3,15 +3,15 @@ name: inso-inkongruente-deckung-131
 description: "§ 131 InsO: Anfechtung inkongruenter Deckung. Sicherung oder Befriedigung, die in dieser Art, zu diesem Zeitpunkt oder überhaupt nicht beansprucht werden konnte. Fristen und Kenntnisvermutung."
 ---
 
-# Inkongrünte Deckung — § 131 InsO
+# Inkongruente Deckung — § 131 InsO
 
 ## Obersatz
 
-Anfechtbar ist nach § 131 Abs. 1 InsO eine Rechtshandlung, die einem Insolvenzgläubiger eine Sicherung oder Befriedigung gewährt oder ermöglicht hat, die er nicht oder nicht in der Art oder nicht zu der Zeit zu beanspruchen hatte (inkongrünte Deckung).
+Anfechtbar ist nach § 131 Abs. 1 InsO eine Rechtshandlung, die einem Insolvenzgläubiger eine Sicherung oder Befriedigung gewährt oder ermöglicht hat, die er nicht oder nicht in der Art oder nicht zu der Zeit zu beanspruchen hatte (inkongruente Deckung).
 
-## Begriff der Inkongrünz
+## Begriff der Inkongruenz
 
-**Inkongrünt ist die Leistung, wenn:**
+**Inkongruent ist die Leistung, wenn:**
 1. Der Gläubiger hatte keinen Anspruch auf diese Leistung (z. B. Sicherheitsbestellung ohne vertragliche Grundlage).
 2. Der Gläubiger hatte keinen Anspruch auf diese Art der Leistung (z. B. Leistung in Sachen statt in Geld, ohne entsprechende Vereinbarung).
 3. Der Gläubiger hatte keinen Anspruch auf die Leistung zu diesem Zeitpunkt (vorzeitige Tilgung einer noch nicht fälligen Schuld).
@@ -22,11 +22,11 @@ Anfechtbar ist nach § 131 Abs. 1 InsO eine Rechtshandlung, die einem Insolvenzg
 |---|---|---|
 | Nr. 1 | Letzter Monat vor Antrag oder nach Antrag | keine |
 | Nr. 2 | Zweiter oder dritter Monat vor Antrag | Zahlungsunfähigkeit |
-| Nr. 3 | Zweiter oder dritter Monat vor Antrag | Kenntnis der Inkongrünz |
+| Nr. 3 | Zweiter oder dritter Monat vor Antrag | Kenntnis der Inkongruenz |
 
-## Indizwirkung der Inkongrünz
+## Indizwirkung der Inkongruenz
 
-Inkongrünte Leistungen sind ein starkes Indiz für den Benachteiligungsvorsatz des Schuldners im Rahmen von § 133 InsO. Das Gericht kann aus der Inkongrünz auf die subjektiven Voraussetzungen schließen.
+Inkongruente Leistungen sind ein starkes Indiz für den Benachteiligungsvorsatz des Schuldners im Rahmen von § 133 InsO. Das Gericht kann aus der Inkongruenz auf die subjektiven Voraussetzungen schließen.
 
 ## Typische Fälle
 

--- a/bereicherungs-und-anfechtungsrecht-pruefer/skills/inso-kongruente-deckung-130/SKILL.md
+++ b/bereicherungs-und-anfechtungsrecht-pruefer/skills/inso-kongruente-deckung-130/SKILL.md
@@ -3,21 +3,21 @@ name: inso-kongruente-deckung-130
 description: "§ 130 InsO: Anfechtung kongruenter Deckung. Sicherung oder Befriedigung in den letzten drei Monaten vor Insolvenzantrag. Zahlungsunfähigkeit und Kenntnis des Anfechtungsgegners."
 ---
 
-# Kongrünte Deckung — § 130 InsO
+# Kongruente Deckung — § 130 InsO
 
 ## Obersatz
 
-Anfechtbar sind nach § 130 Abs. 1 InsO Rechtshandlungen, die einem Insolvenzgläubiger eine Sicherung oder Befriedigung gewährt oder ermöglicht haben, die dieser beanspruchen konnte (kongrünte Deckung), wenn:
+Anfechtbar sind nach § 130 Abs. 1 InsO Rechtshandlungen, die einem Insolvenzgläubiger eine Sicherung oder Befriedigung gewährt oder ermöglicht haben, die dieser beanspruchen konnte (kongruente Deckung), wenn:
 1. die Handlung im letzten Monat vor Antrag oder nach Antrag vorgenommen wurde (§ 130 Abs. 1 Nr. 1) und die Zahlungsunfähigkeit vorlag, oder
 2. die Handlung im zweiten oder dritten Monat vor Antrag vorgenommen wurde (§ 130 Abs. 1 Nr. 2) und der Anfechtungsgegner die Zahlungsunfähigkeit kannte.
 
 ## Tatbestandsmerkmale
 
-### 1. Kongrünte Deckung
+### 1. Kongruente Deckung
 
 Der Gläubiger erhält genau das, was ihm vertraglich oder gesetzlich in dieser Art und zu diesem Zeitpunkt zusteht. Keine Besserstellung gegenüber dem vereinbarten Anspruch.
 
-**Abgrenzung zur Inkongrünz (§ 131 InsO):** Bei kongrünter Deckung sind die Anforderungen an die subjektiven Tatbestandsmerkmale höher als bei inkongrünter.
+**Abgrenzung zur Inkongruenz (§ 131 InsO):** Bei kongruenter Deckung sind die Anforderungen an die subjektiven Tatbestandsmerkmale höher als bei inkongruenter.
 
 ### 2. Zeitlicher Rahmen — drei Monate vor Insolvenzantrag
 

--- a/bereicherungs-und-anfechtungsrecht-pruefer/skills/inso-unmittelbar-nachteilige-rechtshandlungen-132/SKILL.md
+++ b/bereicherungs-und-anfechtungsrecht-pruefer/skills/inso-unmittelbar-nachteilige-rechtshandlungen-132/SKILL.md
@@ -11,7 +11,7 @@ Anfechtbar sind nach § 132 Abs. 1 InsO Rechtshandlungen, die unmittelbar nachte
 
 ## Abgrenzung zu §§ 130, 131 InsO
 
-§ 132 InsO greift bei Rechtshandlungen, die nicht als kongrünte oder inkongrünte Deckung eines bestehenden Anspruchs eines Insolvenzgläubigers zu qualifizieren sind, sondern bei denen die Schädigung des Gläubigervermögens die unmittelbare Folge der Rechtshandlung ist — ohne dass ein anderer die Sicherung oder Befriedigung erlangt.
+§ 132 InsO greift bei Rechtshandlungen, die nicht als kongruente oder inkongruente Deckung eines bestehenden Anspruchs eines Insolvenzgläubigers zu qualifizieren sind, sondern bei denen die Schädigung des Gläubigervermögens die unmittelbare Folge der Rechtshandlung ist — ohne dass ein anderer die Sicherung oder Befriedigung erlangt.
 
 ## Tatbestandsmerkmale
 

--- a/bereicherungs-und-anfechtungsrecht-pruefer/skills/inso-vorsatzanfechtung-133/SKILL.md
+++ b/bereicherungs-und-anfechtungsrecht-pruefer/skills/inso-vorsatzanfechtung-133/SKILL.md
@@ -17,8 +17,8 @@ Das AnfRefG vom 5. April 2017 hat § 133 InsO grundlegend geändert:
 - § 133 Abs. 1 InsO (Vorsatzanfechtung allgemein): zehn Jahre vor Antrag (unverändert).
 - § 133 Abs. 2 InsO (entgeltliche Verträge mit nahestehenden Personen): vier Jahre vor Antrag (neu).
 
-**Einschränkung bei kongrünten Deckungen:**
-§ 133 Abs. 3 InsO schränkt die Vorsatzanfechtung bei kongrünten Deckungen (§ 130 InsO) ein: Kannte der Anfechtungsgegner weder die Zahlungsunfähigkeit noch Umstände, die zwingend auf den Benachteiligungsvorsatz schließen lassen, entfällt die Anfechtung.
+**Einschränkung bei kongruenten Deckungen:**
+§ 133 Abs. 3 InsO schränkt die Vorsatzanfechtung bei kongruenten Deckungen (§ 130 InsO) ein: Kannte der Anfechtungsgegner weder die Zahlungsunfähigkeit noch Umstände, die zwingend auf den Benachteiligungsvorsatz schließen lassen, entfällt die Anfechtung.
 
 ## Tatbestandsmerkmale § 133 Abs. 1 InsO
 
@@ -28,7 +28,7 @@ Das AnfRefG vom 5. April 2017 hat § 133 InsO grundlegend geändert:
 
 **Indizien:**
 - Kenntnis der eigenen Zahlungsunfähigkeit oder drohenden Zahlungsunfähigkeit.
-- Inkongrünte Leistung (starkes Indiz).
+- Inkongruente Leistung (starkes Indiz).
 - Handeln zu Gunsten von nahestehenden Personen.
 
 ### 2. Kenntnis des Anfechtungsgegners

--- a/fachanwalt-insolvenz-sanierungsrecht/skills/fachanwalt-insolvenz-sanierungsrecht-anfechtungsklage-verwalter/SKILL.md
+++ b/fachanwalt-insolvenz-sanierungsrecht/skills/fachanwalt-insolvenz-sanierungsrecht-anfechtungsklage-verwalter/SKILL.md
@@ -14,7 +14,7 @@ Verwalter kann Vermögens-Verschiebungen vor Insolvenz rückgängig machen. Auch
 1. Zeitpunkt der Zahlung / Vermögens-Verfügung?
 2. Verhältnis Schuldner-Empfänger (Geschäftspartner, Bank, Gesellschafter, Naheste-hender)?
 3. Insolvenzantrag-Datum?
-4. Kongrünt (vertraglich geschuldet) vs. inkongrünt (anders erfüllt)?
+4. Kongruent (vertraglich geschuldet) vs. inkongruent (anders erfüllt)?
 5. Wert der Verfügung?
 6. Eigen-Rolle: Verwalter oder Anfechtungs-Gegner?
 
@@ -22,8 +22,8 @@ Verwalter kann Vermögens-Verschiebungen vor Insolvenz rückgängig machen. Auch
 
 | § | Tatbestand | Frist | Beweislast |
 |---|---|---|---|
-| 130 | Kongrünt + Zahlungsunfähigkeit-Kenntnis | 3 Monate vor Antrag | Verwalter |
-| 131 | Inkongrünt | 3 Monate vor Antrag | Verwalter (vereinfacht) |
+| 130 | Kongruent + Zahlungsunfähigkeit-Kenntnis | 3 Monate vor Antrag | Verwalter |
+| 131 | Inkongruent | 3 Monate vor Antrag | Verwalter (vereinfacht) |
 | 132 | Unmittelbar-nachteilig | 3 Monate | Verwalter |
 | 133 | Vorsatz-Anfechtung | **4 Jahre** vor Antrag | Verwalter (Vorsatz beider Seiten) |
 | 134 | Unentgeltlich | 4 Jahre | Verwalter (Schenkungs-Charakter) |

--- a/fachanwalt-insolvenz-sanierungsrecht/skills/fachanwalt-insolvenz-sanierungsrecht-insolvenzanfechtung/SKILL.md
+++ b/fachanwalt-insolvenz-sanierungsrecht/skills/fachanwalt-insolvenz-sanierungsrecht-insolvenzanfechtung/SKILL.md
@@ -11,16 +11,16 @@ description: Insolvenzanfechtung nach §§ 129 ff. InsO. Anfechtungsgegenstand R
 2. Datum des Eröffnungsantrags und der Verfahrenseröffnung? Anfechtungszeiträume danach (3-Monats- bzw. 4- oder 10-Jahres-Fenster)?
 3. Wer ist Anfechtungsgegner (Vertragspartner, nahestehende Person § 138 InsO, Gesellschafter § 135 InsO)?
 4. War der Schuldnerin im Zeitpunkt der Handlung Zahlungsunfähigkeit § 17 oder drohende Zahlungsunfähigkeit § 18 InsO bekannt? Welche Indizien sind aktenkundig (Mahnungen, Vollstreckungsdruck, Ratenzahlungsbitten, Branchenkenntnis)?
-5. Lag eine kongrünte oder inkongrünte Deckung vor (Anspruch auf gerade diese Leistung in dieser Art und zu dieser Zeit)?
+5. Lag eine kongruente oder inkongruente Deckung vor (Anspruch auf gerade diese Leistung in dieser Art und zu dieser Zeit)?
 6. Bei Vorsatzanfechtung § 133 InsO: Gibt es Indizien für Gläubigerbenachteiligungsvorsatz der Schuldnerin und Kenntnis des Empfängers?
 
 ## Rechtsgrundlagen
 
 - **Allgemeine Anfechtungsvoraussetzungen:** § 129 InsO — Rechtshandlung vor Verfahrenseröffnung, Gläubigerbenachteiligung, Anfechtungstatbestand erfüllt.
-- **Kongrünte Deckung:** § 130 InsO — Befriedigung oder Sicherung in den letzten drei Monaten vor Antrag bei eingetretener Zahlungsunfähigkeit und Kenntnis des Anfechtungsgegners.
-- **Inkongrünte Deckung:** § 131 InsO — Befriedigung oder Sicherung, die der Empfänger nicht oder nicht in der Art oder nicht zu der Zeit zu beanspruchen hatte; Dreimonatsfrist; bei nahestehenden Personen § 138 InsO erweitert.
+- **Kongruente Deckung:** § 130 InsO — Befriedigung oder Sicherung in den letzten drei Monaten vor Antrag bei eingetretener Zahlungsunfähigkeit und Kenntnis des Anfechtungsgegners.
+- **Inkongruente Deckung:** § 131 InsO — Befriedigung oder Sicherung, die der Empfänger nicht oder nicht in der Art oder nicht zu der Zeit zu beanspruchen hatte; Dreimonatsfrist; bei nahestehenden Personen § 138 InsO erweitert.
 - **Unmittelbar nachteilige Rechtshandlung:** § 132 InsO — Rechtsgeschäft, das Gläubiger unmittelbar benachteiligt.
-- **Vorsatzanfechtung:** § 133 InsO — Anfechtung von Rechtshandlungen, die in den letzten zehn Jahren mit dem Vorsatz vorgenommen wurden, Gläubiger zu benachteiligen, wenn der Empfänger Kenntnis hatte. Bei kongrünter Deckung gilt seit der Reform 2017 (Gesetz zur Verbesserung der Rechtssicherheit bei Anfechtungen) die verkürzte Vier-Jahres-Frist § 133 Abs. 2 InsO.
+- **Vorsatzanfechtung:** § 133 InsO — Anfechtung von Rechtshandlungen, die in den letzten zehn Jahren mit dem Vorsatz vorgenommen wurden, Gläubiger zu benachteiligen, wenn der Empfänger Kenntnis hatte. Bei kongruenter Deckung gilt seit der Reform 2017 (Gesetz zur Verbesserung der Rechtssicherheit bei Anfechtungen) die verkürzte Vier-Jahres-Frist § 133 Abs. 2 InsO.
 - **Unentgeltliche Leistung:** § 134 InsO — Anfechtung bis vier Jahre vor Antrag, unabhängig von Vorsatz oder Kenntnis.
 - **Gesellschafterdarlehen:** § 135 InsO — Rückzahlung in letzten zwölf Monaten und Besicherung in letzten zehn Jahren anfechtbar.
 - **Rechtsfolge:** § 143 InsO — Rückgewähr in die Insolvenzmasse; Wertersatz bei Untergang.

--- a/fachanwalt-versicherungsrecht/skills/fachanwalt-versicherungsrecht-regress-abwehr/SKILL.md
+++ b/fachanwalt-versicherungsrecht/skills/fachanwalt-versicherungsrecht-regress-abwehr/SKILL.md
@@ -11,14 +11,14 @@ description: "Regress Sozialversicherungstraeger § 116 SGB X Versicherungstraeg
 2. Aus welchem Schadensereignis stammt der Regress — Unfall, Krankheit, Verletzung Dritter? Welcher Mandant haftet warum?
 3. Welche Sozialleistungen wurden für welchen Zeitraum erbracht — Krankenhauskosten, Krankengeld, Reha, Rente, Heilbehandlung?
 4. Ist die zugrundeliegende Schadenshaftung dem Grunde und der Höhe nach bereits geklärt oder noch streitig?
-5. Bestehen Verteidigungseinwände wie Familienprivileg (§ 86 Abs. 3 VVG, § 116 Abs. 6 SGB X), Mitverschulden des Geschädigten, fehlende Kongrünz, Verjährung?
+5. Bestehen Verteidigungseinwände wie Familienprivileg (§ 86 Abs. 3 VVG, § 116 Abs. 6 SGB X), Mitverschulden des Geschädigten, fehlende Kongruenz, Verjährung?
 
 ## Anspruchsgrundlagen Regress
 
 - Sozialleistungsregress § 116 SGB X: Forderungsübergang kraft Gesetzes auf Sozialversicherungsträger zum Zeitpunkt des schadensbegründenden Ereignisses, soweit Sozialleistungen aufgrund desselben Ereignisses gewährt werden müssen.
 - Versicherungsregress § 86 Abs. 1 VVG: Forderungsübergang auf privaten Versicherer im Umfang seiner Leistung.
-- Voraussetzung sachliche Kongrünz: Schaden und Sozialleistung müssen gleichartig sein (Erwerbsschaden-Krankengeld, Heilbehandlung-Krankenversicherung).
-- Voraussetzung zeitliche Kongrünz: Sozialleistung muss in dem Zeitraum erbracht werden für den Schadensersatz beansprucht wird.
+- Voraussetzung sachliche Kongruenz: Schaden und Sozialleistung müssen gleichartig sein (Erwerbsschaden-Krankengeld, Heilbehandlung-Krankenversicherung).
+- Voraussetzung zeitliche Kongruenz: Sozialleistung muss in dem Zeitraum erbracht werden für den Schadensersatz beansprucht wird.
 - Quotenvorrecht des Geschädigten § 116 Abs. 3 SGB X — bei Mitverschulden des Geschädigten oder beschränkter Haftung des Schädigers gehen nur die durch Haftungsanteil gedeckten Beträge auf den Sozialversicherungsträger über; der Geschädigte erhält Bevorzugung bei nicht durch Sozialleistung gedeckten Schadenspositionen (BGH VI ZR 132/11, Urt. v. 24.04.2012, Rn. 25 ff.).
 - Familienprivileg § 86 Abs. 3 VVG, § 116 Abs. 6 SGB X — kein Regress gegen Schädiger der mit Geschädigtem in häuslicher Gemeinschaft lebt; Ausnahme Vorsatz.
 - Verjährung wie zugrundeliegender Anspruch § 195 BGB drei Jahre; Hemmung § 203 BGB durch Verhandlungen.
@@ -27,7 +27,7 @@ Standardliteratur: Geigel Der Haftpflichtprozess; Küppersbusch/Höher Ersatzans
 
 ## Beweislast
 
-- Regressnehmer trägt Beweislast für Sozialleistung, Höhe, Kongrünz und Haftung dem Grunde nach.
+- Regressnehmer trägt Beweislast für Sozialleistung, Höhe, Kongruenz und Haftung dem Grunde nach.
 - Schädiger/Versicherer trägt Beweislast für Mitverschulden des Geschädigten, Familienprivileg und Verjährung.
 
 ## Verteidigungsstrategien
@@ -35,7 +35,7 @@ Standardliteratur: Geigel Der Haftpflichtprozess; Küppersbusch/Höher Ersatzans
 | Einwand | Voraussetzung | Wirkung |
 |---|---|---|
 | Familienprivileg | Häusliche Gemeinschaft Schädiger/Geschädigter ohne Vorsatz | Kein Forderungsübergang |
-| Fehlende Kongrünz | Sozialleistung deckt anderes als geltend gemachten Schaden | Anspruchsausfall in nicht-kongrünten Teil |
+| Fehlende Kongruenz | Sozialleistung deckt anderes als geltend gemachten Schaden | Anspruchsausfall in nicht-kongruenten Teil |
 | Quotenvorrecht | Mitverschulden des Geschädigten | Verteilung nach Quote zugunsten Geschädigtem |
 | Mitverschulden | § 254 BGB | Quotenkürzung |
 | Verjährung | § 195 BGB drei Jahre ab Kenntnis | Anspruch durchsetzbar nicht mehr |

--- a/insolvenzrecht/skills/anfechtungsrechte-pruefen/SKILL.md
+++ b/insolvenzrecht/skills/anfechtungsrechte-pruefen/SKILL.md
@@ -28,19 +28,19 @@ Das wichtigste Werkzeug des Insolvenzverwalters zur Massevermehrung. Bei Mandant
 
 ## Schritt 2 — Spezielle Anfechtungs-Tatbestände
 
-### § 130 InsO — Kongrünte Deckung
+### § 130 InsO — Kongruente Deckung
 
 - Rechtshandlung in **letzten drei Monaten** vor Antrag
 - Schuldner **zahlungsunfähig**
 - Anfechtungs-Gegner **kannte** Zahlungsunfähigkeit oder Umstände die zwingend darauf schließen lassen
-- "Kongrünt" — Anfechtungs-Gegner hatte vertraglichen Anspruch auf das Erlangte
+- "Kongruent" — Anfechtungs-Gegner hatte vertraglichen Anspruch auf das Erlangte
 
-### § 131 InsO — Inkongrünte Deckung
+### § 131 InsO — Inkongruente Deckung
 
 - Rechtshandlung in **letztem Monat** vor Antrag oder danach (Abs. 1 Nr. 1)
 - In letzten drei Monaten — wenn Schuldner zahlungsunfähig (Abs. 1 Nr. 2)
 - In letzten drei Monaten — wenn Anfechtungs-Gegner Benachteiligungs-Wissen (Abs. 1 Nr. 3)
-- "Inkongrünt" — Anfechtungs-Gegner hatte **keinen** vertraglichen Anspruch (Aufrechnungs-Möglichkeit Sicherheit-Leistung Vorauszahlung)
+- "Inkongruent" — Anfechtungs-Gegner hatte **keinen** vertraglichen Anspruch (Aufrechnungs-Möglichkeit Sicherheit-Leistung Vorauszahlung)
 
 ### § 132 InsO — Unmittelbar nachteilige Rechtshandlung
 

--- a/insolvenzrecht/skills/glaeubigerantrag-pruefung/SKILL.md
+++ b/insolvenzrecht/skills/glaeubigerantrag-pruefung/SKILL.md
@@ -271,7 +271,7 @@ Eröffnungsgrund § 17 InsO durch Indizienkombination glaubhaft gemacht
 5. **Sofortige Zahlung als Anfechtungsrisiko**: Zahlt der Schuldner die
    antragsbegründende Forderung kurzfristig, um den Antrag zu Fall zu bringen,
    ist diese Zahlung nach § 133 Abs. 1 InsO (Vorsatzanfechtung) oder § 131 InsO
-   (inkongrünte Deckung) anfechtbar, wenn innerhalb der Anfechtungsfristen
+   (inkongruente Deckung) anfechtbar, wenn innerhalb der Anfechtungsfristen
    Insolvenz eröffnet wird. Der Schuldner „kauft" sich damit nur Zeit, ohne die
    Insolvenzlage zu beseitigen.
 

--- a/insolvenzrecht/skills/vorsatzanfechtung-133-inso/SKILL.md
+++ b/insolvenzrecht/skills/vorsatzanfechtung-133-inso/SKILL.md
@@ -31,8 +31,8 @@ c) **Kenntnis Vertragspartner** des Vorsatzes
 
 **ZUERST PRÜFEN: Welcher Tatbestand?**
 
-- **4 Jahre — § 133 Abs. 2 InsO**: Deckungs- oder Befriedigungs-Handlungen, die dem Gläubiger **kongrünt** eine Sicherung oder Befriedigung gewährt haben (z.B. Fälligkeits-Zahlung Lieferant, planmäßige Tilgung Bank-Kredit, vertraglich vereinbarte Sicherheits-Bestellung)
-- **10 Jahre — § 133 Abs. 1 InsO**: alle anderen Rechts-Handlungen mit Gläubiger-Benachteiligungs-Vorsatz, insbesondere **Vermögens-Verschiebungen** (Schenkungen, Verkauf unter Wert, Übertragung auf nahe-stehende Personen, inkongrünte Deckungen, Vermögens-Ausgliederungen)
+- **4 Jahre — § 133 Abs. 2 InsO**: Deckungs- oder Befriedigungs-Handlungen, die dem Gläubiger **kongruent** eine Sicherung oder Befriedigung gewährt haben (z.B. Fälligkeits-Zahlung Lieferant, planmäßige Tilgung Bank-Kredit, vertraglich vereinbarte Sicherheits-Bestellung)
+- **10 Jahre — § 133 Abs. 1 InsO**: alle anderen Rechts-Handlungen mit Gläubiger-Benachteiligungs-Vorsatz, insbesondere **Vermögens-Verschiebungen** (Schenkungen, Verkauf unter Wert, Übertragung auf nahe-stehende Personen, inkongruente Deckungen, Vermögens-Ausgliederungen)
 - **Vor 22.4.2017** — einheitlich 10 Jahre für alle Tatbestände (Alt-Fälle)
 - **Unentgeltliche Leistungen** — separater Tatbestand § 134 InsO (4 Jahre)
 
@@ -40,12 +40,12 @@ c) **Kenntnis Vertragspartner** des Vorsatzes
 
 | Sachverhalt | Frist | Norm |
 |---|---|---|
-| Kongrünte Fälligkeits-Zahlung | 4 Jahre | § 133 Abs. 2 |
-| Vorzeitige Tilgung (inkongrünt) | 10 Jahre | § 133 Abs. 1 |
+| Kongruente Fälligkeits-Zahlung | 4 Jahre | § 133 Abs. 2 |
+| Vorzeitige Tilgung (inkongruent) | 10 Jahre | § 133 Abs. 1 |
 | Verkauf unter Wert an Dritte | 10 Jahre | § 133 Abs. 1 |
 | Übertragung auf Familie | 10 Jahre | § 133 Abs. 1 (+ § 138) |
 | Schenkung | 4 Jahre | § 134 InsO |
-| Bestellung Sicherheit nach Schuldgrund | 10 Jahre | § 133 Abs. 1 (inkongrünt) |
+| Bestellung Sicherheit nach Schuldgrund | 10 Jahre | § 133 Abs. 1 (inkongruent) |
 
 ### Beweislast Insolvenz-Verwalter
 
@@ -66,12 +66,12 @@ c) **Kenntnis Vertragspartner** des Vorsatzes
 - **Zahlungs-Unfähigkeit** zum Handlungs-Zeitpunkt
 - **Drohende Zahlungs-Unfähigkeit** mit Bewusstsein
 - **Vorzugs-Behandlung** einzelner Gläubiger
-- **Inkongrünte Leistungs-Bedingungen**
+- **Inkongruente Leistungs-Bedingungen**
 
 ### Reform 2017 Modifikation
 
 - **BGH IX ZR 233/19** zur Kenntnis-Vermutung Reform
-- Kenntnis der drohenden Zahlungs-Unfähigkeit allein nicht ausreichend für Vorsatz-Vermutung bei kongrünter Leistung
+- Kenntnis der drohenden Zahlungs-Unfähigkeit allein nicht ausreichend für Vorsatz-Vermutung bei kongruenter Leistung
 
 ## Schritt 3 — Kenntnis Vertragspartner
 
@@ -171,7 +171,7 @@ Schuldner zahlt sofort bei Lieferung.
 ### Konstellation B — Bank erhält Tilgungs-Zahlung
 
 - Bei drohender Insolvenz Schuldner zahlt Bank-Kredit
-- Inkongrünt: vor Fälligkeit
+- Inkongruent: vor Fälligkeit
 - BGH IX ZR-Anfechtungs-Risiko hoch
 - **Verteidigung:** Bei Fälligkeit Bargeschäft
 
@@ -193,15 +193,15 @@ Schuldner zahlt sofort bei Lieferung.
 - BGH IX ZR-Beratung Schutz
 - **Verteidigung:** Beratungs-Erfolg-Aussicht IDW S 6
 
-## Schritt 8 — Inkongrünz und Kongrünz
+## Schritt 8 — Inkongruenz und Kongruenz
 
-### § 130 InsO Kongrünte Deckung
+### § 130 InsO Kongruente Deckung
 
 - Bei Fälligkeit
 - In den letzten 3 Monaten
 - Mit Kenntnis Zahlungs-Unfähigkeit
 
-### § 131 InsO Inkongrünte Deckung
+### § 131 InsO Inkongruente Deckung
 
 - Vor Fälligkeit oder anders als geschuldet
 - In den letzten 3 Monaten ohne Kenntnis-Anforderung
@@ -209,8 +209,8 @@ Schuldner zahlt sofort bei Lieferung.
 
 ### Abgrenzung § 133 InsO
 
-- **§ 133 Abs. 1** — 10 Jahre Rückblick, Vermögens-Verschiebungs- und Inkongrünz-Tatbestände
-- **§ 133 Abs. 2** — 4 Jahre Rückblick, kongrünte Deckungs-/Befriedigungs-Handlungen
+- **§ 133 Abs. 1** — 10 Jahre Rückblick, Vermögens-Verschiebungs- und Inkongruenz-Tatbestände
+- **§ 133 Abs. 2** — 4 Jahre Rückblick, kongruente Deckungs-/Befriedigungs-Handlungen
 - Beide strenger als §§ 130/131: Vorsatz erforderlich, dafür deutlich längere Frist
 - **§ 133 plus § 130/131** parallel möglich — Insolvenz-Verwalter wählt stärkste Norm
 

--- a/wandeldarlehen-lebenszyklus/skills/darlehenshoehe-konditionen/SKILL.md
+++ b/wandeldarlehen-lebenszyklus/skills/darlehenshoehe-konditionen/SKILL.md
@@ -30,7 +30,7 @@ Dieser Skill erfasst alle wirtschaftlichen Kernkonditionen des Wandeldarlehens u
 - §§ 3, 4 StaRUG (Einschränkung Kündigungsrechte im Restrukturierungsrahmen)
 
 ### Rechtsprechung
-- BGH, Urt. v. 7. März 2013 – IX ZR 7/12 (Kongrünzdeckung Darlehensrückzahlung)
+- BGH, Urt. v. 7. März 2013 – IX ZR 7/12 (Kongruenzdeckung Darlehensrückzahlung)
 - BGH, Urt. v. 29. Januar 2015 – IX ZR 279/13 (Fälligkeitsklausel und Insolvenz)
 
 ## Vorgehen

--- a/wandeldarlehen-lebenszyklus/skills/formfehler-heilungs-timeline/SKILL.md
+++ b/wandeldarlehen-lebenszyklus/skills/formfehler-heilungs-timeline/SKILL.md
@@ -160,8 +160,8 @@ Vertrags-Schluss.
 
 ### Konstellationen
 
-- **§ 130 InsO** Kongrünz-Anfechtung — wenn Bestellung nach Insolvenz-Antrag-Stellung
-- **§ 131 InsO** Inkongrünz-Anfechtung — wenn keine entsprechende Gegenleistung
+- **§ 130 InsO** Kongruenz-Anfechtung — wenn Bestellung nach Insolvenz-Antrag-Stellung
+- **§ 131 InsO** Inkongruenz-Anfechtung — wenn keine entsprechende Gegenleistung
 - **§ 132 InsO** unmittelbar nachteilige Rechtsgeschäfte
 - **§ 133 InsO** Vorsatz-Anfechtung — bei Vorsatz auf Gläubiger-Benachteiligung
 


### PR DESCRIPTION
## Codex-Finding behoben

Codex hatte (zu Recht) bemängelt, dass der Phase-2-Umlauten-Patch (PR #52) das juristische Fachwort **kongruent** fälschlich zu **kongrünt** umlautiert hat. Das Wort kommt aus dem Lateinischen (*congruens* = übereinstimmend) und hat keinen Umlaut.

Insbesondere § 130/131 InsO (kongruente / inkongruente Deckung) ist ein etablierter, in Rechtsprechung und Kommentarliteratur durchgängig verwendeter Begriff, der nicht umlautiert werden darf.

## Umfang
- **17 Dateien**, **67 Korrekturen**
- Betroffen: u. a. `bereicherungs-und-anfechtungsrecht-pruefer/`, `insolvenzrecht/`, `fachanwalt-insolvenz-sanierungsrecht/`, `fachanwalt-versicherungsrecht/`, `wandeldarlehen-lebenszyklus/`

## Reparierte Formen
`Kongrünz → Kongruenz`, `kongrünte → kongruente`, `Inkongrünte → Inkongruente`, `Kongrünzdeckung → Kongruenzdeckung` und alle Flexionsvarianten.

## Checks
- ✅ `validate-plugin-structure.mjs` OK
- ✅ Keine Resttreffer (`kongr[üÜ]n` ⇒ 0)
- ✅ Frontmatter unverändert
