### PR TITLE
release: v7.1.0 — Steuer-Plugin-Konsolidierung + ELSTER-Klarstellung

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,13 +13,13 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "aktenauszug-gerichtsverfahren",
       "source": "./aktenauszug-gerichtsverfahren",
       "description": "Strukturierter Aktenauszug fuer deutsche Gerichtsverfahren: Verfahrensidentifikation Einleitungssatz Verfahrenszusammenfassung Sachverhaltschronologie Verfahrensgeschichte tabellarische Gegenueberstellung der Parteivortraege Beweismittel und Rechtsargumente fuer schnelle Einarbeitung in Akten.",
-      "version": "7.0.0",
+      "version": "7.1.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -31,7 +31,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "arbeitsrecht",
@@ -40,7 +40,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "arbeitszeugnis-analyse",
@@ -49,7 +49,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "aussenwirtschaft-zoll-sanktionen",
@@ -58,7 +58,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "bav-strategie-konzern",
@@ -67,7 +67,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "bereicherungs-und-anfechtungsrecht-pruefer",
@@ -76,7 +76,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "berufsrecht-ki-vertragspruefung",
@@ -85,7 +85,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "betreuungsrecht",
@@ -94,7 +94,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "common-law-kompass",
@@ -103,7 +103,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "corporate-kanzlei",
@@ -112,7 +112,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "datenschutzrecht",
@@ -121,7 +121,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "einfache-leichte-sprache-jura",
@@ -130,7 +130,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "email-umformulierer-berufsrecht",
@@ -139,7 +139,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "energierecht",
@@ -148,7 +148,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "europarecht-kompass",
@@ -157,7 +157,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-agrarrecht",
@@ -166,7 +166,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-arbeitsrecht",
@@ -175,7 +175,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-bank-kapitalmarktrecht",
@@ -184,7 +184,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-bau-architektenrecht",
@@ -193,7 +193,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-erbrecht",
@@ -202,7 +202,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-familienrecht",
@@ -211,7 +211,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-gewerblicher-rechtsschutz",
@@ -220,7 +220,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-handels-gesellschaftsrecht",
@@ -229,7 +229,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-insolvenz-sanierungsrecht",
@@ -238,7 +238,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-internationales-wirtschaftsrecht",
@@ -247,7 +247,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-it-recht",
@@ -256,7 +256,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-medizinrecht",
@@ -265,7 +265,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-miet-wohnungseigentumsrecht",
@@ -274,7 +274,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-migrationsrecht",
@@ -283,7 +283,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-sozialrecht",
@@ -292,7 +292,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-sportrecht",
@@ -301,7 +301,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-strafrecht",
@@ -310,7 +310,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-transport-speditionsrecht",
@@ -319,7 +319,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-urheber-medienrecht",
@@ -328,7 +328,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-vergaberecht",
@@ -337,7 +337,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-verkehrsrecht",
@@ -346,7 +346,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-versicherungsrecht",
@@ -355,7 +355,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fachanwalt-verwaltungsrecht",
@@ -364,7 +364,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fluggastrechte",
@@ -373,7 +373,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "forderungsmanagement-klagewerkstatt",
@@ -382,7 +382,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "fortbestehensprognose",
@@ -391,7 +391,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "geldwaeschepraevention-aml-kyc",
@@ -400,7 +400,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "gesellschaftsgruender",
@@ -409,7 +409,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "gesellschaftsrecht",
@@ -418,7 +418,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "gewerblicher-rechtsschutz",
@@ -427,7 +427,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "grosskanzlei-corporate-ma",
@@ -436,7 +436,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "hausarbeitenmacher",
@@ -445,7 +445,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "immobilienrechtspraxis",
@@ -454,7 +454,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "insolvenzforderungsanmeldungspruefung",
@@ -463,7 +463,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "insolvenzplan-starug-planwerkstatt",
@@ -472,7 +472,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "insolvenzrecht",
@@ -481,7 +481,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "insolvenzverwaltung",
@@ -490,7 +490,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "jurastudium",
@@ -499,7 +499,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "jveg-kostenpruefer",
@@ -508,7 +508,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "kanzlei-allgemein",
@@ -517,7 +517,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "kanzlei-builder-hub",
@@ -526,7 +526,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "kanzlei-cowork",
@@ -535,12 +535,12 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "kartellrecht-marktabgrenzung-pruefung",
       "source": "./kartellrecht-marktabgrenzung-pruefung",
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "ki-governance",
@@ -549,7 +549,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "ki-richtlinie-kanzleien",
@@ -558,7 +558,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "ki-vo-ai-act-pruefer",
@@ -567,7 +567,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "krisenfrueherkennung-starug",
@@ -576,14 +576,14 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "legistik-werkstatt",
       "source": "./legistik-werkstatt",
       "description": "Legistik-Werkstatt fuer Bundes- und Landesministerien. Vom politischen Auftrag ueber Normhierarchie Kompetenzpruefung Normenkartierung Terminologie zu Referentenentwurf Kabinettsmappe Formulierungshilfe Rechtsverordnung Satzung. Inkl. Begruendung Synopse Lesefassung XML Folgenabschaetzung Goldplating-Check und Schulungstrainings. Erzeugt am Ende DOCX und PDF im offiziellen HdR-Layout (Times New Roman BT-Drucksachen, Arial Referentenentwurf).",
       "category": "verwaltung",
-      "version": "7.0.0",
+      "version": "7.1.0",
       "tags": [
         "legistik",
         "gesetzgebung",
@@ -605,7 +605,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "mandantenanfragen-assistent",
@@ -614,7 +614,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "markenrecht-fashion-luxus",
@@ -623,7 +623,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "memorandums-ersteller",
@@ -632,7 +632,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "methodenlehre-buergerliches-recht",
@@ -641,7 +641,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "mietrecht",
@@ -650,7 +650,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "mittelstand-corporate-ma",
@@ -659,7 +659,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "nda-abgleich",
@@ -668,7 +668,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "normenkontrolle-bauleitplanung",
@@ -677,7 +677,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "patentrecherche",
@@ -686,7 +686,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "phishing-vorfall-pruefer",
@@ -695,7 +695,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "produktrecht",
@@ -704,7 +704,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "prozessrecht",
@@ -713,7 +713,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "rechtsberatungsstelle",
@@ -722,7 +722,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "regulatorisches-recht",
@@ -731,7 +731,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "schriftform-und-textform-bgb",
@@ -740,7 +740,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "sozialrecht-kanzlei",
@@ -749,7 +749,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "steuerrecht-anwalt-und-berater",
@@ -758,7 +758,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "strafbefehl-verteidiger",
@@ -767,7 +767,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "subsumtions-pruefer",
@@ -776,7 +776,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "tabellenreview-3d",
@@ -785,7 +785,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "umweltrecht",
@@ -794,13 +794,13 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "urteilsbauer-relationsmacher",
       "source": "./urteilsbauer-relationsmacher",
       "description": "Werkstatt-Plugin fuer Amts-, Land- und Familienrichter: Aktenintake, Relation (Voll- oder Kurzfassung mit Wahlfrage), Zulaessigkeit, Anspruchsgrundlagen, CISG, kollidierende AGB, Incoterms, Beweiswuerdigung mit Richter-Input, Tenor, Tatbestand, Entscheidungsgruende, Kosten, vorlaeufige Vollstreckbarkeit, Rechtsmittelbelehrung, Berufungs- und Revisionsfestigkeit, Beschluesse, Familienspezifika sowie Renderer fuer DOCX und PDF im Gerichtslayout. Inklusive Schulungsakte Solis Vision X Smartglasses.",
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "verfassungsrecht",
@@ -809,7 +809,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "verkehr-infrastrukturrecht",
@@ -818,7 +818,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "verkehrsowi-verteidiger",
@@ -827,7 +827,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "verlagsredaktion",
@@ -836,7 +836,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "vertragsausfueller",
@@ -845,7 +845,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "vertragsrecht",
@@ -854,7 +854,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "wandeldarlehen-lebenszyklus",
@@ -863,7 +863,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "zitierweise-deutsches-recht",
@@ -872,7 +872,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     },
     {
       "name": "zwangsverwaltung-zvg",
@@ -881,8 +881,8 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "7.0.0"
+      "version": "7.1.0"
     }
   ],
-  "version": "7.0.0"
+  "version": "7.1.0"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Alle wesentlichen Änderungen an diesem Repository werden hier dokumentiert. Format orientiert an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Versionierung nach [SemVer](https://semver.org/lang/de/).
 
+## v7.1.0 — 2026-05-24 — Steuer-Plugin-Konsolidierung + ELSTER-Klarstellung
+
+### Major-Feature
+- Drei Steuer-Plugins (`steuerrecht-kanzlei`, `fachanwalt-steuerrecht`, `steuerberater-werkzeuge`) zu einem konsolidierten Plugin **`steuerrecht-anwalt-und-berater`** zusammengeführt. 18 Skills mit Präfix-Schema `anw-`/`fa-`/`stb-`: 13× Steueranwalt (Kaltstart-Interview, Mandat-Triage, Steuerbescheid-Analyse, Einspruch ans Finanzamt, AdV, Klage Finanzgericht, Akteneinsicht, Außenprüfung, Selbstanzeige § 371 AO, verbindliche Auskunft § 89 II AO, Fristenbuch, Betriebsausgaben/Werbungskosten-Prüfraster, USt-Vorsteuerabzug), 1× FA-Orientierung, 4× Steuerberater (Kaltstart-Interview, BWA/SuSa/Bilanz, 3-Wochen-Liquiditätsvorschau, 3-/6-/12-Monats-Vorschau). Vier inhaltliche Dubletten (Einspruch, Außenprüfung, Selbstanzeige, verbindliche Auskunft) zu jeweils einem Master-Skill gemergt. Repo-Plugin-Anzahl: 99 → 97.
+
+### Juristische Korrekturen
+- **ELSTER/ERiC statt beA an Finanzämter** (§ 87a Abs. 1 S. 2 AO n.F., JStG 2024, seit 6.12.2024): Versandwege in Einspruch, AdV-Antrag, Akteneinsicht, Selbstanzeige und verbindlicher Auskunft umgestellt. beA an Finanzbehörden ist unzulässig — ein per beA eingelegter Einspruch wäre formunwirksam und wahrt die Frist nicht (Nds. FG 12.2.2026 – 2 K 152/25). beA bleibt Pflicht gegenüber Finanzgerichten (§ 52d FGO).
+- **Triage-Routing-Slugs** im konsolidierten Plugin auf die neuen Skill-Slugs umgestellt; **ASSET_INDEX**-Dubletten bereinigt; **`stb-`-Sister-Skill-Verweise** auf die konsolidierten Pfade aktualisiert.
+
+### Tooling
+- Versionsfelder repo-weit auf 7.1.0 angehoben: 97 `plugin.json`-Dateien plus die zentrale `.claude-plugin/marketplace.json` mit 97 Plugin-Einträgen. Summe: 195 Versions-Stellen in 98 Dateien.
+- `release-plugin-zips.yml` erzeugt nach dem Tag-Push 97 Plugin-ZIPs + 43 Testakten-ZIPs + `marketplace.json` = 141 Release-Assets.
+
 ## v7.0.0 — 2026-05-24 — Reform-Stand 2026
 
 ### Major-Update

--- a/aktenaufbereiter-strafrecht/.claude-plugin/plugin.json
+++ b/aktenaufbereiter-strafrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aktenaufbereiter-strafrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Aktenaufbereiter fuer die Strafverteidigung. Sechs Excel-faehige Uebersichten — Aktenvorblatt; Personenverzeichnis; Tatkomplexe; Beziehungen; Chronologie; Fristen. Fortlaufend ergaenzbar. Erkennt Luecken und Widersprueche. Kein Ersatz fuer Aktenlektuere.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/aktenauszug-gerichtsverfahren/.claude-plugin/plugin.json
+++ b/aktenauszug-gerichtsverfahren/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aktenauszug-gerichtsverfahren",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Strukturierter Aktenauszug fuer deutsche Gerichtsverfahren: Verfahrensidentifikation Einleitungssatz Verfahrenszusammenfassung Sachverhaltschronologie Verfahrensgeschichte tabellarische Gegenueberstellung der Parteivortraege Beweismittel und Rechtsargumente fuer schnelle Einarbeitung in Akten.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/anlagen-zu-schriftsaetzen/.claude-plugin/plugin.json
+++ b/anlagen-zu-schriftsaetzen/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anlagen-zu-schriftsaetzen",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Zuordnung von Anlagen zu gerichtlichen Schriftsaetzen. Sortiert PDF/Word/Excel nach Schriftsatz-Logik; konvertiert alles nach PDF; benennt beA-konform; stempelt oben rechts Anlage K1/B1/A1 in Arial 12; baut Anlagenkonvolut; Pruefmodus fuer bereits zugeordnete Anlagen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/arbeitsrecht/.claude-plugin/plugin.json
+++ b/arbeitsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "arbeitsrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Arbeitsrecht – Individualkündigung (KSchG-Klage, 3-Wochen-Frist), Aufhebungsvertrag inkl. Sperrzeit, Abmahnung, Anhörung Betriebsrat § 102 BetrVG, AGG-Prüfung, Statusfeststellung, Personalrichtlinien (BetrVG, AGG, ArbZG, MuSchG, BEEG, EFZG, TzBfG).",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/arbeitszeugnis-analyse/.claude-plugin/plugin.json
+++ b/arbeitszeugnis-analyse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "arbeitszeugnis-analyse",
   "displayName": "Arbeitszeugnis-Analyse (Ampelsystem)",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Analyse deutscher Arbeitszeugnisse nach Ampelsystem (Rot/Orange/Gruen). Erkennt den Geheimcode der Zeugnissprache, identifiziert notenrelevante Saetze und klassifiziert sie mit Interpretation der versteckten Bewertung.",
   "author": {
     "name": "Klotzkette"

--- a/aussenwirtschaft-zoll-sanktionen/.claude-plugin/plugin.json
+++ b/aussenwirtschaft-zoll-sanktionen/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aussenwirtschaft-zoll-sanktionen",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Freistehendes Plugin für Außenwirtschaft, Sanktionen, Zoll, Exportkontrolle, BAFA, TARIC, CBAM, Verbrauchsteuer, AWV, AML/KYC und Ermittlungen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/bav-strategie-konzern/.claude-plugin/plugin.json
+++ b/bav-strategie-konzern/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bav-strategie-konzern",
   "displayName": "Betriebliche Altersversorgung Strategie Konzern",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Strategische Beratung zur betrieblichen Altersversorgung in Konzernen: Pensionsmodelle alle fuenf Durchfuehrungswege CTA Pension Buyouts Drei-Stufen-Theorie Versorgungssystem-Harmonisierung internationale Benefits Restrukturierung DB-zu-DC im Duesseldorfer Boutique-Stil.",
   "author": {
     "name": "Klotzkette"

--- a/bereicherungs-und-anfechtungsrecht-pruefer/.claude-plugin/plugin.json
+++ b/bereicherungs-und-anfechtungsrecht-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bereicherungs-und-anfechtungsrecht-pruefer",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Mechanisches Durchpruefen von Bereicherungsrecht SS 812 ff. BGB sowie Anfechtung nach AnfG und SS 129-147 InsO. Weichenstellung Rechtsgrund, Insolvenz, Vollstreckungstitel. Keine Rechtsberatung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/berufsrecht-ki-vertragspruefung/.claude-plugin/plugin.json
+++ b/berufsrecht-ki-vertragspruefung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "berufsrecht-ki-vertragspruefung",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Berufsrechtliche und strafrechtliche Forprüfung von Verträgen mit privaten Legal-AI-Anbietern. Für Rechtsanwälte Steuerberater Wirtschaftsprüfer Patentanwälte Notare. §§ 43e BRAO 62a StBerG 50a WPO 39c PAO 26a BNotO § 203 StGB. Maßstab DAV-Stellungnahme. Gutachten Rückfragebrief Klauselvorschläge.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/betreuungsrecht/.claude-plugin/plugin.json
+++ b/betreuungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "betreuungsrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Betreuungsrechtliche Skills für Jahresbericht, Vermögensverzeichnis, Genehmigungspflichten, Kontoanalyse und Verdachtsverträge nach BtOG und BGB.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/common-law-kompass/.claude-plugin/plugin.json
+++ b/common-law-kompass/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "common-law-kompass",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Freistehendes Common-Law-Plugin für deutsche Wirtschaftsjuristen: UK/US-False-Friends, Vertragsbegriffe, Consideration, Suretyship, Indemnity, UCC, Precedent, Discovery und bilinguale Drafting-Reviews.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/corporate-kanzlei/.claude-plugin/plugin.json
+++ b/corporate-kanzlei/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corporate-kanzlei",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Corporate-Kanzlei-Plugin: Deal-Kommandocenter, Datenraum, Due Diligence, SPA/APA, Umwandlung, StaRUG, Insolvenzplan, W&I, Signing/Closing, PMI.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/datenschutzrecht/.claude-plugin/plugin.json
+++ b/datenschutzrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "datenschutzrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "DSGVO/BDSG/TDDDG – PIA/DPIA, AVV-Review als Verantwortlicher und Auftragsverarbeiter, Auskunftsersuchen Art. 15, Datenpannenmeldung Art. 33/34, Drittlandstransfer Art. 44 ff., Drift-Monitoring.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/einfache-leichte-sprache-jura/.claude-plugin/plugin.json
+++ b/einfache-leichte-sprache-jura/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "einfache-leichte-sprache-jura",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Juristische Texte in Einfache Sprache oder Leichte Sprache übertragen: experimentelle Standard-Annäherung, Zielgruppe klären, Rechtsinhalt sichern und Qualitätsgate nutzen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/email-umformulierer-berufsrecht/.claude-plugin/plugin.json
+++ b/email-umformulierer-berufsrecht/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "email-umformulierer-berufsrecht",
   "displayName": "E-Mail-Umformulierer (Berufsrechtskonform)",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Formuliert unfreundliche, emotionale oder unsachliche E-Mails in hoefliche, sachliche und berufsrechtskonform formulierte Texte um. Fokus auf BRAO/BORA-Konformitaet, mit Varianten fuer Steuerberater, Notare und allgemeine berufliche Korrespondenz.",
   "author": {
     "name": "Klotzkette"

--- a/energierecht/.claude-plugin/plugin.json
+++ b/energierecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "energierecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Freistehendes Energierecht-Plugin für Stadtwerke, Versorger, Wärme, Netze, Vertrieb, Industrie, EEG, KWKG, Verfahren, Transaktionen und Projektfinanzierung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/europarecht-kompass/.claude-plugin/plugin.json
+++ b/europarecht-kompass/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "europarecht-kompass",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Freistehendes Europarecht-Plugin gegen deutsche Denkfehler: Vorrang, unmittelbare Wirkung, Richtlinien, Verordnungen, Charta, Grundfreiheiten, Beihilfen, Vorlageverfahren und EU-Drafting.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-agrarrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-agrarrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-agrarrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt für Agrarrecht. Höferecht (HöfeO Anerbenrecht Länder) Landpachtrecht BGB §§ 581 ff. GAP EU-Direktzahlungen Cross-Compliance Düngeverordnung Pflanzenschutz Tierschutz Forstrecht. Schnittstelle Plugin fachanwalt-erbrecht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-arbeitsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-arbeitsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-arbeitsrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Arbeitsrecht nach FAO § 10. KSchG Kuendigungsschutzklage Frist drei Wochen § 4 KSchG. BetrVG Betriebsratsanhoerung § 102. TzBfG Befristung. AGG. Schnittstellen arbeitsrecht und kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-bank-kapitalmarktrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-bank-kapitalmarktrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-bank-kapitalmarktrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Bank- und Kapitalmarktrecht. KWG ZAG WpHG WpIG MiFID-II MAR MiCAR Verbraucherkredit Vermoegensanlage Beratungshaftung. Schnittstellen Plugin gesellschaftsrecht regulatorisches-recht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-bau-architektenrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-bau-architektenrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-bau-architektenrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Bau- und Architektenrecht. BGB Werkvertrag VOB-A VOB-B VOB-C HOAI Bauordnungsrecht. Bauvertrag Maengelhaftung Abnahme Vergaberecht. Schnittstellen Plugin fachanwalt-vergaberecht kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-erbrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-erbrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-erbrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Erbrecht. BGB Erbrecht §§ 1922 ff. Pflichtteil Testament Erbschein Erbauseinandersetzung Erbschaftsteuer EU-ErbVO. Schnittstellen Plugin steuerrecht-anwalt-und-berater kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-familienrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-familienrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-familienrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Familienrecht. Orientierung Normen Mandate Fristen Literatur. Familiengericht FamFG Scheidung Sorge Umgang Unterhalt Zugewinn Ehevertrag eingetragene Lebenspartnerschaft. Ergaenzend zum Plugin kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-gewerblicher-rechtsschutz/.claude-plugin/plugin.json
+++ b/fachanwalt-gewerblicher-rechtsschutz/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-gewerblicher-rechtsschutz",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer gewerblichen Rechtsschutz nach FAO § 14k. MarkenG. DesignG. UWG. PatG GebrMG. UrhG-Bezuege. Markenanmeldung DPMA EUIPO. UWG-Abmahnung §§ 8 ff. UWG. Designverletzung. Einstweilige Verfuegung Verletzungsklage Lizenzanaloger Schadensersatz.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-handels-gesellschaftsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-handels-gesellschaftsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-handels-gesellschaftsrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Handels- und Gesellschaftsrecht nach FAO § 14i. HGB. AktG. GmbHG. PartGG. UmwG. Geschaeftsfuehrerhaftung §§ 43 GmbHG 93 AktG. Gesellschafterstreit Beschlussanfechtung. Handelsvertreterausgleich § 89b HGB. MoPeG GbR seit 2024. Schnittstellen kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-insolvenz-sanierungsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-insolvenz-sanierungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-insolvenz-sanierungsrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Insolvenz- und Sanierungsrecht nach FAO § 14. InsO Eroeffnung Antragspflicht § 15a Glaeubigerantrag § 14 InsO. StaRUG Restrukturierungsplan. Insolvenzanfechtung §§ 129 ff. InsO. Schnittstellen insolvenzrecht und steuerrecht-anwalt-und-berater.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-internationales-wirtschaftsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-internationales-wirtschaftsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-internationales-wirtschaftsrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Internationales Wirtschaftsrecht. CISG Bruessel Ia Rom I Rom II Schiedsverfahren ICC UNCITRAL Investitionsschutz ICSID WTO EU-Aussenhandel LkSG. Schnittstelle Plugin kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-it-recht/.claude-plugin/plugin.json
+++ b/fachanwalt-it-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-it-recht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Informationstechnologierecht. SaaS Software-Lizenz DSGVO BDSG TTDSG TKG NIS2 DDG DSA DMA EU-KI-VO Open-Source. Schnittstellen Plugin datenschutzrecht ki-governance kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-medizinrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-medizinrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-medizinrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Medizinrecht. Arzthaftung §§ 630a ff. BGB Patientenrechte Vertragsarztrecht Berufsrecht Aerzte SGB V Krankenversicherung MPDG Apothekenrecht. Schnittstellen Plugin sozialrecht-kanzlei kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-miet-wohnungseigentumsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-miet-wohnungseigentumsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-miet-wohnungseigentumsrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Miet- und Wohnungseigentumsrecht nach FAO § 14e. BGB §§ 535 ff. Wohnraummiete und Gewerberaummiete. Mieterhoehung §§ 558 ff. Kuendigung §§ 543 569 573 BGB. WEG-Beschlussanfechtung § 44 WEG. BetrKV. Schnittstellen kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-migrationsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-migrationsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-migrationsrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt für Migrationsrecht. AufenthG AsylG GFK Dublin-VO Verfahrens-RL Qualifikations-RL StAG. Einbürgerung Familiennachzug Notfrist § 36 AsylG eine Woche. Schnittstellen Plugin rechtsberatungsstelle.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-sozialrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-sozialrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-sozialrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Sozialrecht nach FAO § 11. SGB I bis XII Sozialgerichtsbarkeit SGG. Widerspruch § 84 SGG Frist ein Monat. Klage Sozialgericht § 87 SGG. Erwerbsminderungsrente. SGB II Buergergeld Bescheid. Schnittstellen sozialrecht-kanzlei und kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-sportrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-sportrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-sportrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt für Sportrecht. Verbandsrecht (DFB FIFA UEFA IOC DOSB) CAS Schiedsverfahren Spielerverträge Doping WADA-Code NADA Sponsoring Persönlichkeitsrechte Veranstalterhaftung. Schnittstelle Plugin gesellschaftsrecht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-strafrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-strafrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-strafrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Strafrecht. Orientierung StPO StGB Nebenstrafrecht. Strafverteidigung Ermittlungsverfahren Hauptverhandlung Berufung Revision Verfassungsbeschwerde. Ergaenzt aktenaufbereiter-strafrecht und kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-transport-speditionsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-transport-speditionsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-transport-speditionsrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Transport- und Speditionsrecht. HGB §§ 407 ff. Frachtvertrag §§ 453 ff. Spedition CMR COTIF Montrealer Uebereinkommen Haager Visby Regeln ADSp. Schnittstelle Plugin kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-urheber-medienrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-urheber-medienrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-urheber-medienrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Urheber- und Medienrecht. UrhG UWG KUG Recht am eigenen Bild Presserecht Persoenlichkeitsrecht Medienstaatsvertrag. Schnittstellen Plugin gewerblicher-rechtsschutz verlagsredaktion kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-vergaberecht/.claude-plugin/plugin.json
+++ b/fachanwalt-vergaberecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-vergaberecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Vergaberecht. GWB §§ 97 ff. VgV UVgO SektVO KonzVgV VOB-A. EU-Vergabe-RL. Nachpruefungsverfahren Vergabekammer und OLG-Vergabesenat. Schnittstelle Plugin fachanwalt-bau-architektenrecht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-verkehrsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-verkehrsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-verkehrsrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Verkehrsrecht. StVG StVO PflVG VVG-Bezuege. Verkehrsunfall Personen- und Sachschaden Bussgeld Fahrerlaubnis Verkehrsstrafrecht (§§ 315c 316 StGB). Schnittstelle Plugin kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-versicherungsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-versicherungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-versicherungsrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Versicherungsrecht. VVG VAG Berufsunfaehigkeit private Krankenversicherung Lebens- und Rentenversicherung Sachversicherung Haftpflicht D-und-O. Schnittstelle Plugin kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-verwaltungsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-verwaltungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-verwaltungsrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Light-Touch-Plugin Fachanwalt für Verwaltungsrecht. VwGO VwVfG. Anfechtungs- und Verpflichtungsklage Eilrechtsschutz § 80 Abs 5 VwGO einstweilige Anordnung Normenkontrolle Polizei- und Ordnungsrecht. Schnittstelle Plugin kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fluggastrechte/.claude-plugin/plugin.json
+++ b/fluggastrechte/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fluggastrechte",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Fluggastrechte selber geltend machen — VO (EG) Nr. 261/2004 plus EuGH-Rspr. Tickets erfassen Annullierung vs Verspaetung pruefen aussergewoehnliche Umstaende Distanz und Ausgleich Forderungsschreiben Mahnung Klage Amtsgericht. Vollmacht Familie. Katalog Airline-Standardausreden.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/forderungsmanagement-klagewerkstatt/.claude-plugin/plugin.json
+++ b/forderungsmanagement-klagewerkstatt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forderungsmanagement-klagewerkstatt",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Klagewerkstatt für Forderungsmanagement mit Zuständigkeitsprüfung, Mahnvorlauf, Inkasso-Zahlungsklage und Anspruchs-Gatekeeper: Nur klare, fällige und belegte Forderungen werden zur Klage freigegeben.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fortbestehensprognose/.claude-plugin/plugin.json
+++ b/fortbestehensprognose/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fortbestehensprognose",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Fortbestehensprognose § 19 Abs. 2 InsO als Geschaeftsfuehrer-Selbstdokumentation. Bilanzstatus Annahmen Plausibilisierung Zwoelf-Monats-Liquiditaet. Sanierungsbausteine Patronatserklaerung Comfortletter Rangruecktritt Stundung Forderungsverzicht. IDW S 11 StaRUG. Eskalation bei negativer Prognose.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/geldwaeschepraevention-aml-kyc/.claude-plugin/plugin.json
+++ b/geldwaeschepraevention-aml-kyc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "geldwaeschepraevention-aml-kyc",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Freistehendes Plugin für Geldwäscheprävention, AML, KYC, GwG-Risikoanalyse, UBO, PEP, Sanktionen, FIU/goAML, Transparenzregister und Behördenverfahren.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gesellschaftsgruender/.claude-plugin/plugin.json
+++ b/gesellschaftsgruender/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gesellschaftsgruender",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Gruendungsassistent deutsche Gesellschaften (GmbH UG GbR OHG KG GmbH und Co KG PartG mbB gGmbH). Von Rechtsformwahl ueber Gesellschaftsvertrag und Geschaeftsfuehrervertrag bis Notar Handelsregister Gewerbeamt Finanzamt Transparenzregister. MoPeG DiRUG GwG. Kein Ersatz fuer Anwaltsberatung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gesellschaftsrecht/.claude-plugin/plugin.json
+++ b/gesellschaftsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gesellschaftsrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Gesellschaftsrecht – GmbH/AG/Personengesellschaften, M&A-Due-Diligence ohne Discovery (Q&A + Datenraum), Gesellschafterbeschlüsse, HRB/HRA-Anmeldungen, Closing Checklists, Compliance-Fristen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gewerblicher-rechtsschutz/.claude-plugin/plugin.json
+++ b/gewerblicher-rechtsschutz/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gewerblicher-rechtsschutz",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Gewerblicher Rechtsschutz – DPMA/EUIPO-Markenrecherche und -anmeldung, Freedom-to-Operate, Patentscreening, UWG- und Urheberrechts-Abmahnung (Versand und Reaktion), Open-Source-Compliance, IP-Klausel-Review, Schutzrechts-Fristen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/grosskanzlei-corporate-ma/.claude-plugin/plugin.json
+++ b/grosskanzlei-corporate-ma/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "grosskanzlei-corporate-ma",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Freistehendes Big-Law-Corporate/M&A-Plugin: Deal-Kommandocenter, Aktenanlage, Datenraum, Legal DD, Tabellenreview, Liquiditätsvorschau, SPA/APA, W&I, Public M&A, Umwandlung, StaRUG/Insolvenzplan, CP-Kalender, E-Rechnung/GoBD, PMI.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/hausarbeitenmacher/.claude-plugin/plugin.json
+++ b/hausarbeitenmacher/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hausarbeitenmacher",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Didaktisches Plugin fuer juristische Hausarbeiten und Seminararbeiten. Fuehrt sokratisch durch Zivilrecht oeffentliches Recht Strafrecht mit Ausfluegen in Europarecht und Rechtstheorie. Adressaten-Strategie ohne Schleimerei. Liefert keine fertigen Loesungen sondern fuehrt zur eigenen Subsumtion.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/immobilienrechtspraxis/.claude-plugin/plugin.json
+++ b/immobilienrechtspraxis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "immobilienrechtspraxis",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Werkzeuge fuer immobilienrechtliche Rechtsabteilungen: musterbasierte Vertragserstellung mit Klauselschutz; Vertragspruefung gegen Playbook; Grundbuchanalyse; Sachverhaltsermittlung; Mieteranfragen mit BGH-Verankerung; Case Management; projektbasierte Arbeitsweise mit AVV-Pruefung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/insolvenzforderungsanmeldungspruefung/.claude-plugin/plugin.json
+++ b/insolvenzforderungsanmeldungspruefung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insolvenzforderungsanmeldungspruefung",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Freistehendes Plugin für die Insolvenzforderungsanmeldungsprüfung: Intake, § 174 InsO, Belege, Grund, Betrag, Rang, vbuH, Nachforderungen, Tabellenimport, Prüfungstermin, Bestreiten, Feststellung, Tabellenauszug und Verteilung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/insolvenzplan-starug-planwerkstatt/.claude-plugin/plugin.json
+++ b/insolvenzplan-starug-planwerkstatt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insolvenzplan-starug-planwerkstatt",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Freistehendes Plugin für Insolvenzplan und StaRUG-Restrukturierungsplan: Intake, Sanierungskonzept, Vergleichsrechnung, Gruppen, Klassen, darstellender und gestaltender Teil, Anlagen, Abstimmung, Cram-down, Minderheitenschutz, Gericht und Planvollzug.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/insolvenzrecht/.claude-plugin/plugin.json
+++ b/insolvenzrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insolvenzrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Insolvenzrechtliche Skills zu Zahlungsunfähigkeit, Überschuldung, Antragspflicht und Gläubigerantrag.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/insolvenzverwaltung/.claude-plugin/plugin.json
+++ b/insolvenzverwaltung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insolvenzverwaltung",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Freistehendes Insolvenzverwaltungs-Plugin aus Sicht von Insolvenzverwalter, Sachwalter und vorläufiger Verwaltung: Regelverfahren, Eigenverwaltung, Schutzschirm, Anfechtung, § 15b InsO, Masse, Forderungsprüfung, Insolvenzplan, StaRUG-Planwerkstatt, Gutachten, Berichte und Schlussrechnung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/jurastudium/.claude-plugin/plugin.json
+++ b/jurastudium/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jurastudium",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Studium und Referendariat – Prüfungsgespräch nach AG-Tradition, Subsumtionslehre, Methodenlehre (Zivilrecht, Strafrecht, Öffentliches Recht), Rechtsgeschichte, Lernstrategien, Lösungsschemata, Gutachtenstil, Klausurkorrektur, Lernplanung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/jveg-kostenpruefer/.claude-plugin/plugin.json
+++ b/jveg-kostenpruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jveg-kostenpruefer",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Freistehender JVEG-Kostenprüfer für Zeugenentschädigung, Vorschuss, Fahrtkosten, Übernachtung, Verdienstausfall, Sachverständigen- und Dolmetscherkosten, Fristen, Festsetzung, Beschwerde und belegfeste Rechenprotokolle.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kanzlei-allgemein/.claude-plugin/plugin.json
+++ b/kanzlei-allgemein/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanzlei-allgemein",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Kanzlei-Allgemein-Plugin: edles Cowork-Kommandocenter, Mandatsannahme/GwG, Klage/Replik, Vertrag, Rechtsprechung, Handelsregister, beA, Rechnung, UStVA.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kanzlei-builder-hub/.claude-plugin/plugin.json
+++ b/kanzlei-builder-hub/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanzlei-builder-hub",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Findet, prüft und installiert Community-Skills mit Security-Review-Gate vor dem Deployment in die Kanzleiumgebung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kanzlei-cowork/.claude-plugin/plugin.json
+++ b/kanzlei-cowork/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanzlei-cowork",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Cowork-Assistent fuer die deutsche Anwaltskanzlei. Fristenbuch Timesheet RVG-Rechnung Versand-Vor-Check (PDF beA Signatur) beA-Versand Postein- und ausgang Mandantenakte Aktenbestand Honorar-Mahnwesen Mandantenbriefe Geburtstage Weihnachtskarten Tagesbrief. Rechtsgebietsunabhaengig.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kartellrecht-marktabgrenzung-pruefung/.claude-plugin/plugin.json
+++ b/kartellrecht-marktabgrenzung-pruefung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kartellrecht-marktabgrenzung-pruefung",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Kritische kartellrechtliche Pruefinstanz fuer vorgelegte Marktabgrenzungen nach Paragraf 18 GWB und Art 101 und 102 AEUV. SSNIP-Test Nachfrage- und Angebotsumstellung raeumlicher Markt Evidenzbasierung Konsistenzcheck EuGH-Leitentscheidungen Red Flags alternative Marktdefinitionen Marktbeherrschung.",
   "author": {
     "name": "Klotzkette"

--- a/ki-governance/.claude-plugin/plugin.json
+++ b/ki-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ki-governance",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "EU-KI-VO + DSGVO – Use-Case-Triage, KI-Inventar, AIA/DPIA, Vendor-Review, Drift-Monitoring der KI-Richtlinie.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/ki-richtlinie-kanzleien/.claude-plugin/plugin.json
+++ b/ki-richtlinie-kanzleien/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ki-richtlinie-kanzleien",
   "displayName": "KI-Richtlinie fuer Kanzleien und Rechtsabteilungen",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Erstellt und pflegt eine berufsrechtskonforme KI-Nutzungsrichtlinie fuer Kanzleien und Rechtsabteilungen mit Anwaelten und Syndikus-Anwaelten. Beruht auf BRAO, BORA, DSGVO, KI-Verordnung sowie BRAK- und DAV-Hinweisen.",
   "author": {
     "name": "Klotzkette"

--- a/ki-vo-ai-act-pruefer/.claude-plugin/plugin.json
+++ b/ki-vo-ai-act-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ki-vo-ai-act-pruefer",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Vollstaendiger Mechanik-Workflow zur Verordnung (EU) 2024/1689 (KI-VO): KI-System-Definition, Rollen, Risikoklassen, Hochrisiko-Pflichten, GPAI-Modelle, Sanktionen. Kein Rechtsrat.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/krisenfrueherkennung-starug/.claude-plugin/plugin.json
+++ b/krisenfrueherkennung-starug/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "krisenfrueherkennung-starug",
   "displayName": "Krisenfrüherkennung und StaRUG-Management",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Krisenfrüherkennung und Krisenmanagement nach StaRUG: Pflicht zum 24-Monats-Frühwarnsystem nach § 1 StaRUG, § 102 StaRUG Warnpflicht der Berater, Geschäftsführerhaftung, drohende Zahlungsunfähigkeit, integrierte Planung, Restrukturierungsplan und Stabilisierungsanordnung.",
   "author": {
     "name": "Klotzkette"

--- a/legistik-werkstatt/.claude-plugin/plugin.json
+++ b/legistik-werkstatt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legistik-werkstatt",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Legistik-Werkstatt fuer Bundes- und Landesministerien. Erstellt Referentenentwuerfe Kabinettsentwuerfe Formulierungshilfen Rechtsverordnungen Satzungen mit Begruendung Synopse Lesefassung XML. Pruefung Verfassungsrecht Europarecht Folgenabschaetzung Goldplating. DOCX im offiziellen HdR-Layout.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/liquiditaetsplanung/.claude-plugin/plugin.json
+++ b/liquiditaetsplanung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "liquiditaetsplanung",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Liquiditaetsplanung nach deutschem Recht: 3-Wochen-Vorschau mit BGH-Passiva-II- und 10-Prozent-Schema, 13/26/52-Wochen-Forecast, Excel-Export mit Quote/Luecken-Ampel, Padlet/JSON-Round-Trip, Integration mit Fortbestehensprognose. Krisen-GmbH, Bugwellenrechtsprechung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/mandantenanfragen-assistent/.claude-plugin/plugin.json
+++ b/mandantenanfragen-assistent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mandantenanfragen-assistent",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Assistent fuer Anwaltskanzleien zur Erstantwort auf Mandantenanfragen per E-Mail: dankt foermlich uebernimmt die Anrede aus der eingehenden E-Mail nennt die telefonische Terminvergabe bittet um Sachverhalt per E-Mail oder bietet eine Telefon-Transkription mit DSGVO-Einwilligungshinweis an.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/markenrecht-fashion-luxus/.claude-plugin/plugin.json
+++ b/markenrecht-fashion-luxus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markenrecht-fashion-luxus",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Markenrecht-Boutique fuer Luxus-Modehaeuser - DPMA/EUIPO Alicante/USPTO Lanham Act via NYC-Korrespondenz, alle Markenarten (Wort/Bild/Slogan/Sound/Duft/3D/Position/Haptik/Anti-KI), Widerspruch, Loeschung, Verletzung, Produktpiraterie, Selektivvertrieb.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/memorandums-ersteller/.claude-plugin/plugin.json
+++ b/memorandums-ersteller/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorandums-ersteller",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Wandelt Mandantenunterlagen in ein juristisches Memorandum mit Vier-Teile-Gliederung — Sachverhalt mit Quellenreferenz; Ein-Satz-Fragen; Ein-Satz-Antworten; rechtliche Ausfuehrungen mit Pinpoint-Zitierung. Optional Piercing-Questions. Rechtsgebietsneutral. Alias Memorandumsmacher.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/methodenlehre-buergerliches-recht/.claude-plugin/plugin.json
+++ b/methodenlehre-buergerliches-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "methodenlehre-buergerliches-recht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Methodenlehre und Rechtsanwendung im deutschen buergerlichen Recht aus Anwaltsperspektive. Gutachtenstil. Anspruchsgrundlagen-Reihenfolge. Auslegung Wortlaut System Historie Telos pragmatisch ohne starren Vorrang. Verfassungs- und unionsrechtskonforme Auslegung. Lueckenfuellung. Verjaehrung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/mietrecht/.claude-plugin/plugin.json
+++ b/mietrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mietrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Mietrecht fuer Mieter und Vermieter mit ausschliesslich amtlichen Mietspiegel-Quellen pro Bundesland und fuer Top- und Universitaetsstaedte. Datenerhebung Mieterhoehungs-Widerspruch Mietsenkungsverlangen Nebenkostenpruefung und Erstellung Mieteranfragen Klageentwurf zum Amtsgericht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/mittelstand-corporate-ma/.claude-plugin/plugin.json
+++ b/mittelstand-corporate-ma/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mittelstand-corporate-ma",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Freistehendes Mittelstandsmandat-Corporate/M&A-Plugin: Deal-Kommandocenter, Aktenanlage, Datenraum, Legal DD, Tabellenreview, Liquiditätsvorschau, SPA/APA, W&I, Public M&A, Umwandlung, StaRUG/Insolvenzplan, CP-Kalender, E-Rechnung/GoBD, PMI.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/nda-abgleich/.claude-plugin/plugin.json
+++ b/nda-abgleich/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nda-abgleich",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Gleicht NDA-Entwurf der Gegenseite gegen eigenen Standard ab und setzt Haltelinien chirurgisch im Word-Aenderungsmodus durch. Ampelmatrix ROT/GELB/GRUEN. Ausgabe .docx mit echten Tracked Changes. Keine Absatzloeschungen, keine Klausel-Neufassungen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/normenkontrolle-bauleitplanung/.claude-plugin/plugin.json
+++ b/normenkontrolle-bauleitplanung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "normenkontrolle-bauleitplanung",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Freistehendes Plugin für die Prüfung und Anfechtung von Bebauungsplänen, Flächennutzungsplänen und örtlichen Bauvorschriften nach § 47 VwGO vor BayVGH und OVG. Mandatsperspektive Antragstellervertretung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/patentrecherche/.claude-plugin/plugin.json
+++ b/patentrecherche/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "patentrecherche",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Patentrecherche fuer Patentanwaelte agentisch in Espacenet Google Patents DPMAregister DEPATISnet EPO Register WIPO USPTO. Stand der Technik Neuheit § 3 PatG Art. 54 EPUe erfinderische Taetigkeit § 4 PatG Art. 56 EPUe Problem-Solution-Approach FTO CPC IPC INPADOC Recherchebericht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/phishing-vorfall-pruefer/.claude-plugin/plugin.json
+++ b/phishing-vorfall-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "phishing-vorfall-pruefer",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Freistehender Phishing-Vorfall-Prüfer für Online-Banking: BGB § 675u, § 675v, § 675w, pushTAN, Call-ID-Spoofing, grobe Fahrlässigkeit, Beweislast, Bankpflichten, Schlichtung und Klage.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/produktrecht/.claude-plugin/plugin.json
+++ b/produktrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "produktrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Produktrechtliche Skills für Launch-Review, Impressumspflicht nach DDG und PAngV sowie UWG-Bewertungen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/prozessrecht/.claude-plugin/plugin.json
+++ b/prozessrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prozessrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Prozessrechtliche Skills für Mandate, Fristen, Mahnbescheid, Eilverfahren, Vollstreckung und Schriftsätze.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/rechtsberatungsstelle/.claude-plugin/plugin.json
+++ b/rechtsberatungsstelle/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rechtsberatungsstelle",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Pro-Bono- und Rechtsberatungsstellen (RDG-konform): Mandantenintake, Fristenkontrolle, Übergabe am Semesterende, mandantenfreundliche Briefe.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/regulatorisches-recht/.claude-plugin/plugin.json
+++ b/regulatorisches-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "regulatorisches-recht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Aufsichtsrecht – KWG, ZAG, WpHG, GwG, EnWG, TKG, HeilMWerbG, Umsatzsteuer-Voranmeldung, Inkasso/RDG, Regulator-Feeds, Wochendigest.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/schriftform-und-textform-bgb/.claude-plugin/plugin.json
+++ b/schriftform-und-textform-bgb/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "schriftform-und-textform-bgb",
   "displayName": "Schriftform und Textform im BGB",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Workflow-Organisator zu Formerfordernissen im deutschen Zivilrecht: Schriftform § 126 BGB qES § 126a Textform § 126b Zugang § 130 BGB lernt aus BGH I ZR 202/25 Maklervertrag und BGH VIII ZR 159/23 Mietkündigung Klauselgenerator Mandantenmemos.",
   "author": {
     "name": "Klotzkette"

--- a/sozialrecht-kanzlei/.claude-plugin/plugin.json
+++ b/sozialrecht-kanzlei/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sozialrecht-kanzlei",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Vollassistenz fuer die sozialrechtliche Kanzlei: Bescheidanalyse Widerspruch Klage zum Sozialgericht Eilantrag Akteneinsicht Anlagen. Spezialisiert auf Buergergeld SGB IX Schwerbehinderung Hilfsmittel (Rollstuhl Hoerhilfe Vorlesekraft) Eingliederungshilfe Schulbegleitung. Mit Fristenbuch und PKH.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/steuerrecht-anwalt-und-berater/.claude-plugin/plugin.json
+++ b/steuerrecht-anwalt-und-berater/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "steuerrecht-anwalt-und-berater",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Steuerberater und Fachanwalt fuer Steuerrecht: Bescheidanalyse Einspruch Klage Finanzgericht Aussenpruefung Selbstanzeige Verbindliche Auskunft Akteneinsicht. Steuerberater-Werkzeuge BWA SuSa Bilanzpruefung Krisenfrueherkennung. Praefixe anw- fa- stb-.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/strafbefehl-verteidiger/.claude-plugin/plugin.json
+++ b/strafbefehl-verteidiger/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "strafbefehl-verteidiger",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Freistehendes Strafbefehls-Plugin für Verteidigung gegen Strafbefehl, Einspruch, Akteneinsicht, Tagessätze, Nebenfolgen, Pflichtverteidigung, Wiedereinsetzung, Einstellung, Zeugenstrategie und Hauptverhandlung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/subsumtions-pruefer/.claude-plugin/plugin.json
+++ b/subsumtions-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "subsumtions-pruefer",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Interaktiver Subsumtions-Workflow fuer deutsches Recht und Europarecht: Tatbestandsmerkmale zerlegen, Vier-Schritt-Schema anwenden, Rechtsfolgen und Einreden pruefen. Keine Rechtsberatung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/tabellenreview-3d/.claude-plugin/plugin.json
+++ b/tabellenreview-3d/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tabellenreview-3d",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "3D-Tabellenreview als Wuerfel: Spaltenprompts pro Datenpunkt x Zeilenprompts pro Dokument x Arbeitsblatt-Perspektiven (Recht / Steuer / Wirtschaft) gestapelt. Massenpruefung Vertragsstapel M&A-DD Immobilien Vendor-Onboarding mit Excel-Mehrblatt Kreuzblatt-Konsistenz Audit-Trail Belegkette.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/umweltrecht/.claude-plugin/plugin.json
+++ b/umweltrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "umweltrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Freistehendes Umweltrecht-Plugin für BImSchG, TEHG, Abfall, Wasser, Boden, Naturschutz, UIG, Verfahren, Bußgeld, Umwelt-Due-Diligence, Klimaklagen UmwRG, Lieferkettensorgfalt LkSG/CSDDD und ESG-Greenwashing/CSRD.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/urteilsbauer-relationsmacher/.claude-plugin/plugin.json
+++ b/urteilsbauer-relationsmacher/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "urteilsbauer-relationsmacher",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Urteils- und Beschluss-Werkstatt fuer Amts- Land- und Familienrichter sowie Rechtspfleger. Aktenintake Relation Beweiswuerdigung mit Richter-Input Tatbestandsmerkmale Tenor Tatbestand Entscheidungsgruende Rechtsmittelbelehrung. Erzeugt DOCX nach Paragraf 313 ZPO.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verfassungsrecht/.claude-plugin/plugin.json
+++ b/verfassungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verfassungsrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Deutsches Verfassungsrecht unter dem Grundgesetz aus Sicht einer Spezialkanzlei. Rechtsprechungsgetrieben mit Live-Recherche auf bundesverfassungsgericht.de. Acht Skills für Gesetzgebungskompetenz formelle und materielle Verfassungsmäßigkeit Grundrechte und Verfassungsbeschwerde.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verkehr-infrastrukturrecht/.claude-plugin/plugin.json
+++ b/verkehr-infrastrukturrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verkehr-infrastrukturrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Freistehendes Verkehrs- und Infrastrukturrecht-Plugin für Verkehrsplanung, Planfeststellung, Straßenbahn, Ladeinfrastruktur, Parkraum und Verkehrswende.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verkehrsowi-verteidiger/.claude-plugin/plugin.json
+++ b/verkehrsowi-verteidiger/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verkehrsowi-verteidiger",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Freistehendes VerkehrsOWi-Plugin für Bußgeldbescheid, Anhörung, Einspruch, Punkte, Fahrverbot, Rotlicht, Geschwindigkeit, Abstand, Handy, Alkohol, Drogen, Akteneinsicht, Messakte, Zeugenstrategie und Amtsgericht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verlagsredaktion/.claude-plugin/plugin.json
+++ b/verlagsredaktion/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verlagsredaktion",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Verlegerischer Redaktionsassistent fuer juristische Verlage und Autoren. Macht aus disparaten Inputs ein Rohmanuskript fuer Aufsatz Kommentar oder Buchkapitel. Editionssystem ueberarbeitet umgliedert verdichtet erkennt Widersprueche. Hauszitierweise mit Pinpoint-Randnummer.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/vertragsausfueller/.claude-plugin/plugin.json
+++ b/vertragsausfueller/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vertragsausfueller",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Freistehendes Vertragsausfüller-Plugin: DOCX-Vorlagen und Altverträge strippen, Felder erkennen, Term Sheets mappen, Rückfragen führen, neue Verträge erzeugen und Track-Changes-Fassungen nur nach ausdrücklicher Nachfrage vorbereiten.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/vertragsrecht/.claude-plugin/plugin.json
+++ b/vertragsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vertragsrecht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Vertragsrecht – Lieferanten- und Vertriebsverträge, AGB §§ 305 ff. BGB, NDA, SaaS-/MSA-Review, Renewal-Tracking, Eskalations-Routing, Business-Zusammenfassungen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/wandeldarlehen-lebenszyklus/.claude-plugin/plugin.json
+++ b/wandeldarlehen-lebenszyklus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wandeldarlehen-lebenszyklus",
   "displayName": "Wandeldarlehen-Lebenszyklus (Erstellung bis Cap-Table)",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Begleitet den vollstaendigen Lebenszyklus eines Wandeldarlehens fuer GmbH und UG: Vertragserstellung (bilingual/einsprachig), Beurkundungspruefung, Wandelereignisse, Wandlungsberechnung, Cap-Table-Update, Gesellschafterbeschluss und Notar-Paket.",
   "author": {
     "name": "Klotzkette"

--- a/zitierweise-deutsches-recht/.claude-plugin/plugin.json
+++ b/zitierweise-deutsches-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zitierweise-deutsches-recht",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Deutsche juristische Zitierweise v3.0. Rspr. mit Az.-Marker Datum Aktenzeichen Fundstelle Rn. Kommentar mit Bearbeiter Werk Auflage Jahr Rn. Verlag bei Monographien. Diss. Habil. mit Hochschulort. Reihenfolge erst Gerichtshierarchie dann Zeit oder Relevanz. Palandt heißt seit 2022 Grüneberg.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/zwangsverwaltung-zvg/.claude-plugin/plugin.json
+++ b/zwangsverwaltung-zvg/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zwangsverwaltung-zvg",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Freistehendes ZVG-Plugin für Zwangsverwaltung und Versteigerung: Beschlagnahme, Besitz, Mieten, Treuhandkonto, Berichte, Verteilung, ZVG-Portal-Recherche, Bieterangebote und Versteigerungsteilnahme.",
   "license": "Apache-2.0 OR MIT",
   "author": {


### PR DESCRIPTION
## v7.1.0

**Major-Feature:** Drei Steuer-Plugins zu einem konsolidierten Plugin `steuerrecht-anwalt-und-berater` zusammengeführt (18 Skills mit Präfix-Schema anw-/fa-/stb-, 4 Dubletten gemergt). Repo-Plugin-Anzahl: 99 → 97.

**Juristische Korrektur:** ELSTER/ERiC statt beA an Finanzämter (§ 87a Abs. 1 S. 2 AO n.F., JStG 2024, seit 6.12.2024). beA bleibt Pflicht ggü Finanzgerichten (§ 52d FGO).

**Tooling:** Versionsfelder repo-weit auf 7.1.0 (195 Stellen). Release-Workflow erzeugt 97 Plugin-ZIPs + 43 Testakten-ZIPs + marketplace.json = 141 Assets.

Validator: OK.

Siehe CHANGELOG.md für Details.