### PR TITLE
release: v7.0.0 — Reform-Stand 2026

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,13 +13,13 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "aktenauszug-gerichtsverfahren",
       "source": "./aktenauszug-gerichtsverfahren",
       "description": "Strukturierter Aktenauszug fuer deutsche Gerichtsverfahren: Verfahrensidentifikation Einleitungssatz Verfahrenszusammenfassung Sachverhaltschronologie Verfahrensgeschichte tabellarische Gegenueberstellung der Parteivortraege Beweismittel und Rechtsargumente fuer schnelle Einarbeitung in Akten.",
-      "version": "6.1.0",
+      "version": "7.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -31,7 +31,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "arbeitsrecht",
@@ -40,7 +40,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "arbeitszeugnis-analyse",
@@ -49,7 +49,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "aussenwirtschaft-zoll-sanktionen",
@@ -58,7 +58,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "bav-strategie-konzern",
@@ -67,7 +67,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "bereicherungs-und-anfechtungsrecht-pruefer",
@@ -76,7 +76,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "berufsrecht-ki-vertragspruefung",
@@ -85,7 +85,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "betreuungsrecht",
@@ -94,7 +94,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "common-law-kompass",
@@ -103,7 +103,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "corporate-kanzlei",
@@ -112,7 +112,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "datenschutzrecht",
@@ -121,7 +121,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "einfache-leichte-sprache-jura",
@@ -130,7 +130,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "email-umformulierer-berufsrecht",
@@ -139,7 +139,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "energierecht",
@@ -148,7 +148,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "europarecht-kompass",
@@ -157,7 +157,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-agrarrecht",
@@ -166,7 +166,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-arbeitsrecht",
@@ -175,7 +175,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-bank-kapitalmarktrecht",
@@ -184,7 +184,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-bau-architektenrecht",
@@ -193,7 +193,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-erbrecht",
@@ -202,7 +202,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-familienrecht",
@@ -211,7 +211,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-gewerblicher-rechtsschutz",
@@ -220,7 +220,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-handels-gesellschaftsrecht",
@@ -229,7 +229,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-insolvenz-sanierungsrecht",
@@ -238,7 +238,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-internationales-wirtschaftsrecht",
@@ -247,7 +247,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-it-recht",
@@ -256,7 +256,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-medizinrecht",
@@ -265,7 +265,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-miet-wohnungseigentumsrecht",
@@ -274,7 +274,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-migrationsrecht",
@@ -283,7 +283,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-sozialrecht",
@@ -292,7 +292,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-sportrecht",
@@ -301,7 +301,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-steuerrecht",
@@ -310,7 +310,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-strafrecht",
@@ -319,7 +319,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-transport-speditionsrecht",
@@ -328,7 +328,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-urheber-medienrecht",
@@ -337,7 +337,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-vergaberecht",
@@ -346,7 +346,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-verkehrsrecht",
@@ -355,7 +355,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-versicherungsrecht",
@@ -364,7 +364,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fachanwalt-verwaltungsrecht",
@@ -373,7 +373,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fluggastrechte",
@@ -382,7 +382,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "forderungsmanagement-klagewerkstatt",
@@ -391,7 +391,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "fortbestehensprognose",
@@ -400,7 +400,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "geldwaeschepraevention-aml-kyc",
@@ -409,7 +409,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "gesellschaftsgruender",
@@ -418,7 +418,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "gesellschaftsrecht",
@@ -427,7 +427,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "gewerblicher-rechtsschutz",
@@ -436,7 +436,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "grosskanzlei-corporate-ma",
@@ -445,7 +445,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "hausarbeitenmacher",
@@ -454,7 +454,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "immobilienrechtspraxis",
@@ -463,7 +463,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "insolvenzforderungsanmeldungspruefung",
@@ -472,7 +472,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "insolvenzplan-starug-planwerkstatt",
@@ -481,7 +481,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "insolvenzrecht",
@@ -490,7 +490,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "insolvenzverwaltung",
@@ -499,7 +499,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "jurastudium",
@@ -508,7 +508,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "jveg-kostenpruefer",
@@ -517,7 +517,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "kanzlei-allgemein",
@@ -526,7 +526,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "kanzlei-builder-hub",
@@ -535,7 +535,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "kanzlei-cowork",
@@ -544,12 +544,12 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "kartellrecht-marktabgrenzung-pruefung",
       "source": "./kartellrecht-marktabgrenzung-pruefung",
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "ki-governance",
@@ -558,7 +558,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "ki-richtlinie-kanzleien",
@@ -567,7 +567,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "ki-vo-ai-act-pruefer",
@@ -576,7 +576,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "krisenfrueherkennung-starug",
@@ -585,14 +585,14 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "legistik-werkstatt",
       "source": "./legistik-werkstatt",
       "description": "Legistik-Werkstatt fuer Bundes- und Landesministerien. Vom politischen Auftrag ueber Normhierarchie Kompetenzpruefung Normenkartierung Terminologie zu Referentenentwurf Kabinettsmappe Formulierungshilfe Rechtsverordnung Satzung. Inkl. Begruendung Synopse Lesefassung XML Folgenabschaetzung Goldplating-Check und Schulungstrainings. Erzeugt am Ende DOCX und PDF im offiziellen HdR-Layout (Times New Roman BT-Drucksachen, Arial Referentenentwurf).",
       "category": "verwaltung",
-      "version": "6.1.0",
+      "version": "7.0.0",
       "tags": [
         "legistik",
         "gesetzgebung",
@@ -614,7 +614,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "mandantenanfragen-assistent",
@@ -623,7 +623,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "markenrecht-fashion-luxus",
@@ -632,7 +632,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "memorandums-ersteller",
@@ -641,7 +641,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "methodenlehre-buergerliches-recht",
@@ -650,7 +650,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "mietrecht",
@@ -659,7 +659,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "mittelstand-corporate-ma",
@@ -668,7 +668,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "nda-abgleich",
@@ -677,7 +677,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "normenkontrolle-bauleitplanung",
@@ -686,7 +686,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "patentrecherche",
@@ -695,7 +695,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "phishing-vorfall-pruefer",
@@ -704,7 +704,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "produktrecht",
@@ -713,7 +713,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "prozessrecht",
@@ -722,7 +722,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "rechtsberatungsstelle",
@@ -731,7 +731,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "regulatorisches-recht",
@@ -740,7 +740,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "schriftform-und-textform-bgb",
@@ -749,7 +749,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "sozialrecht-kanzlei",
@@ -758,7 +758,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "steuerberater-werkzeuge",
@@ -767,7 +767,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "steuerrecht-kanzlei",
@@ -776,7 +776,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "strafbefehl-verteidiger",
@@ -785,7 +785,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "subsumtions-pruefer",
@@ -794,7 +794,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "tabellenreview-3d",
@@ -803,7 +803,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "umweltrecht",
@@ -812,13 +812,13 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "urteilsbauer-relationsmacher",
       "source": "./urteilsbauer-relationsmacher",
       "description": "Werkstatt-Plugin fuer Amts-, Land- und Familienrichter: Aktenintake, Relation (Voll- oder Kurzfassung mit Wahlfrage), Zulaessigkeit, Anspruchsgrundlagen, CISG, kollidierende AGB, Incoterms, Beweiswuerdigung mit Richter-Input, Tenor, Tatbestand, Entscheidungsgruende, Kosten, vorlaeufige Vollstreckbarkeit, Rechtsmittelbelehrung, Berufungs- und Revisionsfestigkeit, Beschluesse, Familienspezifika sowie Renderer fuer DOCX und PDF im Gerichtslayout. Inklusive Schulungsakte Solis Vision X Smartglasses.",
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "verfassungsrecht",
@@ -827,7 +827,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "verkehr-infrastrukturrecht",
@@ -836,7 +836,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "verkehrsowi-verteidiger",
@@ -845,7 +845,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "verlagsredaktion",
@@ -854,7 +854,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "vertragsausfueller",
@@ -863,7 +863,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "vertragsrecht",
@@ -872,7 +872,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "wandeldarlehen-lebenszyklus",
@@ -881,7 +881,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "zitierweise-deutsches-recht",
@@ -890,7 +890,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     {
       "name": "zwangsverwaltung-zvg",
@@ -899,8 +899,8 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "6.1.0"
+      "version": "7.0.0"
     }
   ],
-  "version": "6.0.0"
+  "version": "7.0.0"
 }

--- a/ASSET_INDEX.md
+++ b/ASSET_INDEX.md
@@ -2,7 +2,7 @@
 
 Übersicht aller Dateien, die der Release-Workflow (`.github/workflows/release-plugin-zips.yml`) pro Tag-Release `vX.Y.Z` an den GitHub-Release anhängt.
 
-**Stand:** v6.3.0
+**Stand:** v7.0.0
 
 ## Asset-Typen
 

--- a/INSTALLATION_EINFACH.md
+++ b/INSTALLATION_EINFACH.md
@@ -6,7 +6,7 @@
 
 ## Kurzfassung
 
-> 📆 **Hinweis Release vs. Entwicklungsstand:** Die ZIPs in der Releases-Seite entsprechen einem **getaggten, validierten Stand** (zur Zeit `v6.3.0`). Der `main`-Branch des Repos kann **neuer** sein — mit weiteren Fixes, kleinen Ergänzungen oder neuen Tests. Für stabile Tagung → ZIPs aus dem Release; für neueste Korrekturen → Marketplace-Sync über den GitHub-Pfad (siehe README.md, Weg 1).
+> 📆 **Hinweis Release vs. Entwicklungsstand:** Die ZIPs in der Releases-Seite entsprechen einem **getaggten, validierten Stand** (zur Zeit `v7.0.0`). Der `main`-Branch des Repos kann **neuer** sein — mit weiteren Fixes, kleinen Ergänzungen oder neuen Tests. Für stabile Tagung → ZIPs aus dem Release; für neueste Korrekturen → Marketplace-Sync über den GitHub-Pfad (siehe README.md, Weg 1).
 
 1. Auf [die Releases-Seite](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest) gehen.
 2. Pro gewünschtem Rechtsgebiet **eine ZIP-Datei** herunterladen, z. B. `liquiditaetsplanung.zip`.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Die Skills sind inzwischen deutlich verbessert und in verschiedenen Konstellatio
 
 Dieses Repository trifft **keine Aussage** zur Zulässigkeit eines Einsatzes im konkreten Mandat oder Unternehmen – insbesondere nicht zu §§ 203, 204 StGB, § 43e BRAO, § 2 BORA, § 53, § 97, § 160a StPO, DSGVO / BDSG (inkl. Drittlandtransfer), US-Cloud-Act / FISA, der KI-VO (VO (EU) 2024/1689) oder sonstigen berufsrechtlichen, datenschutzrechtlichen und regulatorischen Vorgaben. Ob und wie ihr diese Beispiele produktiv nutzen dürft, müsst ihr **eigenverantwortlich** prüfen und in eure bestehende Governance (Mandatsgeheimnis, AVV, TOMs, KI-Richtlinien, Betriebsvereinbarungen etc.) integrieren.
 
-## Überblick v6.3.0 auf einen Blick
+## Überblick v7.0.0 auf einen Blick
 
 | Kennzahl | Wert |
 |---|---|
@@ -27,7 +27,7 @@ Dieses Repository trifft **keine Aussage** zur Zulässigkeit eines Einsatzes im 
 | **Skills (SKILL.md)** | über 1500 |
 | **Testakten** | 44 |
 | **Fachanwalts-/-anwältinnen-Profile** | alle 24 |
-| **Letzter Release** | [v6.3.0](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/tag/v6.3.0) |
+| **Letzter Release** | [v7.0.0](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/tag/v7.0.0) |
 | **Marketplace-Definition** | [`.claude-plugin/marketplace.json`](./.claude-plugin/marketplace.json) |
 
 > 🧪 **Übrigens — es gibt auch sehr schöne Testakten.** Im Verzeichnis [`testakten/`](./testakten) liegen mehrere umfangreiche, fiktive Mandatsakten mit echten PDFs, Excel-Tabellen, Word-Entwürfen und handschriftlichen Notizen — bewusst unstrukturiert benannt wie ein realer Datenraum, damit sich die Plugins an echten Mandaten ausprobieren lassen. Details und Direkt-Downloads im [Testakten-README](./testakten/README.md).
@@ -56,7 +56,7 @@ Die vollständige Plugin-Liste findest du in [`.claude-plugin/marketplace.json`]
 /plugin install <plugin-name>@claude-fuer-deutsches-recht
 ```
 
-Alternativ: über die Claude-Desktop-GUI unter **Customize → Skills** → ZIP aus dem [Release v6.3.0](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/tag/v6.3.0) hochladen. Schritt-für-Schritt unter [Schnellstart](#schnellstart) und [Für Einsteiger](#für-einsteiger-schritt-für-schritt-anleitung).
+Alternativ: über die Claude-Desktop-GUI unter **Customize → Skills** → ZIP aus dem [Release v7.0.0](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/tag/v7.0.0) hochladen. Schritt-für-Schritt unter [Schnellstart](#schnellstart) und [Für Einsteiger](#für-einsteiger-schritt-für-schritt-anleitung).
 
 ## 🚨 KEINE Aussage über Berufsrecht, Datenschutz, KI-VO oder Beschlagnahmeverbote
 
@@ -318,7 +318,7 @@ Für einen neuen Plugin gilt: L1 ist der akzeptable Start, L2 wird angestrebt, s
 
 Dieses Skill-Set lässt sich auf drei Wegen einbinden. Empfohlen ist **Weg 1** über die grafische Oberfläche; **Weg 2** für gezielten ZIP-Upload einer bestimmten Version; **Weg 3** für Claude Code im Terminal.
 
-> 📆 **Release- vs. main-Stand.** Der **letzte Release-Tag** ist [v6.3.0](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest). Über **Weg 1 (Marketplace-Sync)** und **Weg 3 (Marketplace-Kommando)** wird der `main`-Branch geladen — das ist meist **neuer** als der letzte Release-Tag (Zwischen-Commits mit Fixes, neuen Tests, kleinen Ergänzungen). Über **Weg 2 (ZIP-Upload aus Release)** bekommst du den **getaggten, validierten Stand**. Für Stabilität → Weg 2; für neueste Korrekturen → Weg 1/3.
+> 📆 **Release- vs. main-Stand.** Der **letzte Release-Tag** ist [v7.0.0](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest). Über **Weg 1 (Marketplace-Sync)** und **Weg 3 (Marketplace-Kommando)** wird der `main`-Branch geladen — das ist meist **neuer** als der letzte Release-Tag (Zwischen-Commits mit Fixes, neuen Tests, kleinen Ergänzungen). Über **Weg 2 (ZIP-Upload aus Release)** bekommst du den **getaggten, validierten Stand**. Für Stabilität → Weg 2; für neueste Korrekturen → Weg 1/3.
 
 > 💡 **Findest du in Cowork kein Feld für den GitHub-Pfad?** Dann ist in deiner Oberfläche der Marketplace-Weg vermutlich noch nicht freigeschaltet. Lade die Plugin-ZIPs einzeln aus dem [Release](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest) herunter und installiere sie über denselben Dialog, mit dem du z. B. „Legal Plugin" installierst. Schritt für Schritt erklärt: **[INSTALLATION_EINFACH.md](./INSTALLATION_EINFACH.md)**.
 
@@ -398,7 +398,7 @@ Dieses Repository ist vollständig auf das deutsche Recht und die Arbeitsweise d
 - Due Diligence läuft über Q&A, Datenraum und anwaltliche Sachverhaltsaufklärung.
 - Kündigungsschutz: Regelfall nach KSchG ab 6 Monate / mehr als 10 Arbeitnehmer.
 
-Stand v6.3.0: **99 Plugins, 1565 Skills, 44 Testakten**. Abgedeckt sind klassische Mandantenpraxis, alle 24 Fachanwaltschaften, Großkanzlei- und Mittelstandsformate sowie Spezialdisziplinen wie Insolvenzverwaltung, Zwangsverwaltung, Zwangsversteigerung, Markenrecht für Luxus-Fashion mit USPTO-Lanham-Act-Modul, betriebliche Altersversorgung in Konzernen mit Düsseldorf-Kyoto-Profil, StaRUG-Krisenfrüherkennung mit Vier-und-zwanzig-Monats-Horizont, Schriftform-/Textform-Workflow-Organisator nach BGH I ZR 202/25 und BGH VIII ZR 159/23, Wandeldarlehen-Lebenszyklus mit Cap-Table-Mechanik sowie generische Mechanik-Prüfer für Subsumtion, Bereicherungs-/Anfechtungsrecht und die KI-VO (Verordnung (EU) 2024/1689).
+Stand v7.0.0: **99 Plugins, 1565 Skills, 44 Testakten**. Abgedeckt sind klassische Mandantenpraxis, alle 24 Fachanwaltschaften, Großkanzlei- und Mittelstandsformate sowie Spezialdisziplinen wie Insolvenzverwaltung, Zwangsverwaltung, Zwangsversteigerung, Markenrecht für Luxus-Fashion mit USPTO-Lanham-Act-Modul, betriebliche Altersversorgung in Konzernen mit Düsseldorf-Kyoto-Profil, StaRUG-Krisenfrüherkennung mit Vier-und-zwanzig-Monats-Horizont, Schriftform-/Textform-Workflow-Organisator nach BGH I ZR 202/25 und BGH VIII ZR 159/23, Wandeldarlehen-Lebenszyklus mit Cap-Table-Mechanik sowie generische Mechanik-Prüfer für Subsumtion, Bereicherungs-/Anfechtungsrecht und die KI-VO (Verordnung (EU) 2024/1689).
 
 ### Materielle Rechtsgebiete
 

--- a/aktenaufbereiter-strafrecht/.claude-plugin/plugin.json
+++ b/aktenaufbereiter-strafrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aktenaufbereiter-strafrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Aktenaufbereiter fuer die Strafverteidigung. Sechs Excel-faehige Uebersichten — Aktenvorblatt; Personenverzeichnis; Tatkomplexe; Beziehungen; Chronologie; Fristen. Fortlaufend ergaenzbar. Erkennt Luecken und Widersprueche. Kein Ersatz fuer Aktenlektuere.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/aktenauszug-gerichtsverfahren/.claude-plugin/plugin.json
+++ b/aktenauszug-gerichtsverfahren/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aktenauszug-gerichtsverfahren",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Strukturierter Aktenauszug fuer deutsche Gerichtsverfahren: Verfahrensidentifikation Einleitungssatz Verfahrenszusammenfassung Sachverhaltschronologie Verfahrensgeschichte tabellarische Gegenueberstellung der Parteivortraege Beweismittel und Rechtsargumente fuer schnelle Einarbeitung in Akten.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/anlagen-zu-schriftsaetzen/.claude-plugin/plugin.json
+++ b/anlagen-zu-schriftsaetzen/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anlagen-zu-schriftsaetzen",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Zuordnung von Anlagen zu gerichtlichen Schriftsaetzen. Sortiert PDF/Word/Excel nach Schriftsatz-Logik; konvertiert alles nach PDF; benennt beA-konform; stempelt oben rechts Anlage K1/B1/A1 in Arial 12; baut Anlagenkonvolut; Pruefmodus fuer bereits zugeordnete Anlagen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/arbeitsrecht/.claude-plugin/plugin.json
+++ b/arbeitsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "arbeitsrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Arbeitsrecht – Individualkündigung (KSchG-Klage, 3-Wochen-Frist), Aufhebungsvertrag inkl. Sperrzeit, Abmahnung, Anhörung Betriebsrat § 102 BetrVG, AGG-Prüfung, Statusfeststellung, Personalrichtlinien (BetrVG, AGG, ArbZG, MuSchG, BEEG, EFZG, TzBfG).",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/arbeitszeugnis-analyse/.claude-plugin/plugin.json
+++ b/arbeitszeugnis-analyse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "arbeitszeugnis-analyse",
   "displayName": "Arbeitszeugnis-Analyse (Ampelsystem)",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Analyse deutscher Arbeitszeugnisse nach Ampelsystem (Rot/Orange/Gruen). Erkennt den Geheimcode der Zeugnissprache, identifiziert notenrelevante Saetze und klassifiziert sie mit Interpretation der versteckten Bewertung.",
   "author": {
     "name": "Klotzkette"

--- a/aussenwirtschaft-zoll-sanktionen/.claude-plugin/plugin.json
+++ b/aussenwirtschaft-zoll-sanktionen/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aussenwirtschaft-zoll-sanktionen",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Freistehendes Plugin für Außenwirtschaft, Sanktionen, Zoll, Exportkontrolle, BAFA, TARIC, CBAM, Verbrauchsteuer, AWV, AML/KYC und Ermittlungen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/bav-strategie-konzern/.claude-plugin/plugin.json
+++ b/bav-strategie-konzern/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bav-strategie-konzern",
   "displayName": "Betriebliche Altersversorgung Strategie Konzern",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Strategische Beratung zur betrieblichen Altersversorgung in Konzernen: Pensionsmodelle alle fuenf Durchfuehrungswege CTA Pension Buyouts Drei-Stufen-Theorie Versorgungssystem-Harmonisierung internationale Benefits Restrukturierung DB-zu-DC im Duesseldorfer Boutique-Stil.",
   "author": {
     "name": "Klotzkette"

--- a/bereicherungs-und-anfechtungsrecht-pruefer/.claude-plugin/plugin.json
+++ b/bereicherungs-und-anfechtungsrecht-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bereicherungs-und-anfechtungsrecht-pruefer",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Mechanisches Durchpruefen von Bereicherungsrecht SS 812 ff. BGB sowie Anfechtung nach AnfG und SS 129-147 InsO. Weichenstellung Rechtsgrund, Insolvenz, Vollstreckungstitel. Keine Rechtsberatung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/berufsrecht-ki-vertragspruefung/.claude-plugin/plugin.json
+++ b/berufsrecht-ki-vertragspruefung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "berufsrecht-ki-vertragspruefung",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Berufsrechtliche und strafrechtliche Forprüfung von Verträgen mit privaten Legal-AI-Anbietern. Für Rechtsanwälte Steuerberater Wirtschaftsprüfer Patentanwälte Notare. §§ 43e BRAO 62a StBerG 50a WPO 39c PAO 26a BNotO § 203 StGB. Maßstab DAV-Stellungnahme. Gutachten Rückfragebrief Klauselvorschläge.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/betreuungsrecht/.claude-plugin/plugin.json
+++ b/betreuungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "betreuungsrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Betreuungsrechtliche Skills für Jahresbericht, Vermögensverzeichnis, Genehmigungspflichten, Kontoanalyse und Verdachtsverträge nach BtOG und BGB.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/common-law-kompass/.claude-plugin/plugin.json
+++ b/common-law-kompass/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "common-law-kompass",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Freistehendes Common-Law-Plugin für deutsche Wirtschaftsjuristen: UK/US-False-Friends, Vertragsbegriffe, Consideration, Suretyship, Indemnity, UCC, Precedent, Discovery und bilinguale Drafting-Reviews.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/corporate-kanzlei/.claude-plugin/plugin.json
+++ b/corporate-kanzlei/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corporate-kanzlei",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Corporate-Kanzlei-Plugin: Deal-Kommandocenter, Datenraum, Due Diligence, SPA/APA, Umwandlung, StaRUG, Insolvenzplan, W&I, Signing/Closing, PMI.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/datenschutzrecht/.claude-plugin/plugin.json
+++ b/datenschutzrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "datenschutzrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "DSGVO/BDSG/TDDDG – PIA/DPIA, AVV-Review als Verantwortlicher und Auftragsverarbeiter, Auskunftsersuchen Art. 15, Datenpannenmeldung Art. 33/34, Drittlandstransfer Art. 44 ff., Drift-Monitoring.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/einfache-leichte-sprache-jura/.claude-plugin/plugin.json
+++ b/einfache-leichte-sprache-jura/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "einfache-leichte-sprache-jura",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Juristische Texte in Einfache Sprache oder Leichte Sprache übertragen: experimentelle Standard-Annäherung, Zielgruppe klären, Rechtsinhalt sichern und Qualitätsgate nutzen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/email-umformulierer-berufsrecht/.claude-plugin/plugin.json
+++ b/email-umformulierer-berufsrecht/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "email-umformulierer-berufsrecht",
   "displayName": "E-Mail-Umformulierer (Berufsrechtskonform)",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Formuliert unfreundliche, emotionale oder unsachliche E-Mails in hoefliche, sachliche und berufsrechtskonform formulierte Texte um. Fokus auf BRAO/BORA-Konformitaet, mit Varianten fuer Steuerberater, Notare und allgemeine berufliche Korrespondenz.",
   "author": {
     "name": "Klotzkette"

--- a/energierecht/.claude-plugin/plugin.json
+++ b/energierecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "energierecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Freistehendes Energierecht-Plugin für Stadtwerke, Versorger, Wärme, Netze, Vertrieb, Industrie, EEG, KWKG, Verfahren, Transaktionen und Projektfinanzierung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/europarecht-kompass/.claude-plugin/plugin.json
+++ b/europarecht-kompass/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "europarecht-kompass",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Freistehendes Europarecht-Plugin gegen deutsche Denkfehler: Vorrang, unmittelbare Wirkung, Richtlinien, Verordnungen, Charta, Grundfreiheiten, Beihilfen, Vorlageverfahren und EU-Drafting.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-agrarrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-agrarrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-agrarrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt für Agrarrecht. Höferecht (HöfeO Anerbenrecht Länder) Landpachtrecht BGB §§ 581 ff. GAP EU-Direktzahlungen Cross-Compliance Düngeverordnung Pflanzenschutz Tierschutz Forstrecht. Schnittstelle Plugin fachanwalt-erbrecht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-arbeitsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-arbeitsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-arbeitsrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Arbeitsrecht nach FAO § 10. KSchG Kuendigungsschutzklage Frist drei Wochen § 4 KSchG. BetrVG Betriebsratsanhoerung § 102. TzBfG Befristung. AGG. Schnittstellen arbeitsrecht und kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-bank-kapitalmarktrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-bank-kapitalmarktrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-bank-kapitalmarktrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Bank- und Kapitalmarktrecht. KWG ZAG WpHG WpIG MiFID-II MAR MiCAR Verbraucherkredit Vermoegensanlage Beratungshaftung. Schnittstellen Plugin gesellschaftsrecht regulatorisches-recht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-bau-architektenrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-bau-architektenrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-bau-architektenrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Bau- und Architektenrecht. BGB Werkvertrag VOB-A VOB-B VOB-C HOAI Bauordnungsrecht. Bauvertrag Maengelhaftung Abnahme Vergaberecht. Schnittstellen Plugin fachanwalt-vergaberecht kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-erbrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-erbrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-erbrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Erbrecht. BGB Erbrecht §§ 1922 ff. Pflichtteil Testament Erbschein Erbauseinandersetzung Erbschaftsteuer EU-ErbVO. Schnittstellen Plugin steuerrecht-kanzlei kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-familienrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-familienrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-familienrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Familienrecht. Orientierung Normen Mandate Fristen Literatur. Familiengericht FamFG Scheidung Sorge Umgang Unterhalt Zugewinn Ehevertrag eingetragene Lebenspartnerschaft. Ergaenzend zum Plugin kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-gewerblicher-rechtsschutz/.claude-plugin/plugin.json
+++ b/fachanwalt-gewerblicher-rechtsschutz/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-gewerblicher-rechtsschutz",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer gewerblichen Rechtsschutz nach FAO § 14k. MarkenG. DesignG. UWG. PatG GebrMG. UrhG-Bezuege. Markenanmeldung DPMA EUIPO. UWG-Abmahnung §§ 8 ff. UWG. Designverletzung. Einstweilige Verfuegung Verletzungsklage Lizenzanaloger Schadensersatz.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-handels-gesellschaftsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-handels-gesellschaftsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-handels-gesellschaftsrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Handels- und Gesellschaftsrecht nach FAO § 14i. HGB. AktG. GmbHG. PartGG. UmwG. Geschaeftsfuehrerhaftung §§ 43 GmbHG 93 AktG. Gesellschafterstreit Beschlussanfechtung. Handelsvertreterausgleich § 89b HGB. MoPeG GbR seit 2024. Schnittstellen kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-insolvenz-sanierungsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-insolvenz-sanierungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-insolvenz-sanierungsrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Insolvenz- und Sanierungsrecht nach FAO § 14. InsO Eroeffnung Antragspflicht § 15a Glaeubigerantrag § 14 InsO. StaRUG Restrukturierungsplan. Insolvenzanfechtung §§ 129 ff. InsO. Schnittstellen insolvenzrecht und steuerrecht-kanzlei.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-internationales-wirtschaftsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-internationales-wirtschaftsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-internationales-wirtschaftsrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Internationales Wirtschaftsrecht. CISG Bruessel Ia Rom I Rom II Schiedsverfahren ICC UNCITRAL Investitionsschutz ICSID WTO EU-Aussenhandel LkSG. Schnittstelle Plugin kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-it-recht/.claude-plugin/plugin.json
+++ b/fachanwalt-it-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-it-recht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Informationstechnologierecht. SaaS Software-Lizenz DSGVO BDSG TTDSG TKG NIS2 DDG DSA DMA EU-KI-VO Open-Source. Schnittstellen Plugin datenschutzrecht ki-governance kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-medizinrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-medizinrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-medizinrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Medizinrecht. Arzthaftung §§ 630a ff. BGB Patientenrechte Vertragsarztrecht Berufsrecht Aerzte SGB V Krankenversicherung MPDG Apothekenrecht. Schnittstellen Plugin sozialrecht-kanzlei kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-miet-wohnungseigentumsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-miet-wohnungseigentumsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-miet-wohnungseigentumsrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Miet- und Wohnungseigentumsrecht nach FAO § 14e. BGB §§ 535 ff. Wohnraummiete und Gewerberaummiete. Mieterhoehung §§ 558 ff. Kuendigung §§ 543 569 573 BGB. WEG-Beschlussanfechtung § 44 WEG. BetrKV. Schnittstellen kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-migrationsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-migrationsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-migrationsrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt für Migrationsrecht. AufenthG AsylG GFK Dublin-VO Verfahrens-RL Qualifikations-RL StAG. Einbürgerung Familiennachzug Notfrist § 36 AsylG eine Woche. Schnittstellen Plugin rechtsberatungsstelle.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-sozialrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-sozialrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-sozialrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Sozialrecht nach FAO § 11. SGB I bis XII Sozialgerichtsbarkeit SGG. Widerspruch § 84 SGG Frist ein Monat. Klage Sozialgericht § 87 SGG. Erwerbsminderungsrente. SGB II Buergergeld Bescheid. Schnittstellen sozialrecht-kanzlei und kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-sportrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-sportrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-sportrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt für Sportrecht. Verbandsrecht (DFB FIFA UEFA IOC DOSB) CAS Schiedsverfahren Spielerverträge Doping WADA-Code NADA Sponsoring Persönlichkeitsrechte Veranstalterhaftung. Schnittstelle Plugin gesellschaftsrecht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-steuerrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-steuerrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-steuerrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Steuerrecht nach FAO § 9. AO Einspruch Stundung Vollstreckungsaufschub. Aussenpruefung Schlussbesprechung. Steuerstrafrecht Selbstanzeige § 371 AO. Schnittstellen steuerrecht-kanzlei und kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-strafrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-strafrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-strafrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Strafrecht. Orientierung StPO StGB Nebenstrafrecht. Strafverteidigung Ermittlungsverfahren Hauptverhandlung Berufung Revision Verfassungsbeschwerde. Ergaenzt aktenaufbereiter-strafrecht und kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-transport-speditionsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-transport-speditionsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-transport-speditionsrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Transport- und Speditionsrecht. HGB §§ 407 ff. Frachtvertrag §§ 453 ff. Spedition CMR COTIF Montrealer Uebereinkommen Haager Visby Regeln ADSp. Schnittstelle Plugin kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-urheber-medienrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-urheber-medienrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-urheber-medienrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Urheber- und Medienrecht. UrhG UWG KUG Recht am eigenen Bild Presserecht Persoenlichkeitsrecht Medienstaatsvertrag. Schnittstellen Plugin gewerblicher-rechtsschutz verlagsredaktion kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-vergaberecht/.claude-plugin/plugin.json
+++ b/fachanwalt-vergaberecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-vergaberecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Vergaberecht. GWB §§ 97 ff. VgV UVgO SektVO KonzVgV VOB-A. EU-Vergabe-RL. Nachpruefungsverfahren Vergabekammer und OLG-Vergabesenat. Schnittstelle Plugin fachanwalt-bau-architektenrecht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-verkehrsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-verkehrsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-verkehrsrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Verkehrsrecht. StVG StVO PflVG VVG-Bezuege. Verkehrsunfall Personen- und Sachschaden Bussgeld Fahrerlaubnis Verkehrsstrafrecht (§§ 315c 316 StGB). Schnittstelle Plugin kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-versicherungsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-versicherungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-versicherungsrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Versicherungsrecht. VVG VAG Berufsunfaehigkeit private Krankenversicherung Lebens- und Rentenversicherung Sachversicherung Haftpflicht D-und-O. Schnittstelle Plugin kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-verwaltungsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-verwaltungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-verwaltungsrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Light-Touch-Plugin Fachanwalt für Verwaltungsrecht. VwGO VwVfG. Anfechtungs- und Verpflichtungsklage Eilrechtsschutz § 80 Abs 5 VwGO einstweilige Anordnung Normenkontrolle Polizei- und Ordnungsrecht. Schnittstelle Plugin kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fluggastrechte/.claude-plugin/plugin.json
+++ b/fluggastrechte/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fluggastrechte",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Fluggastrechte selber geltend machen — VO (EG) Nr. 261/2004 plus EuGH-Rspr. Tickets erfassen Annullierung vs Verspaetung pruefen aussergewoehnliche Umstaende Distanz und Ausgleich Forderungsschreiben Mahnung Klage Amtsgericht. Vollmacht Familie. Katalog Airline-Standardausreden.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/forderungsmanagement-klagewerkstatt/.claude-plugin/plugin.json
+++ b/forderungsmanagement-klagewerkstatt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forderungsmanagement-klagewerkstatt",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Klagewerkstatt für Forderungsmanagement mit Zuständigkeitsprüfung, Mahnvorlauf, Inkasso-Zahlungsklage und Anspruchs-Gatekeeper: Nur klare, fällige und belegte Forderungen werden zur Klage freigegeben.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fortbestehensprognose/.claude-plugin/plugin.json
+++ b/fortbestehensprognose/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fortbestehensprognose",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Fortbestehensprognose § 19 Abs. 2 InsO als Geschaeftsfuehrer-Selbstdokumentation. Bilanzstatus Annahmen Plausibilisierung Zwoelf-Monats-Liquiditaet. Sanierungsbausteine Patronatserklaerung Comfortletter Rangruecktritt Stundung Forderungsverzicht. IDW S 11 StaRUG. Eskalation bei negativer Prognose.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/geldwaeschepraevention-aml-kyc/.claude-plugin/plugin.json
+++ b/geldwaeschepraevention-aml-kyc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "geldwaeschepraevention-aml-kyc",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Freistehendes Plugin für Geldwäscheprävention, AML, KYC, GwG-Risikoanalyse, UBO, PEP, Sanktionen, FIU/goAML, Transparenzregister und Behördenverfahren.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gesellschaftsgruender/.claude-plugin/plugin.json
+++ b/gesellschaftsgruender/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gesellschaftsgruender",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Gruendungsassistent deutsche Gesellschaften (GmbH UG GbR OHG KG GmbH und Co KG PartG mbB gGmbH). Von Rechtsformwahl ueber Gesellschaftsvertrag und Geschaeftsfuehrervertrag bis Notar Handelsregister Gewerbeamt Finanzamt Transparenzregister. MoPeG DiRUG GwG. Kein Ersatz fuer Anwaltsberatung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gesellschaftsrecht/.claude-plugin/plugin.json
+++ b/gesellschaftsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gesellschaftsrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Gesellschaftsrecht – GmbH/AG/Personengesellschaften, M&A-Due-Diligence ohne Discovery (Q&A + Datenraum), Gesellschafterbeschlüsse, HRB/HRA-Anmeldungen, Closing Checklists, Compliance-Fristen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gewerblicher-rechtsschutz/.claude-plugin/plugin.json
+++ b/gewerblicher-rechtsschutz/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gewerblicher-rechtsschutz",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Gewerblicher Rechtsschutz – DPMA/EUIPO-Markenrecherche und -anmeldung, Freedom-to-Operate, Patentscreening, UWG- und Urheberrechts-Abmahnung (Versand und Reaktion), Open-Source-Compliance, IP-Klausel-Review, Schutzrechts-Fristen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/grosskanzlei-corporate-ma/.claude-plugin/plugin.json
+++ b/grosskanzlei-corporate-ma/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "grosskanzlei-corporate-ma",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Freistehendes Big-Law-Corporate/M&A-Plugin: Deal-Kommandocenter, Aktenanlage, Datenraum, Legal DD, Tabellenreview, Liquiditätsvorschau, SPA/APA, W&I, Public M&A, Umwandlung, StaRUG/Insolvenzplan, CP-Kalender, E-Rechnung/GoBD, PMI.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/hausarbeitenmacher/.claude-plugin/plugin.json
+++ b/hausarbeitenmacher/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hausarbeitenmacher",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Didaktisches Plugin fuer juristische Hausarbeiten und Seminararbeiten. Fuehrt sokratisch durch Zivilrecht oeffentliches Recht Strafrecht mit Ausfluegen in Europarecht und Rechtstheorie. Adressaten-Strategie ohne Schleimerei. Liefert keine fertigen Loesungen sondern fuehrt zur eigenen Subsumtion.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/immobilienrechtspraxis/.claude-plugin/plugin.json
+++ b/immobilienrechtspraxis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "immobilienrechtspraxis",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Werkzeuge fuer immobilienrechtliche Rechtsabteilungen: musterbasierte Vertragserstellung mit Klauselschutz; Vertragspruefung gegen Playbook; Grundbuchanalyse; Sachverhaltsermittlung; Mieteranfragen mit BGH-Verankerung; Case Management; projektbasierte Arbeitsweise mit AVV-Pruefung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/insolvenzforderungsanmeldungspruefung/.claude-plugin/plugin.json
+++ b/insolvenzforderungsanmeldungspruefung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insolvenzforderungsanmeldungspruefung",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Freistehendes Plugin für die Insolvenzforderungsanmeldungsprüfung: Intake, § 174 InsO, Belege, Grund, Betrag, Rang, vbuH, Nachforderungen, Tabellenimport, Prüfungstermin, Bestreiten, Feststellung, Tabellenauszug und Verteilung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/insolvenzplan-starug-planwerkstatt/.claude-plugin/plugin.json
+++ b/insolvenzplan-starug-planwerkstatt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insolvenzplan-starug-planwerkstatt",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Freistehendes Plugin für Insolvenzplan und StaRUG-Restrukturierungsplan: Intake, Sanierungskonzept, Vergleichsrechnung, Gruppen, Klassen, darstellender und gestaltender Teil, Anlagen, Abstimmung, Cram-down, Minderheitenschutz, Gericht und Planvollzug.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/insolvenzrecht/.claude-plugin/plugin.json
+++ b/insolvenzrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insolvenzrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Insolvenzrechtliche Skills zu Zahlungsunfähigkeit, Überschuldung, Antragspflicht und Gläubigerantrag.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/insolvenzverwaltung/.claude-plugin/plugin.json
+++ b/insolvenzverwaltung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insolvenzverwaltung",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Freistehendes Insolvenzverwaltungs-Plugin aus Sicht von Insolvenzverwalter, Sachwalter und vorläufiger Verwaltung: Regelverfahren, Eigenverwaltung, Schutzschirm, Anfechtung, § 15b InsO, Masse, Forderungsprüfung, Insolvenzplan, StaRUG-Planwerkstatt, Gutachten, Berichte und Schlussrechnung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/jurastudium/.claude-plugin/plugin.json
+++ b/jurastudium/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jurastudium",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Studium und Referendariat – Prüfungsgespräch nach AG-Tradition, Subsumtionslehre, Methodenlehre (Zivilrecht, Strafrecht, Öffentliches Recht), Rechtsgeschichte, Lernstrategien, Lösungsschemata, Gutachtenstil, Klausurkorrektur, Lernplanung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/jveg-kostenpruefer/.claude-plugin/plugin.json
+++ b/jveg-kostenpruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jveg-kostenpruefer",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Freistehender JVEG-Kostenprüfer für Zeugenentschädigung, Vorschuss, Fahrtkosten, Übernachtung, Verdienstausfall, Sachverständigen- und Dolmetscherkosten, Fristen, Festsetzung, Beschwerde und belegfeste Rechenprotokolle.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kanzlei-allgemein/.claude-plugin/plugin.json
+++ b/kanzlei-allgemein/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanzlei-allgemein",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Kanzlei-Allgemein-Plugin: edles Cowork-Kommandocenter, Mandatsannahme/GwG, Klage/Replik, Vertrag, Rechtsprechung, Handelsregister, beA, Rechnung, UStVA.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kanzlei-builder-hub/.claude-plugin/plugin.json
+++ b/kanzlei-builder-hub/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanzlei-builder-hub",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Findet, prüft und installiert Community-Skills mit Security-Review-Gate vor dem Deployment in die Kanzleiumgebung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kanzlei-cowork/.claude-plugin/plugin.json
+++ b/kanzlei-cowork/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanzlei-cowork",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Cowork-Assistent fuer die deutsche Anwaltskanzlei. Fristenbuch Timesheet RVG-Rechnung Versand-Vor-Check (PDF beA Signatur) beA-Versand Postein- und ausgang Mandantenakte Aktenbestand Honorar-Mahnwesen Mandantenbriefe Geburtstage Weihnachtskarten Tagesbrief. Rechtsgebietsunabhaengig.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kartellrecht-marktabgrenzung-pruefung/.claude-plugin/plugin.json
+++ b/kartellrecht-marktabgrenzung-pruefung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kartellrecht-marktabgrenzung-pruefung",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Kritische kartellrechtliche Pruefinstanz fuer vorgelegte Marktabgrenzungen nach Paragraf 18 GWB und Art 101 und 102 AEUV. SSNIP-Test Nachfrage- und Angebotsumstellung raeumlicher Markt Evidenzbasierung Konsistenzcheck EuGH-Leitentscheidungen Red Flags alternative Marktdefinitionen Marktbeherrschung.",
   "author": {
     "name": "Klotzkette"

--- a/ki-governance/.claude-plugin/plugin.json
+++ b/ki-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ki-governance",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "EU-KI-VO + DSGVO – Use-Case-Triage, KI-Inventar, AIA/DPIA, Vendor-Review, Drift-Monitoring der KI-Richtlinie.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/ki-richtlinie-kanzleien/.claude-plugin/plugin.json
+++ b/ki-richtlinie-kanzleien/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ki-richtlinie-kanzleien",
   "displayName": "KI-Richtlinie fuer Kanzleien und Rechtsabteilungen",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Erstellt und pflegt eine berufsrechtskonforme KI-Nutzungsrichtlinie fuer Kanzleien und Rechtsabteilungen mit Anwaelten und Syndikus-Anwaelten. Beruht auf BRAO, BORA, DSGVO, KI-Verordnung sowie BRAK- und DAV-Hinweisen.",
   "author": {
     "name": "Klotzkette"

--- a/ki-vo-ai-act-pruefer/.claude-plugin/plugin.json
+++ b/ki-vo-ai-act-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ki-vo-ai-act-pruefer",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Vollstaendiger Mechanik-Workflow zur Verordnung (EU) 2024/1689 (KI-VO): KI-System-Definition, Rollen, Risikoklassen, Hochrisiko-Pflichten, GPAI-Modelle, Sanktionen. Kein Rechtsrat.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/krisenfrueherkennung-starug/.claude-plugin/plugin.json
+++ b/krisenfrueherkennung-starug/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "krisenfrueherkennung-starug",
   "displayName": "Krisenfrüherkennung und StaRUG-Management",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Krisenfrüherkennung und Krisenmanagement nach StaRUG: Pflicht zum 24-Monats-Frühwarnsystem nach § 1 StaRUG, § 102 StaRUG Warnpflicht der Berater, Geschäftsführerhaftung, drohende Zahlungsunfähigkeit, integrierte Planung, Restrukturierungsplan und Stabilisierungsanordnung.",
   "author": {
     "name": "Klotzkette"

--- a/legistik-werkstatt/.claude-plugin/plugin.json
+++ b/legistik-werkstatt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legistik-werkstatt",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Legistik-Werkstatt fuer Bundes- und Landesministerien. Erstellt Referentenentwuerfe Kabinettsentwuerfe Formulierungshilfen Rechtsverordnungen Satzungen mit Begruendung Synopse Lesefassung XML. Pruefung Verfassungsrecht Europarecht Folgenabschaetzung Goldplating. DOCX im offiziellen HdR-Layout.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/liquiditaetsplanung/.claude-plugin/plugin.json
+++ b/liquiditaetsplanung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "liquiditaetsplanung",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Liquiditaetsplanung nach deutschem Recht: 3-Wochen-Vorschau mit BGH-Passiva-II- und 10-Prozent-Schema, 13/26/52-Wochen-Forecast, Excel-Export mit Quote/Luecken-Ampel, Padlet/JSON-Round-Trip, Integration mit Fortbestehensprognose. Krisen-GmbH, Bugwellenrechtsprechung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/mandantenanfragen-assistent/.claude-plugin/plugin.json
+++ b/mandantenanfragen-assistent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mandantenanfragen-assistent",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Assistent fuer Anwaltskanzleien zur Erstantwort auf Mandantenanfragen per E-Mail: dankt foermlich uebernimmt die Anrede aus der eingehenden E-Mail nennt die telefonische Terminvergabe bittet um Sachverhalt per E-Mail oder bietet eine Telefon-Transkription mit DSGVO-Einwilligungshinweis an.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/markenrecht-fashion-luxus/.claude-plugin/plugin.json
+++ b/markenrecht-fashion-luxus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markenrecht-fashion-luxus",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Markenrecht-Boutique fuer Luxus-Modehaeuser - DPMA/EUIPO Alicante/USPTO Lanham Act via NYC-Korrespondenz, alle Markenarten (Wort/Bild/Slogan/Sound/Duft/3D/Position/Haptik/Anti-KI), Widerspruch, Loeschung, Verletzung, Produktpiraterie, Selektivvertrieb.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/memorandums-ersteller/.claude-plugin/plugin.json
+++ b/memorandums-ersteller/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorandums-ersteller",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Wandelt Mandantenunterlagen in ein juristisches Memorandum mit Vier-Teile-Gliederung — Sachverhalt mit Quellenreferenz; Ein-Satz-Fragen; Ein-Satz-Antworten; rechtliche Ausfuehrungen mit Pinpoint-Zitierung. Optional Piercing-Questions. Rechtsgebietsneutral. Alias Memorandumsmacher.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/methodenlehre-buergerliches-recht/.claude-plugin/plugin.json
+++ b/methodenlehre-buergerliches-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "methodenlehre-buergerliches-recht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Methodenlehre und Rechtsanwendung im deutschen buergerlichen Recht aus Anwaltsperspektive. Gutachtenstil. Anspruchsgrundlagen-Reihenfolge. Auslegung Wortlaut System Historie Telos pragmatisch ohne starren Vorrang. Verfassungs- und unionsrechtskonforme Auslegung. Lueckenfuellung. Verjaehrung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/mietrecht/.claude-plugin/plugin.json
+++ b/mietrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mietrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Mietrecht fuer Mieter und Vermieter mit ausschliesslich amtlichen Mietspiegel-Quellen pro Bundesland und fuer Top- und Universitaetsstaedte. Datenerhebung Mieterhoehungs-Widerspruch Mietsenkungsverlangen Nebenkostenpruefung und Erstellung Mieteranfragen Klageentwurf zum Amtsgericht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/mittelstand-corporate-ma/.claude-plugin/plugin.json
+++ b/mittelstand-corporate-ma/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mittelstand-corporate-ma",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Freistehendes Mittelstandsmandat-Corporate/M&A-Plugin: Deal-Kommandocenter, Aktenanlage, Datenraum, Legal DD, Tabellenreview, Liquiditätsvorschau, SPA/APA, W&I, Public M&A, Umwandlung, StaRUG/Insolvenzplan, CP-Kalender, E-Rechnung/GoBD, PMI.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/nda-abgleich/.claude-plugin/plugin.json
+++ b/nda-abgleich/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nda-abgleich",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Gleicht NDA-Entwurf der Gegenseite gegen eigenen Standard ab und setzt Haltelinien chirurgisch im Word-Aenderungsmodus durch. Ampelmatrix ROT/GELB/GRUEN. Ausgabe .docx mit echten Tracked Changes. Keine Absatzloeschungen, keine Klausel-Neufassungen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/normenkontrolle-bauleitplanung/.claude-plugin/plugin.json
+++ b/normenkontrolle-bauleitplanung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "normenkontrolle-bauleitplanung",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Freistehendes Plugin für die Prüfung und Anfechtung von Bebauungsplänen, Flächennutzungsplänen und örtlichen Bauvorschriften nach § 47 VwGO vor BayVGH und OVG. Mandatsperspektive Antragstellervertretung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/patentrecherche/.claude-plugin/plugin.json
+++ b/patentrecherche/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "patentrecherche",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Patentrecherche fuer Patentanwaelte agentisch in Espacenet Google Patents DPMAregister DEPATISnet EPO Register WIPO USPTO. Stand der Technik Neuheit § 3 PatG Art. 54 EPUe erfinderische Taetigkeit § 4 PatG Art. 56 EPUe Problem-Solution-Approach FTO CPC IPC INPADOC Recherchebericht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/phishing-vorfall-pruefer/.claude-plugin/plugin.json
+++ b/phishing-vorfall-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "phishing-vorfall-pruefer",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Freistehender Phishing-Vorfall-Prüfer für Online-Banking: BGB § 675u, § 675v, § 675w, pushTAN, Call-ID-Spoofing, grobe Fahrlässigkeit, Beweislast, Bankpflichten, Schlichtung und Klage.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/produktrecht/.claude-plugin/plugin.json
+++ b/produktrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "produktrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Produktrechtliche Skills für Launch-Review, Impressumspflicht nach DDG und PAngV sowie UWG-Bewertungen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/prozessrecht/.claude-plugin/plugin.json
+++ b/prozessrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prozessrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Prozessrechtliche Skills für Mandate, Fristen, Mahnbescheid, Eilverfahren, Vollstreckung und Schriftsätze.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/rechtsberatungsstelle/.claude-plugin/plugin.json
+++ b/rechtsberatungsstelle/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rechtsberatungsstelle",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Pro-Bono- und Rechtsberatungsstellen (RDG-konform): Mandantenintake, Fristenkontrolle, Übergabe am Semesterende, mandantenfreundliche Briefe.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/regulatorisches-recht/.claude-plugin/plugin.json
+++ b/regulatorisches-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "regulatorisches-recht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Aufsichtsrecht – KWG, ZAG, WpHG, GwG, EnWG, TKG, HeilMWerbG, Umsatzsteuer-Voranmeldung, Inkasso/RDG, Regulator-Feeds, Wochendigest.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/schriftform-und-textform-bgb/.claude-plugin/plugin.json
+++ b/schriftform-und-textform-bgb/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "schriftform-und-textform-bgb",
   "displayName": "Schriftform und Textform im BGB",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Workflow-Organisator zu Formerfordernissen im deutschen Zivilrecht: Schriftform § 126 BGB qES § 126a Textform § 126b Zugang § 130 BGB lernt aus BGH I ZR 202/25 Maklervertrag und BGH VIII ZR 159/23 Mietkündigung Klauselgenerator Mandantenmemos.",
   "author": {
     "name": "Klotzkette"

--- a/sozialrecht-kanzlei/.claude-plugin/plugin.json
+++ b/sozialrecht-kanzlei/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sozialrecht-kanzlei",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Vollassistenz fuer die sozialrechtliche Kanzlei: Bescheidanalyse Widerspruch Klage zum Sozialgericht Eilantrag Akteneinsicht Anlagen. Spezialisiert auf Buergergeld SGB IX Schwerbehinderung Hilfsmittel (Rollstuhl Hoerhilfe Vorlesekraft) Eingliederungshilfe Schulbegleitung. Mit Fristenbuch und PKH.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/steuerberater-werkzeuge/.claude-plugin/plugin.json
+++ b/steuerberater-werkzeuge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "steuerberater-werkzeuge",
   "description": "Werkzeugbox für Steuerberater mit BWA-, SuSa- und Belegprüfung sowie Krisenfrüherkennung.",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "author": {
     "name": "Klotzkette"
   },

--- a/steuerrecht-kanzlei/.claude-plugin/plugin.json
+++ b/steuerrecht-kanzlei/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "steuerrecht-kanzlei",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Vollassistenz fuer die steueranwaltliche Kanzlei: Bescheidanalyse Einspruch AO Klage Finanzgericht FGO Aussetzung der Vollziehung Aussenpruefung Selbstanzeige Verbindliche Auskunft Akteneinsicht. Anwaltlich-streitbezogen statt Steuererklaerung. Mit Fristenbuch und PKH.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/strafbefehl-verteidiger/.claude-plugin/plugin.json
+++ b/strafbefehl-verteidiger/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "strafbefehl-verteidiger",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Freistehendes Strafbefehls-Plugin für Verteidigung gegen Strafbefehl, Einspruch, Akteneinsicht, Tagessätze, Nebenfolgen, Pflichtverteidigung, Wiedereinsetzung, Einstellung, Zeugenstrategie und Hauptverhandlung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/subsumtions-pruefer/.claude-plugin/plugin.json
+++ b/subsumtions-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "subsumtions-pruefer",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Interaktiver Subsumtions-Workflow fuer deutsches Recht und Europarecht: Tatbestandsmerkmale zerlegen, Vier-Schritt-Schema anwenden, Rechtsfolgen und Einreden pruefen. Keine Rechtsberatung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/tabellenreview-3d/.claude-plugin/plugin.json
+++ b/tabellenreview-3d/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tabellenreview-3d",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "3D-Tabellenreview als Wuerfel: Spaltenprompts pro Datenpunkt x Zeilenprompts pro Dokument x Arbeitsblatt-Perspektiven (Recht / Steuer / Wirtschaft) gestapelt. Massenpruefung Vertragsstapel M&A-DD Immobilien Vendor-Onboarding mit Excel-Mehrblatt Kreuzblatt-Konsistenz Audit-Trail Belegkette.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/umweltrecht/.claude-plugin/plugin.json
+++ b/umweltrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "umweltrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Freistehendes Umweltrecht-Plugin für BImSchG, TEHG, Abfall, Wasser, Boden, Naturschutz, UIG, Verfahren, Bußgeld, Umwelt-Due-Diligence, Klimaklagen UmwRG, Lieferkettensorgfalt LkSG/CSDDD und ESG-Greenwashing/CSRD.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/urteilsbauer-relationsmacher/.claude-plugin/plugin.json
+++ b/urteilsbauer-relationsmacher/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "urteilsbauer-relationsmacher",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Urteils- und Beschluss-Werkstatt fuer Amts- Land- und Familienrichter sowie Rechtspfleger. Aktenintake Relation Beweiswuerdigung mit Richter-Input Tatbestandsmerkmale Tenor Tatbestand Entscheidungsgruende Rechtsmittelbelehrung. Erzeugt DOCX nach Paragraf 313 ZPO.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verfassungsrecht/.claude-plugin/plugin.json
+++ b/verfassungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verfassungsrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Deutsches Verfassungsrecht unter dem Grundgesetz aus Sicht einer Spezialkanzlei. Rechtsprechungsgetrieben mit Live-Recherche auf bundesverfassungsgericht.de. Acht Skills für Gesetzgebungskompetenz formelle und materielle Verfassungsmäßigkeit Grundrechte und Verfassungsbeschwerde.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verkehr-infrastrukturrecht/.claude-plugin/plugin.json
+++ b/verkehr-infrastrukturrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verkehr-infrastrukturrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Freistehendes Verkehrs- und Infrastrukturrecht-Plugin für Verkehrsplanung, Planfeststellung, Straßenbahn, Ladeinfrastruktur, Parkraum und Verkehrswende.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verkehrsowi-verteidiger/.claude-plugin/plugin.json
+++ b/verkehrsowi-verteidiger/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verkehrsowi-verteidiger",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Freistehendes VerkehrsOWi-Plugin für Bußgeldbescheid, Anhörung, Einspruch, Punkte, Fahrverbot, Rotlicht, Geschwindigkeit, Abstand, Handy, Alkohol, Drogen, Akteneinsicht, Messakte, Zeugenstrategie und Amtsgericht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verlagsredaktion/.claude-plugin/plugin.json
+++ b/verlagsredaktion/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verlagsredaktion",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Verlegerischer Redaktionsassistent fuer juristische Verlage und Autoren. Macht aus disparaten Inputs ein Rohmanuskript fuer Aufsatz Kommentar oder Buchkapitel. Editionssystem ueberarbeitet umgliedert verdichtet erkennt Widersprueche. Hauszitierweise mit Pinpoint-Randnummer.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/vertragsausfueller/.claude-plugin/plugin.json
+++ b/vertragsausfueller/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vertragsausfueller",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Freistehendes Vertragsausfüller-Plugin: DOCX-Vorlagen und Altverträge strippen, Felder erkennen, Term Sheets mappen, Rückfragen führen, neue Verträge erzeugen und Track-Changes-Fassungen nur nach ausdrücklicher Nachfrage vorbereiten.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/vertragsrecht/.claude-plugin/plugin.json
+++ b/vertragsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vertragsrecht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Vertragsrecht – Lieferanten- und Vertriebsverträge, AGB §§ 305 ff. BGB, NDA, SaaS-/MSA-Review, Renewal-Tracking, Eskalations-Routing, Business-Zusammenfassungen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/wandeldarlehen-lebenszyklus/.claude-plugin/plugin.json
+++ b/wandeldarlehen-lebenszyklus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wandeldarlehen-lebenszyklus",
   "displayName": "Wandeldarlehen-Lebenszyklus (Erstellung bis Cap-Table)",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Begleitet den vollstaendigen Lebenszyklus eines Wandeldarlehens fuer GmbH und UG: Vertragserstellung (bilingual/einsprachig), Beurkundungspruefung, Wandelereignisse, Wandlungsberechnung, Cap-Table-Update, Gesellschafterbeschluss und Notar-Paket.",
   "author": {
     "name": "Klotzkette"

--- a/zitierweise-deutsches-recht/.claude-plugin/plugin.json
+++ b/zitierweise-deutsches-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zitierweise-deutsches-recht",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Deutsche juristische Zitierweise v3.0. Rspr. mit Az.-Marker Datum Aktenzeichen Fundstelle Rn. Kommentar mit Bearbeiter Werk Auflage Jahr Rn. Verlag bei Monographien. Diss. Habil. mit Hochschulort. Reihenfolge erst Gerichtshierarchie dann Zeit oder Relevanz. Palandt heißt seit 2022 Grüneberg.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/zwangsverwaltung-zvg/.claude-plugin/plugin.json
+++ b/zwangsverwaltung-zvg/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zwangsverwaltung-zvg",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Freistehendes ZVG-Plugin für Zwangsverwaltung und Versteigerung: Beschlagnahme, Besitz, Mieten, Treuhandkonto, Berichte, Verteilung, ZVG-Portal-Recherche, Bieterangebote und Versteigerungsteilnahme.",
   "license": "Apache-2.0 OR MIT",
   "author": {


### PR DESCRIPTION
## Major-Bump v7.0.0 — Reform-Stand 2026

### Versions-Update
- **298 plugin.json/marketplace.json**-Versionsfelder von 6.0.0/6.1.0 → 7.0.0
- README, INSTALLATION_EINFACH, ASSET_INDEX angepasst

### Inhaltliche Major-Updates seit v6.3.0

| PR | Bereich | Inhalt |
|---|---|---|
| #50 | README | Plugin- und Skill-Sammlung; Beck-Verweise entfernt |
| #52 | repo-weit | ae/oe/ue/ss-Transliterationen in SKILL.md-Bodies |
| #53 | README | Testakten-Hinweis prominent im Überblick |
| #54 | inso/anfechtungsrecht | `kongruent` (lat. congruens) — Terminologie wiederhergestellt |
| #51/#57 | liquiditaetsplanung | openpyxl-Dependency komplett entfernt; Stdlib-XLSX-Writer mit DXF-Solid-Fills |
| #58 | wandeldarlehen | Reform-Stand 05/2026 (DiRUG, SanInsFoG, PostModG, GesLV) |
| #59 | juristisch | `§ DSGVO` → `Art. DSGVO` bzw. `§ BDSG` (Stress-Sweep) |
| #60 | steuerrecht + wandeldarlehen | WtcG-Gebühren, eRechnung-Pflicht 1.1.2025, § 153 AO; Selbstanzeige-Dublette entfernt; Codex-Fix § 57 II GmbHG |

### Checks
- ✅ Validator OK
- ✅ Alle 298 Versionsfelder einheitlich auf 7.0.0
- ✅ Keine v6.3-Resttreffer (historische "neu in v6.0.0"-Verweise bleiben)
