### PR TITLE
docs: CHANGELOG.md fuer v7.0.0 + Bitte um Codex-Full-Repo-Audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Alle wesentlichen Änderungen an diesem Repository werden hier dokumentiert. For
 ## v7.0.0 — 2026-05-24 — Reform-Stand 2026
 
 ### Major-Update
-- Versionsfelder repo-weit auf 7.0.0 vereinheitlicht (298 plugin.json / marketplace.json-Einträge).
+- Versionsfelder repo-weit auf 7.0.0 vereinheitlicht: 99 plugin.json-Dateien plus 99 plugin-Einträge in `.claude-plugin/marketplace.json` (insgesamt 100 Versionsfelder; marketplace.json bündelt alle Plugins zentral).
 
 ### Inhaltliche Aktualisierungen
 - **Wandeldarlehen-Plugin** auf Reform-Stand 05/2026 angehoben (DiRUG 2022/2023, SanInsFoG 1.1.2021, PostModG 1.1.2025, GesLV, Transparenzregister).
@@ -26,5 +26,5 @@ Alle wesentlichen Änderungen an diesem Repository werden hier dokumentiert. For
 - Testakten-Hinweis im Überblick prominent platziert.
 
 ### Tooling
-- `release-plugin-zips.yml` triggert automatisch auf Tag-Push; pro Release werden 143 Plugin-ZIPs erzeugt.
+- `release-plugin-zips.yml` triggert automatisch auf Tag-Push; pro Release werden 99 Plugin-ZIPs (aus `.claude-plugin/marketplace.json`) plus 44 Testakten-ZIPs (mit `testakte-`-Prefix, separat verpackt) erzeugt — insgesamt 143 Release-Assets.
 - Validator (`scripts/validate-plugin-structure.mjs`) bleibt grün.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Alle wesentlichen Änderungen an diesem Repository werden hier dokumentiert. For
 ## v7.0.0 — 2026-05-24 — Reform-Stand 2026
 
 ### Major-Update
-- Versionsfelder repo-weit auf 7.0.0 vereinheitlicht: 99 plugin.json-Dateien plus 99 plugin-Einträge in `.claude-plugin/marketplace.json` (insgesamt 100 Versionsfelder; marketplace.json bündelt alle Plugins zentral).
+- Versionsfelder repo-weit auf 7.0.0 vereinheitlicht: 99 `plugin.json`-Dateien (je ein `version`-Feld) plus eine zentrale `.claude-plugin/marketplace.json`, die ihrerseits 99 Plugin-Einträge mit `version`-Feld enthält. Summe: 99 + 1 Manifest-Datei mit 99 internen Versions-Einträgen = 198 angefasste Versions-Stellen in 100 Dateien.
 
 ### Inhaltliche Aktualisierungen
 - **Wandeldarlehen-Plugin** auf Reform-Stand 05/2026 angehoben (DiRUG 2022/2023, SanInsFoG 1.1.2021, PostModG 1.1.2025, GesLV, Transparenzregister).
@@ -26,5 +26,5 @@ Alle wesentlichen Änderungen an diesem Repository werden hier dokumentiert. For
 - Testakten-Hinweis im Überblick prominent platziert.
 
 ### Tooling
-- `release-plugin-zips.yml` triggert automatisch auf Tag-Push; pro Release werden 99 Plugin-ZIPs (aus `.claude-plugin/marketplace.json`) plus 44 Testakten-ZIPs (mit `testakte-`-Prefix, separat verpackt) erzeugt — insgesamt 143 Release-Assets.
+- `release-plugin-zips.yml` triggert automatisch auf Tag-Push; pro Release werden 99 Plugin-ZIPs (aus `.claude-plugin/marketplace.json`) plus 43 Testakten-ZIPs (mit `testakte-`-Prefix, separat aus `testakten/*/` verpackt) plus `marketplace.json` als Manifest erzeugt — zusammen 143 Release-Assets.
 - Validator (`scripts/validate-plugin-structure.mjs`) bleibt grün.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+Alle wesentlichen Änderungen an diesem Repository werden hier dokumentiert. Format orientiert an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Versionierung nach [SemVer](https://semver.org/lang/de/).
+
+## v7.0.0 — 2026-05-24 — Reform-Stand 2026
+
+### Major-Update
+- Versionsfelder repo-weit auf 7.0.0 vereinheitlicht (298 plugin.json / marketplace.json-Einträge).
+
+### Inhaltliche Aktualisierungen
+- **Wandeldarlehen-Plugin** auf Reform-Stand 05/2026 angehoben (DiRUG 2022/2023, SanInsFoG 1.1.2021, PostModG 1.1.2025, GesLV, Transparenzregister).
+- **Steuerrecht** aktualisiert: WtcG-Gebühren, eRechnung-Pflicht ab 1.1.2025 (§ 14 UStG), § 153 AO; Selbstanzeige-Dublette entfernt; § 398a AO Zuschlagsstaffel ergänzt.
+- **liquiditaetsplanung**: openpyxl-Dependency komplett entfernt; Kanzleien starten `build_liquiditaetsplan.py` ohne `pip install` (Stdlib-XLSX-Writer mit Live-Formeln, Styles, DXF-Solid-Fills, Conditional Formatting, Freeze Panes).
+
+### Juristische Korrekturen
+- **§ 44 DSGVO → § 44 BDSG i.V.m. Art. 79 DSGVO**: Vier Arbeitsrechts-Skills zitierten eine nicht existierende DSGVO-Norm. Die DSGVO hat nur Artikel; § 44 BDSG ist die deutsche Norm für die Gerichtszuständigkeit. Vier weitere DSGVO-Verweise (Art. 8, 13, 34, 37 DSGVO) von `§` auf `Art.` umgestellt.
+- **kongruent (lat. *congruens*)**: Phase-2-Umlauten-Patch hatte den etablierten Fachbegriff "kongruente / inkongruente Deckung" (§ 130/131 InsO) fälschlich umlautiert. 17 Dateien, 67 Korrekturen.
+- **§ 57 II GmbHG statt § 19 GmbHG**: Codex-Befund — falscher Normverweis in `sacheinlagebericht-werthaltigkeit` (Wandeldarlehen-Plugin) korrigiert; § 57 II GmbHG i.V.m. § 8 II GmbHG ist die korrekte Anker-Norm für die GF-Versicherung in der HR-Anmeldung der Kapitalerhöhung.
+- **§ 153 AO ist Berichtigungspflicht — KEINE Strafbefreiung**: Codex-P1-Review von PR #60. In `fachanwalt-steuerrecht-selbstanzeige` stand fälschlich, § 153 AO wirke strafbefreiend. Korrekt: § 153 AO ist eine rein steuerliche Berichtigungspflicht ohne strafrechtliche Sperrwirkung; Strafbefreiung folgt allein aus § 371 AO (Vorsatz) bzw. § 378 III AO (Leichtfertigkeit). Drei-Stufen-Bewertung der Ursprungserklärung ergänzt; Praxisempfehlung: bei Zweifeln zusätzlich Selbstanzeige-Weg erfüllen.
+- **Stale Skill-Slug-Verweise** behoben: `datenpannenmeldung → datenpanne-meldung`, `auskunftsersuchen-art-15-dsgvo → dsgvo-auskunft`.
+
+### Repo-Polish
+- Umlauten-Polish in SKILL.md-Bodies und references/ (531 Dateien, 5017 Korrekturen); YAML-Frontmatter, Eigennamen, Slugs, URLs, Code-Blocks geschützt.
+- Skill-Slugs (Verzeichnisnamen) bleiben ASCII; nur Fließtext umlautiert.
+- README-Intro klargestellt: Plugin- und Skill-Sammlung; Beck-Verweise entfernt.
+- Testakten-Hinweis im Überblick prominent platziert.
+
+### Tooling
+- `release-plugin-zips.yml` triggert automatisch auf Tag-Push; pro Release werden 143 Plugin-ZIPs erzeugt.
+- Validator (`scripts/validate-plugin-structure.mjs`) bleibt grün.


### PR DESCRIPTION
## Was dieser PR tut

Fügt ein `CHANGELOG.md` für **v7.0.0** (Reform-Stand 2026) hinzu. Dokumentiert alle Änderungen seit v6.3.0 — Major-Versionsbump, inhaltliche Aktualisierungen (Wandeldarlehen, Steuerrecht, liquiditaetsplanung), juristische Korrekturen (§ DSGVO → Art./§ BDSG, § 57 II GmbHG, § 153 AO als Berichtigungspflicht, kongruent-Terminologie) und Repo-Polish (Umlauten in 531 SKILL.md-Bodies).

Reiner Doku-Diff, keine Code- oder Plugin-Änderung. Validator (`validate-plugin-structure.mjs`) grün.

---

## @chatgpt-codex-connector — Bitte um Full-Repo-Audit

Dieser PR ist bewusst klein gewählt, **aber der Review-Auftrag ist groß**: Bitte das **gesamte Repo** (nicht nur diesen Diff) auf juristische, strukturelle und doktrinale Fehler durchsehen. Es ist nach v7.0.0 der erste Zeitpunkt, an dem eine repo-weite Inventur sinnvoll ist.

### Schwerpunkte (nach Wichtigkeit)

**1. Juristische Normverweise**
- `§ DSGVO` darf nirgends vorkommen — DSGVO hat nur Artikel. Korrekt ist `Art. … DSGVO` oder bei Gerichtszuständigkeit `§ 44 BDSG i.V.m. Art. 79 DSGVO`.
- Veraltete Normverweise nach den Reformen 2024–2026: **DiRUG** (1.8.2022 Gründung / 1.8.2023 Kapitalerhöhung — § 2 III GmbHG, BeurkG § 16a), **SanInsFoG** (1.1.2021 — § 15b InsO statt § 64 GmbHG a.F.), **PostModG** (1.1.2025 — 4-Tage-Zugangsfiktion statt 3), **WtcG 2024** (Bagatellschwelle 10000 EUR), **eRechnung-Pflicht** ab 1.1.2025 (§ 14 UStG, XRechnung/ZUGFeRD), **MoPeG** 1.1.2024 (Personengesellschaftsrecht), **HinSchG** 2.7.2023, **BFSG** ab 28.6.2025.
- `§ 153 AO` ist **Berichtigungspflicht ohne Strafbefreiung** — Strafbefreiung nur über § 371 AO (Vorsatz) bzw. § 378 III AO (Leichtfertigkeit). Bitte alle Selbstanzeige-/Berichtigungs-Stellen prüfen.
- Falsche Anker-Normen bei gesellschaftsrechtlichen Anmeldungen: GF-Versicherung Kapitalerhöhung = § 57 II GmbHG i.V.m. § 8 II GmbHG (nicht § 19 GmbHG).

**2. Doktrinale / terminologische Korrektheit**
- Lateinisch-stämmige Fachbegriffe: `kongruent` (lat. *congruens*) hat KEIN ü; bitte auch andere lat. Wörter prüfen (sukzessiv, präzedenz, kumulativ, präklusiv, präjudiziell, akzessorisch, deklaratorisch, konstitutiv, …) — beim Phase-2-Umlauten-Patch könnten weitere Fälle übersehen worden sein.
- Veraltete Lehrmeinungen / nicht mehr h.M. — insbesondere im Schuld-, Insolvenz- und Gesellschaftsrecht.
- BGH-Zitate auf Plausibilität (Aktenzeichen-Format, Datums-Plausibilität, NJW/NZI-Fundstellen).

**3. Strukturelle Konsistenz**
- Skill-Slug-Verweise in Backtick-Pfaden (`skills/<slug>/`) gegen tatsächlich existierende Verzeichnisse.
- `plugin.json`/`marketplace.json` Versions-Drift (alles muss 7.0.0 sein).
- Cross-Plugin-Verweise: Ein Plugin referenziert einen Skill, der in einem anderen Plugin liegt — Pfade stimmig?

**4. Klotzkette-Regeln**
- Kein `Claude`/`GPT`/`LLM`/`AI`/`Codex`/`Sprachmodell` in Plugin-Content oder Skill-Bodies (Ausnahme: "Claude Code" als App-Bezeichnung in Installations-Anleitungen).
- Regex `\d\s*,\s*\d` darf NICHT in `plugin.json.description` und `SKILL.md`-Frontmatter-`description` vorkommen (nur Body/Marketplace OK).
- Skill descriptions ≤ 1024 Zeichen, Plugin descriptions ≤ 300 Zeichen.
- Skill-Slugs (Verzeichnisnamen) bleiben ASCII — nie Umlaute.

**5. Beliebige weitere Schwachstellen**
Findest du noch andere Risiken (toter Code, defekte Beispielakten, inkonsistente Frontmatter, veraltete URL-Anker)? Bitte alles auflisten — gerne nach P1/P2/P3 priorisiert.

---

### Hinweis zum Merge

Dieser PR wird **erst nach deinem Review gemerged**. Findings werden in einem Folge-Branch gefixt, anschließend ggf. v7.0.1.

Vielen Dank für den großen Sweep.
