### PR TITLE
fix(juristisch): § DSGVO -> Art. DSGVO bzw. § BDSG + Slug-Fix (Stress-Sweep)

### DIFF
--- a/arbeitsrecht/skills/agg-pruefung-bewerber-und-beschaeftigte/SKILL.md
+++ b/arbeitsrecht/skills/agg-pruefung-bewerber-und-beschaeftigte/SKILL.md
@@ -220,7 +220,7 @@ Ein kumulativer Missbrauchsnachweis ist erforderlich:
 Die Hürden bleiben **hoch**: Das Auskunftsrecht (Art. 8 GRCh) gilt; Ausnahmen sind eng auszulegen. Ein einziger Antrag ohne weitere Anhaltspunkte genügt nicht.
 
 **Praxishinweise für den Arbeitgeber:**
-- DSGVO-Auskunft (Art. 15 DSGVO) und AGG-Entschädigungsbegehren (§ 15 AGG) laufen auf verschiedenen Rechtsgebieten parallel: Auskunftsklage gehört vor das **Landgericht** (§ 44 DSGVO); AGG-Entschädigungsklage vor das **Arbeitsgericht** (§ 2 Abs. 1 Nr. 3 ArbGG).
+- DSGVO-Auskunft (Art. 15 DSGVO) und AGG-Entschädigungsbegehren (§ 15 AGG) laufen auf verschiedenen Rechtsgebieten parallel: Auskunftsklage gehört vor das **Landgericht** (§ 44 BDSG i.V.m. Art. 79 DSGVO); AGG-Entschädigungsklage vor das **Arbeitsgericht** (§ 2 Abs. 1 Nr. 3 ArbGG).
 - Auskunft innerhalb eines Monats erteilen (Art. 12 Abs. 3 DSGVO); andernfalls droht eigenständiger Schadensersatz nach Art. 82 DSGVO zusätzlich zur AGG-Haftung.
 - Auswahlunterlagen und Bewertungsbögen sind personenbezogene Daten des Bewerbers — Offenlegungs- und Auskunftspflicht beachten; Geheimhaltungsinteressen Dritter (andere Bewerber) abwägen.
 - BAG, Urt. v. 20.06.2024 – 8 AZR 91/22: Bloßer Kontrollverlust durch Auskunftspflichtverletzung begründet nicht automatisch Art.-82-Schaden. `[Modellwissen – prüfen]`

--- a/arbeitsrecht/skills/kuendigungs-pruefung/SKILL.md
+++ b/arbeitsrecht/skills/kuendigungs-pruefung/SKILL.md
@@ -130,7 +130,7 @@ Hürden sind **hoch**: Das Auskunftsrecht ist ein Grundrecht (Art. 8 GRCh); Ausn
 **Praxishinweise für den Arbeitgeber:**
 - DSGVO-Auskunft fristgerecht innerhalb eines Monats beantworten (Art. 12 Abs. 3 DSGVO); unberechtigte Ablehnung kann eigenständigen Schadensersatzanspruch nach Art. 82 DSGVO auslösen.
 - Dokumentation für Missbrauchseinwand anlegen: Datum Kündigung, Datum Auskunftsantrag, Vorliegen von Legal-Tech-Vollmacht, Muster bei anderen Mitarbeitern.
-- Parallellauf Kündigungsschutzverfahren und DSGVO-Auskunftsstreit im Blick behalten: Zuständiges Gericht für Auskunftsklage ist nach § 44 DSGVO das Landgericht (nicht das Arbeitsgericht); Koordinierung der Prozesstaktik erforderlich.
+- Parallellauf Kündigungsschutzverfahren und DSGVO-Auskunftsstreit im Blick behalten: Zuständiges Gericht für Auskunftsklage ist nach Art. 79 DSGVO i.V.m. § 44 BDSG das Landgericht (nicht das Arbeitsgericht); Koordinierung der Prozesstaktik erforderlich.
 
 Querverweis: `datenschutzrecht/skills/dsgvo-auskunft/SKILL.md` (soweit im Plugin vorhanden).
 

--- a/arbeitsrecht/skills/kuendigungsschutzklage/SKILL.md
+++ b/arbeitsrecht/skills/kuendigungsschutzklage/SKILL.md
@@ -190,7 +190,7 @@ Ein erstmaliges Auskunftsersuchen kann ausnahmsweise nach Art. 12 Abs. 5 S. 2 DS
 - BAG, Urt. v. 20.02.2025 – 8 AZR 61/24: Der Betroffene muss konkrete nachteilige Auswirkungen der Auskunftspflichtverletzung darlegen. `[Modellwissen – prüfen]`
 
 **Prozessuale Koordination:**
-- Auskunftsklage nach Art. 15 DSGVO ist vor dem **Landgericht** einzuklagen (§ 44 DSGVO); das Arbeitsgericht ist nicht zuständig.
+- Auskunftsklage nach Art. 15 DSGVO ist vor dem **Landgericht** einzuklagen (§ 44 BDSG i.V.m. Art. 79 DSGVO); das Arbeitsgericht ist nicht zuständig.
 - Bei parallelem KSchG-Verfahren (Arbeitsgericht) und DSGVO-Auskunftsverfahren (Landgericht) Prozesstaktik koordinieren.
 - Unberechtigte Ablehnung eines legitimen Auskunftsersuchens kann eigenständigen Schadensersatzanspruch nach Art. 82 DSGVO auslösen — auch ohne rechtswidrige Verarbeitung.
 - Frist: Art. 12 Abs. 3 DSGVO — Antwort innerhalb eines Monats ab Eingang des Ersuchens; Verzögerung muss begründet und kommuniziert werden.

--- a/arbeitsrecht/skills/mandat-triage-arbeitsrecht/SKILL.md
+++ b/arbeitsrecht/skills/mandat-triage-arbeitsrecht/SKILL.md
@@ -141,7 +141,7 @@ Bei jedem Kündigungs-, Aufhebungsvertrag- oder AGG-Mandat zusätzlich prüfen:
 3. Prüfen: Liegt objektives + subjektives Element für Missbrauchseinwand vor (EuGH C-526/24)?
 4. Falls Missbrauchseinwand nicht sicher: Auskunft erteilen oder begründet verzögern (max. zwei weitere Monate, Art. 12 Abs. 3 S. 2 DSGVO).
 5. Ausgleichsklausel im Aufhebungsvertrag: DSGVO-Ansprüche und Art.-82-Schadensersatz einbeziehen?
-6. Zuständigkeit: Auskunftsklage gehört vor das Landgericht (§ 44 DSGVO), nicht vor das Arbeitsgericht.
+6. Zuständigkeit: Auskunftsklage gehört vor das Landgericht (§ 44 BDSG i.V.m. Art. 79 DSGVO), nicht vor das Arbeitsgericht.
 
 Querverweis: `arbeitsrecht/skills/kuendigungs-pruefung/SKILL.md` (Abschnitt DSGVO-Auskunftsersuchen als Druckmittel) und `arbeitsrecht/skills/aufhebungsvertrag/SKILL.md` (DSGVO-Auskunftsersuchen als Verhandlungshebel).
 

--- a/datenschutzrecht/skills/datenschutzrecht-kaltstart-interview/SKILL.md
+++ b/datenschutzrecht/skills/datenschutzrecht-kaltstart-interview/SKILL.md
@@ -92,7 +92,7 @@ Praxisumgebung: Unternehmen intern
 Primär: Auftragsverarbeiter (Art. 28 DSGVO) für Kundendaten
 Rechtsgrundlage: Art. 6 Abs. 1 lit. b DSGVO (Vertragserfüllung) für Kunden; Art. 6 Abs. 1 lit. c DSGVO (gesetzliche Pflicht)
 Zuständige Aufsichtsbehörde: LfDI NRW (Hauptniederlassung NRW)
-DSB: [Name], intern, bestellt nach § 37 DSGVO / § 38 BDSG
+DSB: [Name], intern, bestellt nach Art. 37 DSGVO / § 38 BDSG
 Drittlandtransfer: nein (Hosting Frankfurt, alle Sub-AVs EU)
 Deal-Breaker: Sub-AV-Wechsel ohne 4-Wochen-Vorankündigung
 ```

--- a/fachanwalt-bank-kapitalmarktrecht/skills/fachanwalt-bank-kapitalmarktrecht-schufa-loeschungsanspruch/SKILL.md
+++ b/fachanwalt-bank-kapitalmarktrecht/skills/fachanwalt-bank-kapitalmarktrecht-schufa-loeschungsanspruch/SKILL.md
@@ -118,7 +118,7 @@ Mandate von Verbrauchern mit unrechtmaessigen SCHUFA-Eintraegen. Auskunft, Wider
 ## 8) Anschluss
 
 - `fachanwalt-bank-kapitalmarktrecht-kreditkuendigung-490-bgb` — bei verbundener Kredit-Konstellation
-- `datenschutzrecht/skills/auskunftsersuchen-art-15-dsgvo` — für formelle Anträge
+- `datenschutzrecht/skills/dsgvo-auskunft` — für formelle Anträge nach Art. 15 DSGVO
 - `forderungsmanagement-klagewerkstatt` — bei Inkasso-Streit-Hintergrund
 
 ## 9) Aktuelle BGH-/EuGH-Linien

--- a/fachanwalt-it-recht/skills/fachanwalt-it-recht-cyber-vorfall-sofortmassnahmen/SKILL.md
+++ b/fachanwalt-it-recht/skills/fachanwalt-it-recht-cyber-vorfall-sofortmassnahmen/SKILL.md
@@ -78,7 +78,7 @@ Bei akutem Cyber-Vorfall (Ransomware, Datenleck, Hack): koordinierte rechtliche 
 
 - Forensik-Bericht-Zwischenstand
 - Schadens-Bewertung
-- Betroffene-Information § 34 DSGVO falls Pflicht
+- Betroffene-Information Art. 34 DSGVO falls Pflicht
 
 ### Tag 6-7
 

--- a/kanzlei-cowork/skills/geburtstage-feiertage/SKILL.md
+++ b/kanzlei-cowork/skills/geburtstage-feiertage/SKILL.md
@@ -31,7 +31,7 @@ description: Pflegt einen Mandanten- und Geschaeftspartner-Geburtstagsverteiler.
 
 - **Art. 6 Abs. 1 lit. f DSGVO** berechtigtes Interesse — Mandantenpflege ist allgemein zulässig.
 - **Widerspruchsrecht** beachten — auf Widerspruch hin Eintrag deaktivieren.
-- **Information bei Mandatsbeginn** (Datenschutzhinweis § 13 DSGVO) auf mögliche Glückwunschsendungen.
+- **Information bei Mandatsbeginn** (Datenschutzhinweis Art. 13 DSGVO) auf mögliche Glückwunschsendungen.
 - **Verarbeitungsverzeichnis** nach Art. 30 DSGVO ergänzen.
 
 ## Tagesbrief-Integration

--- a/produktrecht/agents/markteinfuehrungs-monitor.md
+++ b/produktrecht/agents/markteinfuehrungs-monitor.md
@@ -36,7 +36,7 @@ Neben Kalibrierungsmustern auch Tickets mit folgenden Begriffen kennzeichnen:
 
 **Datenschutz-Trigger:**
 - „neue Daten" / „erheben" / „Tracking"
-- „unter 13" / „Kinder" / „COPPA-Äquivalent" → Prüfung Kinderdatenschutz (§ 8 DSGVO, Art. 8 DSGVO, KOSA-Äquivalent)
+- „unter 13" / „Kinder" / „COPPA-Äquivalent" → Prüfung Kinderdatenschutz (Art. 8 DSGVO, KOSA-Äquivalent)
 - „Jugendliche" / „Minderjährige" / „13–17" / „altersgerecht" / „Schüler" → Prüfung altersgerechtes Design (anderes Regime, andere Kalibrierung)
 - „Gesundheit" / „medizinisch" / „Gesundheitsdaten" (§ 22 BDSG, Art. 9 DSGVO)
 - „personenbezogene Daten" / „PII" / „Nutzerdaten"


### PR DESCRIPTION
## Stress-Sweep — **böser Fehler gefunden**

Stichprobensweep über strukturelle und juristische Klassen. Ein **echter, doktrinal heikler Fehler** war drin:

### Hauptbefund: `§ 44 DSGVO` existiert nicht

Vier Arbeitsrechts-Skills zitierten `§ 44 DSGVO` als Norm für die Gerichtszuständigkeit der Auskunftsklage (Landgericht statt Arbeitsgericht). Die DSGVO hat aber **gar keinen § 44** — sie hat nur Artikel. Die DSGVO kennt nur Art. 1 bis Art. 99.

**Korrekt:** **§ 44 BDSG** i.V.m. Art. 79 DSGVO. § 44 BDSG regelt im deutschen Recht die Gerichtszuständigkeit für Klagen wegen DSGVO-Verstößen.

Das ist genau die Sorte Fehler, der ungeprüft in echte Schriftsätze gerät und peinlich wird.

### Weitere DSGVO-§-Verstöße (Klotzkette-Regel)

| Datei | Vorher | Nachher |
|---|---|---|
| `arbeitsrecht/kuendigungs-pruefung` | § 44 DSGVO | § 44 BDSG i.V.m. Art. 79 DSGVO |
| `arbeitsrecht/mandat-triage` | § 44 DSGVO | § 44 BDSG i.V.m. Art. 79 DSGVO |
| `arbeitsrecht/kuendigungsschutzklage` | § 44 DSGVO | § 44 BDSG i.V.m. Art. 79 DSGVO |
| `arbeitsrecht/agg-pruefung-bewerber` | § 44 DSGVO | § 44 BDSG i.V.m. Art. 79 DSGVO |
| `datenschutzrecht/kaltstart-interview` | § 37 DSGVO | Art. 37 DSGVO |
| `produktrecht/markteinfuehrungs-monitor` | § 8 DSGVO | (Dublette entfernt) |
| `fachanwalt-it-recht/cyber-vorfall` | § 34 DSGVO | Art. 34 DSGVO |
| `kanzlei-cowork/geburtstage-feiertage` | § 13 DSGVO | Art. 13 DSGVO |

### Zusatz-Fix: toter Skill-Verweis

`fachanwalt-bank-kapitalmarktrecht/schufa-loeschungsanspruch` verwies auf `datenschutzrecht/skills/auskunftsersuchen-art-15-dsgvo` — existiert nicht. Korrigiert auf den existierenden Slug `datenschutzrecht/skills/dsgvo-auskunft`.

### Sweep-Statistik

| Check | Ergebnis |
|---|---|
| Validator | OK |
| plugin.json + marketplace.json JSON-Syntax | 0 Fehler |
| SKILL.md ohne Frontmatter | 0 |
| Frontmatter ohne `name`/`description` | 0 |
| Description > 1024 (Skill) / 300 (Plugin) | 0 |
| `\d,\s*\d` in descriptions | 0 |
| Frontmatter-name != Verzeichnis | 0 |
| Python-Werkzeuge mit Syntaxfehler | 0 |
| Broken Markdown links (mit URL-decode) | 0 |
| Stale Skill-Slug-Verweise | **1** (gefixt) |
| § statt Art. bei DSGVO | **8** (gefixt) |

**9 Dateien, 9 Korrekturen.**
