### PR TITLE
wandeldarlehen: Reform-Stand 2026 aktualisieren (DiRUG, SanInsFoG, PostModG, § 19 GmbHG)

### DIFF
--- a/wandeldarlehen-lebenszyklus/skills/beurkundungserfordernis-pruefung/SKILL.md
+++ b/wandeldarlehen-lebenszyklus/skills/beurkundungserfordernis-pruefung/SKILL.md
@@ -24,6 +24,8 @@ Dieser Skill klärt, ob der Wandeldarlehensvertrag der notariellen Beurkundung b
 - § 15 Abs. 4 GmbHG (Beurkundungspflicht Anteilsübertragung selbst)
 - § 55 Abs. 1 GmbHG (Kapitalerhöhungsbeschluss – notarielle Beurkundung gemäß § 53 Abs. 2 GmbHG)
 - § 53 Abs. 2 GmbHG (Satzungsänderung durch Kapitalerhöhung – notariell)
+- § 2 Abs. 3 GmbHG (Online-Beurkundung Gründung; durch DiRUG 2022 eingeführt, BeurkG § 16a)
+- § 53 Abs. 4 GmbHG analog / BeurkG § 16a (Online-Beurkundung Kapitalerhöhung seit 1.8.2023 zulässig)
 - § 311 Abs. 1 BGB (Schuldrechtliche Verpflichtung)
 
 ### Rechtsprechung
@@ -50,6 +52,9 @@ Schriftliches Memo: Beurkundungserfordernis ja/nein. Falls nein: Begründung (zw
 
 ### 6. Trennungsprinzip sicherstellen
 Verpflichtungs- und Verfügungsebene sauber getrennt halten. Keine Formulierungen im Wandeldarlehensvertrag, die einen Direkterwerb bestehender Anteile ohne Kapitalerhöhung vorsehen.
+
+### 7. Online-Beurkundung als Option prüfen (DiRUG)
+Seit DiRUG (1.8.2022) ist Online-Beurkundung der GmbH-Gründung möglich (§ 2 Abs. 3 GmbHG); seit 1.8.2023 erstreckt auf Kapitalerhöhungs- und Satzungsänderungsbeschlüsse (§ 53 Abs. 4 GmbHG analog, BeurkG § 16a). Mit Lender im Ausland: Online-Beurkundung kann Reise- und Apostille-Aufwand sparen. Voraussetzung: Notar mit Online-Verfahren der BNotK; elektronische Identifizierung via eID-Funktion oder Lichtbildausweis-Abgleich.
 
 ## Checkliste Beurkundungserfordernis
 
@@ -78,4 +83,4 @@ Verpflichtungs- und Verfügungsebene sauber getrennt halten. Keine Formulierunge
 
 ## Quellen und Updates
 
-Stand: 05/2026. Leitentscheidungen: OLG München 31 Wx 79/16, BGH II ZR 256/08. Bei Änderung GmbHG § 15 aktualisieren.
+Stand: 05/2026. Leitentscheidungen: OLG München 31 Wx 79/16, BGH II ZR 256/08. Stand DiRUG-Reform (2022) und Erweiterung auf Kapitalerhöhungen (1.8.2023) berücksichtigt. Bei Änderung GmbHG § 15 / § 2 III / BeurkG § 16a aktualisieren.

--- a/wandeldarlehen-lebenszyklus/skills/gesellschafterliste-aktualisieren/SKILL.md
+++ b/wandeldarlehen-lebenszyklus/skills/gesellschafterliste-aktualisieren/SKILL.md
@@ -20,11 +20,12 @@ Dieser Skill erstellt die aktualisierte Gesellschafterliste nach der Kapitalerh�
 ## Rechtlicher Rahmen
 
 ### Primärnormen
-- § 40 Abs. 1 GmbHG (Geschäftsführerin reicht neue Gesellschafterliste bei Änderung ein)
+- § 40 Abs. 1 GmbHG (Geschäftsführerin reicht neue Gesellschafterliste bei Änderung ein; Pflichtinhalte durch DiRUG/Gesellschafterlistenverordnung erweitert: prozentuale Beteiligung am Stammkapital, ggf. Geburtsname, weitere Identifikatoren)
 - § 40 Abs. 2 GmbHG (Mitwirkung eines Notars: Notar reicht Liste ein, wenn er an Änderung mitgewirkt hat)
+- Gesellschafterlistenverordnung (GesLV, in Kraft 1.7.2018, modifiziert durch DiRUG) — Pflichtinhalte und Format
 - § 16 GmbHG (Gutglaubenswirkung der Gesellschafterliste: nur als Gesellschafter gilt, wer eingetragen ist)
 - § 15 GmbHG (Anteilsübertragung – Vollwirkung erst mit Eintragung)
-- § 19 GwG (Transparenzregister – wirtschaftlich Berechtigte nach Änderung melden)
+- § 19 GwG (Transparenzregister – wirtschaftlich Berechtigte nach Änderung melden; Vollregister seit August 2021)
 
 ### Rechtsprechung
 - BGH, Urt. v. 17. November 2008 – II ZR 244/07 (Gutglaubenswirkung § 16 GmbHG – nur eingetragene Gesellschafter)
@@ -33,12 +34,13 @@ Dieser Skill erstellt die aktualisierte Gesellschafterliste nach der Kapitalerh�
 ## Vorgehen
 
 ### 1. Listenentwurf erstellen
-Alle Gesellschafterinnen und neuer Lender mit vollständigen Angaben:
+Alle Gesellschafterinnen und neuer Lender mit vollständigen Angaben gemäß § 40 Abs. 1 GmbHG i.V.m. GesLV:
 - Laufende Nummer (fortlaufend, keine Lücken)
-- Gesellschaftername (Vor- und Nachname oder Firma)
+- Gesellschaftername (Vor- und Nachname oder Firma); bei natürlichen Personen ggf. Geburtsname, wenn abweichend
 - Geburtsdatum (natürliche Person) oder HRB + Amtsgericht (juristische Person)
 - Anschrift (Wohnanschrift oder Geschäftsanschrift Sitz)
 - Anzahl der Geschäftsanteile und Nennwert (in EUR)
+- Prozentuale Beteiligung am Stammkapital (Pflicht seit DiRUG)
 - Datum des Erwerbs (Beurkundungsdatum Kapitalerhöhung)
 
 ### 2. Vollständigkeitsprüfung

--- a/wandeldarlehen-lebenszyklus/skills/rangruecktritt-formulieren/SKILL.md
+++ b/wandeldarlehen-lebenszyklus/skills/rangruecktritt-formulieren/SKILL.md
@@ -23,9 +23,9 @@ Dieser Skill formuliert den qualifizierten Rangrücktritt für § 6 des Wandelda
 - § 19 Abs. 2 Satz 2 InsO (Qualifizierter Rangrücktritt im Überschuldungsstatus)
 - § 39 Abs. 1 Nr. 5 InsO (Nachrang eigenkapitalersetzender Gesellschafterdarlehen)
 - § 39 Abs. 2 InsO (Vereinbarter Nachrang)
-- § 15a InsO (Insolvenzantragspflicht – bleibt unberührt)
-- § 15b InsO (Zahlungsverbote nach Insolvenzreife – Schutzklausel)
-- § 17 InsO (Zahlungsunfähigkeit), § 19 InsO (Überschuldung)
+- § 15a InsO (Insolvenzantragspflicht – bleibt unberührt; nach SanInsFoG 2020/2021 erweitert auf alle juristischen Personen)
+- § 15b InsO (Zahlungsverbote nach Insolvenzreife — durch SanInsFoG eingefügt, hat den früheren § 64 GmbHG abgelöst; Schutzklausel zwingend, da Geschäftsführerhaftung jetzt allein über § 15b InsO greift)
+- § 17 InsO (Zahlungsunfähigkeit), § 19 InsO (Überschuldung; Prognosezeitraum modifiziert durch SanInsKG/SanInsFoG)
 - § 44 InsO (Unwirksamkeit von Lösungsklauseln)
 - § 328 BGB (Vertrag zugunsten Dritter – Aufhebungsverbot)
 
@@ -49,7 +49,7 @@ Ausdrückliche Klarstellung, dass es sich um einen qualifizierten Rangrücktritt
 Rangrücktritt als echter Vertrag zugunsten Dritter (§ 328 BGB) zugunsten aller Gläubiger i.S.d. §§ 38 / 39 Abs. 1 InsO. Aufhebung nur mit vorheriger schriftlicher Zustimmung der Gesellschaft und nur soweit keine Insolvenzreife entsteht.
 
 ### 5. § 15b InsO-Schutzklausel
-Gesellschaft und Geschäftsführerinnen sind nicht zur Rückzahlung verpflichtet, soweit dies persönliche Haftung nach § 15b InsO auslösen würde. Bei verbotswidriger Rückzahlung: Rückgewährpflicht auf erstes Anfordern.
+Gesellschaft und Geschäftsführerinnen sind nicht zur Rückzahlung verpflichtet, soweit dies persönliche Haftung nach § 15b InsO auslösen würde. Bei verbotswidriger Rückzahlung: Rückgewährpflicht auf erstes Anfordern. Hintergrund: § 15b InsO wurde durch das SanInsFoG (Inkrafttreten 1.1.2021) eingefügt und löste § 64 GmbHG a.F. (Massesicherungspflicht) ab; die GF-Haftung für „verbotswidrige Zahlungen nach Insolvenzreife" knüpft seit der Reform allein an die InsO an. Klausel daher zwingend, sonst GF-persönliches Risiko.
 
 ### 6. GIRA-Bestätigungstext vorbereiten
 Für den Wirtschaftsprüfer: kurze Bestätigungserklärung, dass qualifizierter Rangrücktritt vorliegt und Nachrangforderungen im Überschuldungsstatus nicht zu berücksichtigen sind (§ 19 Abs. 2 Satz 2 InsO; IDW S 11 Rn. 23 ff.).
@@ -83,4 +83,4 @@ zu verursachen droht (vgl. BGH, Urt. v. 5. März 2015 – IX ZR 133/14).
 
 ## Quellen und Updates
 
-Stand: 05/2026. BGH IX ZR 133/14 und IX ZR 191/15 als Leitentscheidungen. Bei Änderung InsO/IDW S 11 aktualisieren.
+Stand: 05/2026. BGH IX ZR 133/14 und IX ZR 191/15 als Leitentscheidungen. Stand SanInsFoG (1.1.2021, § 15b InsO statt § 64 GmbHG a.F.) und SanInsKG-Modifikationen am Überschuldungsprognosezeitraum berücksichtigt. Bei Änderung InsO/IDW S 11 aktualisieren.

--- a/wandeldarlehen-lebenszyklus/skills/sacheinlagebericht-werthaltigkeit/SKILL.md
+++ b/wandeldarlehen-lebenszyklus/skills/sacheinlagebericht-werthaltigkeit/SKILL.md
@@ -22,8 +22,10 @@ Dieser Skill erstellt den Sacheinlagebericht und prüft die Werthaltigkeit der a
 
 ### Primärnormen
 - § 9 GmbHG (Differenzhaftung Gesellschafter bei Überbewertung der Sacheinlage)
+- § 19 Abs. 4 GmbHG (Werthaltigkeitsversicherung der Geschäftsführer in der Anmeldung — Falschangabe begründet GF-Haftung gegen die Gesellschaft, ergänzt zur Gesellschafter-Differenzhaftung des § 9 GmbHG)
 - § 56 GmbHG (Sacheinlage: Leistung muss vor Anmeldung erbracht/gesichert sein)
 - § 56a GmbHG (Sachgründungsbericht analog für Kapitalerhöhung gegen Sacheinlage)
+- § 82 GmbHG (Strafbarkeit falscher Angaben zur Werthaltigkeit in HR-Anmeldung)
 - § 272 Abs. 2 Nr. 4 HGB (Kapitalrücklage)
 - IDW RS HFA 42 (Werthaltigkeit von Forderungen als Sacheinlage)
 
@@ -45,8 +47,8 @@ Hinweis: Der qualifizierte Rangrücktritt schränkt die Durchsetzbarkeit der For
 ### 4. Sacheinlagebericht erstellen
 Inhalt: (a) Beschreibung der Sacheinlage (Art der Forderung, Betrag, Fälligkeit), (b) Bewertungsgrundlagen (Buchwert, Marktwert, Plausibilisierung), (c) Ergebnis der Werthaltigkeitsprüfung, (d) Unterschrift Geschäftsführerin und ggf. Steuerberater.
 
-### 5. Differenzhaftungsrisiko
-Falls Forderung überbewertet eingebracht wird (z. B. Buchwert EUR 275694, tatsächlicher Wert EUR 200000 wegen Ausfallrisiko): Differenzhaftung der einbringenden Gesellschafterin / des Lenders i.H.d. Differenz (§ 9 GmbHG). Gegenstrategie: konservative Bewertung.
+### 5. Differenzhaftungs- und Geschäftsführer-Haftungsrisiko
+Falls Forderung überbewertet eingebracht wird (z. B. Buchwert EUR 275694, tatsächlicher Wert EUR 200000 wegen Ausfallrisiko): Differenzhaftung der einbringenden Gesellschafterin / des Lenders i.H.d. Differenz (§ 9 GmbHG). Zusätzlich Geschäftsführer-Eigenhaftung aus § 19 Abs. 4 GmbHG, wenn die Werthaltigkeit in der HR-Anmeldung wahrheitswidrig versichert wird; strafrechtlich flankiert durch § 82 GmbHG (falsche Angaben). Gegenstrategie: konservative Bewertung, dokumentierte Bewertungsgrundlage (Bilanz, BWA, Liquiditätsstatus), externe Plausibilisierung durch Steuerberater oder Wirtschaftsprüfer.
 
 ### 6. Vorlage beim Notar
 Sacheinlagebericht wird dem Kapitalerhöhungsbeschluss als Anlage beigefügt und dem Handelsregister übermittelt.
@@ -79,6 +81,7 @@ entspricht ihrem Nennwert von EUR 275694. Eine Überbewertung liegt nicht vor.
 | Kein Sacheinlagebericht | HR-Eintragung scheitert | Bericht unvollständig | Vollständiger Bericht |
 | Rangrücktritt noch aktiv bei Einbringung | Werthaltigkeit strittig | Rangrücktritt wird zeitgleich aufgehoben | Klar aufgehoben |
 | Differenzhaftungsrisiko ignoriert | Persönliche Haftung Lender/Gesellschafterinnen | Risiko bekannt aber nicht quantifiziert | Konservative Bewertung |
+| GF-Versicherung Werthaltigkeit ohne Plausibilisierung | § 19 IV GmbHG-Haftung GF, § 82 GmbHG strafrechtlich | Versicherung dünn dokumentiert | Plausibilisierung durch StB/WP dokumentiert |
 
 ## Querverweise
 

--- a/wandeldarlehen-lebenszyklus/skills/wandelereignis-eingang/SKILL.md
+++ b/wandeldarlehen-lebenszyklus/skills/wandelereignis-eingang/SKILL.md
@@ -24,6 +24,7 @@ Dieser Skill strukturiert den Workflow nach Eingang der Wandlungserklärung des 
 - § 132 BGB (Zugang bei Verweigerung der Annahme)
 - § 4.4 Wandeldarlehensvertrag (Frist: ein Monat nach Zugang Wandlungsmitteilung)
 - § 286 BGB (Verzug bei Fristversäumnis der Gesellschaft)
+- Zugangsfiktion bei einfachem Brief: seit Postrechtsmodernisierungsgesetz (PostModG, 1.1.2025) gilt regelmäßig **vier-Tage-Frist** ab Aufgabe zur Post (zuvor drei Tage); maßgeblich bei Berechnung der Wandlungsfrist, wenn Wandlungserklärung oder Wandlungsmitteilung postalisch verschickt wird
 
 ### Rechtsprechung
 - BGH, Urt. v. 12. März 2009 – IX ZR 85/08 (Zugang von Erklärungen per E-Mail – Eingangszeitpunkt)


### PR DESCRIPTION
## Stresstest

Plugin `wandeldarlehen-lebenszyklus` (32 Skills, v6.1.0) auf Aktualitaet und Funktion geprueft.

**Strukturell OK:**
- Validator gruen
- Marketplace-Eintrag korrekt
- 32 Skills mit Frontmatter
- Testakten-Pfade vorhanden
- Anschluss-Verweise konsistent

**Aktualitaetsluecken (P1/P2):**

| # | Skill | Reform | Befund |
|---|---|---|---|
| 1 | `beurkundungserfordernis-pruefung` | **DiRUG** 2022/2023 | Online-Beurkundung § 2 III GmbHG bei Gruendung und seit 1.8.2023 auch bei Kapitalerhoehungen (BeurkG § 16a) fehlte komplett — relevant bei Lender im Ausland |
| 2 | `sacheinlagebericht-werthaltigkeit` | **§ 19 IV GmbHG** | Nur § 9 GmbHG (Gesellschafter-Differenzhaftung) zitiert; GF-Werthaltigkeitsversicherung in HR-Anmeldung + § 82 GmbHG-Strafbarkeit fehlten |
| 3 | `rangruecktritt-formulieren` | **SanInsFoG** 1.1.2021 | § 15b InsO bereits drin, aber Reform-Kontext (§ 64 GmbHG a.F. abgeloest) und SanInsKG-Prognosezeitraum nicht klargestellt |
| 4 | `wandelereignis-eingang` | **PostModG** 1.1.2025 | 4-Tage-Zugangsfiktion (statt zuvor 3) bei postalischer Wandlungserklaerung — kritisch fuer Fristberechnung |
| 5 | `gesellschafterliste-aktualisieren` | **DiRUG** | Pflichtinhalte erweitert (prozentuale Beteiligung, ggf. Geburtsname); GesLV fehlte als Sekundaerquelle |

## Fix

Punktgenaue Aktualisierungen in den fuenf SKILL.md (Primaernormen, Vorgehen, Red Flags, Quellen-Updates). Inhalt der Skills im Uebrigen unveraendert.

## Test plan

- [x] `node scripts/validate-plugin-structure.mjs` OK
- [x] Marketplace-Listung weiterhin korrekt
- [x] Frontmatter unveraendert (alle Slugs bestehen weiter)
- [x] Stand-Vermerke (`Stand: 05/2026`) durch konkrete Reform-Datierungen flankiert

https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL

---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_