### PR TITLE
fix(liquiditaetsplanung): DXF-Fills mit patternType="solid" — Ampel-Faerbung repariert

### DIFF
--- a/liquiditaetsplanung/skills/liquiditaetsvorschau-3-6-12-monate/werkzeuge/build_liquiditaetsplan.py
+++ b/liquiditaetsplanung/skills/liquiditaetsvorschau-3-6-12-monate/werkzeuge/build_liquiditaetsplan.py
@@ -576,8 +576,14 @@ class XlsxWorkbook:
                     parts.append("<b/>")
                 parts.append(f'<color rgb="FF{fc}"/>')
                 parts.append("</font>")
+                # patternType="solid" ist zwingend, sonst rendern Excel-konforme
+                # Reader keine Hintergrundfarbe. Excel-DXFs nutzen bgColor als
+                # Solid-Color (anders als normale Fills, die fgColor nehmen);
+                # wir setzen beide auf denselben Wert fuer maximale Kompatibilitaet.
                 parts.append(
-                    f'<fill><patternFill><bgColor rgb="FF{bg}"/></patternFill></fill>'
+                    f'<fill><patternFill patternType="solid">'
+                    f'<fgColor rgb="FF{bg}"/><bgColor rgb="FF{bg}"/>'
+                    f'</patternFill></fill>'
                 )
                 parts.append("</dxf>")
             parts.append("</dxfs>")


### PR DESCRIPTION
## Codex-Review Befund (P2)

Im DXF-Block (Conditional Formatting) der Ampel-Rules in `build_liquiditaetsplan.py`:

```xml
<fill><patternFill><bgColor rgb="FFF4B7BA"/></patternFill></fill>
```

Das `<patternFill>` hat **kein `patternType="solid"`**. Excel-konforme Reader interpretieren das als "kein solider Hintergrund" — die rote/gelbe/gruene Ampel-Faerbung in der bedingten Formatierung wird nicht gerendert. Die `cfRule`-Bedingungen evaluieren weiterhin, aber das visuelle Signal geht verloren.

Regression gegenueber dem urspruenglichen openpyxl-Output, der `PatternFill("solid", fgColor=…)` schrieb.

## Fix

```xml
<fill><patternFill patternType="solid">
  <fgColor rgb="FFF4B7BA"/><bgColor rgb="FFF4B7BA"/>
</patternFill></fill>
```

- `patternType="solid"` zwingend gesetzt
- `fgColor` + `bgColor` auf denselben Wert: Excel-DXFs nutzen typischerweise `bgColor` als Solid-Color, andere Reader (LibreOffice u.a.) `fgColor` — beide gesetzt fuer maximale Kompatibilitaet

## Cross-Check

```
DXF 0: patternType='solid', fgColor='FFF4B7BA', bgColor='FFF4B7BA'  # ROT
DXF 1: patternType='solid', fgColor='FFFFE9A8', bgColor='FFFFE9A8'  # GELB
DXF 2: patternType='solid', fgColor='FFC9E5C1', bgColor='FFC9E5C1'  # GRUEN
```

(via openpyxl `_differential_styles`)

## Test plan

- [x] Syntax-Check
- [x] Skript mit Beispielakte laeuft
- [x] openpyxl liest DXFs mit `patternType='solid'`
- [x] cfRule-Bedingungen unveraendert (Range C44:O44, equal "ROT"/"GELB"/"GRÜN")

https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL

---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_