### PR TITLE
fix: Slug-Verweis datenpanne-meldung in cyber-vorfall-skill (rebased)

### DIFF
--- a/fachanwalt-it-recht/skills/fachanwalt-it-recht-cyber-vorfall-sofortmassnahmen/SKILL.md
+++ b/fachanwalt-it-recht/skills/fachanwalt-it-recht-cyber-vorfall-sofortmassnahmen/SKILL.md
@@ -202,5 +202,5 @@ Bei akutem Cyber-Vorfall (Ransomware, Datenleck, Hack): koordinierte rechtliche 
 ## Anschluss
 
 - `phishing-vorfall-pruefer` — bei Phishing-Vorfall
-- `datenschutzrecht/skills/datenpannenmeldung` — für formellen Antrag
+- `datenschutzrecht/skills/datenpanne-meldung` — für formellen Antrag
 - `fachanwalt-strafrecht-orientierung` — bei Strafanzeige


### PR DESCRIPTION
## Befund

Stichprobe der 72 neuen Fachanwalt-Skills: Anschluss-Verweis in `fachanwalt-it-recht-cyber-vorfall-sofortmassnahmen` zeigt auf nicht-existierenden Slug `datenschutzrecht/skills/datenpannenmeldung`. Korrekter Slug ist `datenpanne-meldung` (mit Bindestrich).

Ersetzt PR #49 (nach Force-Push automatisch geschlossen — Rebase auf aktuelles main mit Konfliktauflösung).

## Fix

Eine Zeile in `SKILL.md` korrigiert.

## Test plan

- [x] `ls datenschutzrecht/skills/datenpanne-meldung` -> existiert
- [x] Rebased auf aktuelles main
- [x] `validate-plugin-structure.mjs` OK

https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL

---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_