### PR TITLE
fix(steuerrecht): Tippfehler + ASCII-Umlaut-Reste aus Stresstest

### DIFF
--- a/steuerrecht-anwalt-und-berater/skills/anw-akteneinsicht-steuerakte/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/anw-akteneinsicht-steuerakte/SKILL.md
@@ -32,7 +32,7 @@ einschließlich
 - Korrespondenz mit Dritten
 - Daten über Kontroll- und Überwachungsprüfungen
 
-bevorzugt durch elektronische Übersendung über **Mein ELSTER** (Nachrichtenfunktion); alternativ in Papierform oder per Telefax. Eine Übersendung über beA ist seit 6.12.2024 unzulaessig (§ 87a Abs. 1 S. 2 AO n.F.).
+bevorzugt durch elektronische Übersendung über **Mein ELSTER** (Nachrichtenfunktion); alternativ in Papierform oder per Telefax. Eine Übersendung über beA ist seit 6.12.2024 unzulässig (§ 87a Abs. 1 S. 2 AO n.F.).
 ```
 
 ### Im Klageverfahren

--- a/steuerrecht-anwalt-und-berater/skills/anw-aussetzung-vollziehung/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/anw-aussetzung-vollziehung/SKILL.md
@@ -80,4 +80,4 @@ Keine gesetzliche Antragsfrist. Empfehlung: zusammen mit Einspruch oder Klage ei
 
 ## Versand
 
-AdV-Antrag bei der **Finanzbehoerde** (§ 361 AO): über **ELSTER**/ERiC, Briefpost oder Telefax. **beA an Finanzamt unzulaessig** seit 6.12.2024 (§ 87a Abs. 1 S. 2 AO n.F.). AdV-Antrag beim **Finanzgericht** (§ 69 Abs. 3 FGO): über beA (§ 52d FGO). Vor Versand `versand-vor-check` aus `kanzlei-cowork`.
+AdV-Antrag bei der **Finanzbehoerde** (§ 361 AO): über **ELSTER**/ERiC, Briefpost oder Telefax. **beA an Finanzamt unzulässig** seit 6.12.2024 (§ 87a Abs. 1 S. 2 AO n.F.). AdV-Antrag beim **Finanzgericht** (§ 69 Abs. 3 FGO): über beA (§ 52d FGO). Vor Versand `versand-vor-check` aus `kanzlei-cowork`.

--- a/steuerrecht-anwalt-und-berater/skills/anw-einspruch-finanzamt/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/anw-einspruch-finanzamt/SKILL.md
@@ -58,7 +58,7 @@ description: Entwirft begruendeten Einspruch gegen Steuerbescheid nach §§ 347 
 ### 1. Rubrum
 
 - Einspruchsführer (Steuerpflichtiger) mit Anschrift und Steuernummer.
-- Vertreter (RA mit ELSTER-Zugang als Bevollmaechtigter).
+- Vertreter (RA mit ELSTER-Zugang als Bevollmächtigter).
 - Empfangsfinanzamt mit Aktenzeichen / Steuernummer.
 - Bezug: Bescheid vom (Datum) über (Steuerart) (Veranlagungsjahr).
 
@@ -95,7 +95,7 @@ description: Entwirft begruendeten Einspruch gegen Steuerbescheid nach §§ 347 
 Finanzamt [Ort]
 [Anschrift]
 
-vorab per Telefax oder ELSTER (beA an Finanzamt seit 6.12.2024 unzulaessig, § 87a Abs. 1 S. 2 AO n.F.)
+vorab per Telefax oder ELSTER (beA an Finanzamt seit 6.12.2024 unzulässig, § 87a Abs. 1 S. 2 AO n.F.)
                                                                 [Ort], [Datum]
 
 Steuernummer: [SteuerNr]
@@ -157,5 +157,5 @@ Mit freundlichen Grüßen
 
 ## Versand
 
-Über **ELSTER** (Mein ELSTER — sicheres Verfahren der Finanzverwaltung) oder ERiC; alternativ Briefpost oder Telefax. **beA ist seit 6.12.2024 unzulaessig** gegenueber Finanzbehoerden (§ 87a Abs. 1 S. 2 AO n.F. nach JStG 2024) — Einspruch per beA waere formunwirksam und wuerde die Einspruchsfrist nicht wahren (Nds. FG 12.2.2026 – 2 K 152/25). Vor Versand `versand-vor-check` aus `kanzlei-cowork`.
+Über **ELSTER** (Mein ELSTER — sicheres Verfahren der Finanzverwaltung) oder ERiC; alternativ Briefpost oder Telefax. **beA ist seit 6.12.2024 unzulässig** gegenüber Finanzbehoerden (§ 87a Abs. 1 S. 2 AO n.F. nach JStG 2024) — Einspruch per beA wäre formunwirksam und würde die Einspruchsfrist nicht wahren (Nds. FG 12.2.2026 – 2 K 152/25). Vor Versand `versand-vor-check` aus `kanzlei-cowork`.
 Zitierweise nach `zitierweise-deutsches-recht` v3.0 (Az.-Marker, Hierarchie + Chronologie).

--- a/steuerrecht-anwalt-und-berater/skills/anw-kaltstart-interview/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/anw-kaltstart-interview/SKILL.md
@@ -53,7 +53,7 @@ description: "Kaltstart-Interview fuer die steuerrechtsanwaltliche Kanzlei. Erfr
 
 ### 6. Versandwege
 
-- **ELSTER / ERiC** Pflichtkanal **gegenueber Finanzbehoerden** seit JStG 2024 (§ 87a Abs. 1 S. 2 AO n.F., 6.12.2024) — Einspruch AdV-Antrag verbindliche Auskunft Selbstanzeige Akteneinsicht. beA an Finanzamt unzulaessig (Einspruch per beA formunwirksam, Nds. FG 12.2.2026 – 2 K 152/25).
+- **ELSTER / ERiC** Pflichtkanal **gegenueber Finanzbehoerden** seit JStG 2024 (§ 87a Abs. 1 S. 2 AO n.F., 6.12.2024) — Einspruch AdV-Antrag verbindliche Auskunft Selbstanzeige Akteneinsicht. beA an Finanzamt unzulässig (Einspruch per beA formunwirksam, Nds. FG 12.2.2026 – 2 K 152/25).
 - **beA** Pflicht **gegenueber Gerichten** (§ 52d FGO) — Klage Finanzgericht AdV-Antrag FG Revision BFH.
 - **EGVP** als Alternative zum beA gegenueber Gerichten.
 - **Briefpost / Telefax** weiterhin in alle Richtungen zulaessig (§ 87a AO bezieht sich nur auf elektronische Wege).

--- a/steuerrecht-anwalt-und-berater/skills/anw-klage-finanzgericht/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/anw-klage-finanzgericht/SKILL.md
@@ -31,7 +31,7 @@ description: Entwurf einer Klage zum Finanzgericht nach §§ 40 ff. FGO. Klagefr
 
 - Klagepartei mit Vertretung (RA mit beA-Adresse).
 - Beklagte: Finanzamt vertreten durch den Vorsteher.
-- Az der Einspruchsentscheidung und des urspruenglichen Bescheids.
+- Az der Einspruchsentscheidung und des ursprünglichen Bescheids.
 
 ### 2. Anträge
 

--- a/steuerrecht-anwalt-und-berater/skills/anw-selbstanzeige-371/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/anw-selbstanzeige-371/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: anw-selbstanzeige-371
-description: Selbstanzeige nach § 371 AO als strafbefreiende Berichtigung bei Steuerhinterziehung. Pruefraster Vollstaendigkeit aller unverjaehrten Steuerstraftaten binnen zehn Jahren (§ 376 AO ggf. 15 Jahre). Sperrgruende § 371 Abs. 2 AO. Nachentrichtung § 371 Abs. 3 AO mit Zinsen § 235 AO und gestaffeltem Zuschlag § 398a AO. Abgrenzung § 153 AO (Berichtigungspflicht — KEINE Strafbefreiung) zu § 371 AO (Vorsatz) und § 378 Abs. 3 AO (Leichtfertigkeit). Erzeugt Berichtigungserklaerung. Hoestrisikobereich — Pflichtpruefung mehrere Anwaelte.
+description: Selbstanzeige nach § 371 AO als strafbefreiende Berichtigung bei Steuerhinterziehung. Pruefraster Vollstaendigkeit aller unverjaehrten Steuerstraftaten binnen zehn Jahren (§ 376 AO ggf. 15 Jahre). Sperrgruende § 371 Abs. 2 AO. Nachentrichtung § 371 Abs. 3 AO mit Zinsen § 235 AO und gestaffeltem Zuschlag § 398a AO. Abgrenzung § 153 AO (Berichtigungspflicht — KEINE Strafbefreiung) zu § 371 AO (Vorsatz) und § 378 Abs. 3 AO (Leichtfertigkeit). Erzeugt Berichtigungserklaerung. Hoechstrisikobereich — Pflichtpruefung mehrere Anwaelte.
 ---
 
 # Selbstanzeige nach § 371 AO
@@ -96,7 +96,7 @@ Die Selbstanzeige ist **gesperrt**, wenn:
 ### 1. Rubrum
 
 - Steuerpflichtiger mit Anschrift und Steuernummer.
-- Vertretung (RA mit ELSTER-Zugang als Bevollmaechtigter).
+- Vertretung (RA mit ELSTER-Zugang als Bevollmächtigter).
 - Empfangsfinanzamt.
 
 ### 2. Erklärung
@@ -170,7 +170,7 @@ Mit freundlichen Grüßen
 1. **Schweigepflichtsentbindung** der Berater des Mandanten klären.
 2. **Vollständige Datenerhebung** in allen Steuerarten und Jahren — Vermögensaufstellung Depots ausländische Konten.
 3. **Doppelprüfung** durch zweiten qualifizierten Anwalt.
-4. **Selbstanzeige einreichen** über **ELSTER** (Mein ELSTER — Nachrichtenfunktion) an Finanzamt. Alternativ Briefpost oder Telefax. **beA an Finanzamt seit 6.12.2024 unzulaessig** (§ 87a Abs. 1 S. 2 AO n.F. nach JStG 2024) — eine Selbstanzeige per beA waere formunwirksam und wuerde die Sperrwirkung des § 371 Abs. 2 AO durch andere Wege moeglicherweise nicht durchbrechen koennen.
+4. **Selbstanzeige einreichen** über **ELSTER** (Mein ELSTER — Nachrichtenfunktion) an Finanzamt. Alternativ Briefpost oder Telefax. **beA an Finanzamt seit 6.12.2024 unzulässig** (§ 87a Abs. 1 S. 2 AO n.F. nach JStG 2024) — eine Selbstanzeige per beA wäre formunwirksam und würde die Sperrwirkung des § 371 Abs. 2 AO durch andere Wege möglicherweise nicht durchbrechen können.
 5. **Nachzahlung leisten** innerhalb der gesetzten Frist.
 
 ## Übergabe

--- a/steuerrecht-anwalt-und-berater/skills/anw-verbindliche-auskunft/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/anw-verbindliche-auskunft/SKILL.md
@@ -42,7 +42,7 @@ Vor der Verwirklichung eines noch nicht verwirklichten Sachverhalts (z. B. gepla
 ### 1. Rubrum
 
 - Antragsteller mit Steuernummer und Anschrift.
-- Vertretung (RA / StB mit ELSTER-Zugang als Bevollmaechtigter).
+- Vertretung (RA / StB mit ELSTER-Zugang als Bevollmächtigter).
 - Empfangsfinanzamt.
 
 ### 2. Antragsgegenstand
@@ -145,7 +145,7 @@ Präzise Fragen z. B.:
 
 ## Versand
 
-Über **ELSTER** (Mein ELSTER — Nachrichtenfunktion) an Finanzamt; alternativ Briefpost oder Telefax. **beA an Finanzamt seit 6.12.2024 unzulaessig** (§ 87a Abs. 1 S. 2 AO n.F. nach JStG 2024). Vor Versand `versand-vor-check` aus `kanzlei-cowork`.
+Über **ELSTER** (Mein ELSTER — Nachrichtenfunktion) an Finanzamt; alternativ Briefpost oder Telefax. **beA an Finanzamt seit 6.12.2024 unzulässig** (§ 87a Abs. 1 S. 2 AO n.F. nach JStG 2024). Vor Versand `versand-vor-check` aus `kanzlei-cowork`.
 
 ## Anschluss
 


### PR DESCRIPTION
## Stresstest steuerrecht-anwalt-und-berater (post v7.1.0)

Vollständiger Stresstest des konsolidierten Plugins. **12 von 13 Kategorien clean**, eine Kategorie mit Funden:

### Befund: Body-ASCII-Inkonsistenzen + 1 Tippfehler

Sonst durchgängig umlautierter Body enthielt vereinzelt noch ASCII-Schreibungen — wahrscheinlich Reste der Konsolidierung aus PR #64, die durch die früheren Umlauten-Patches durchgerutscht sind.

| Skill | Fix |
|---|---|
| anw-selbstanzeige-371 (Description) | `Hoestrisikobereich` → `Hoechstrisikobereich` |
| anw-akteneinsicht-steuerakte | `unzulaessig` → `unzulässig` |
| anw-aussetzung-vollziehung | `unzulaessig` → `unzulässig` |
| anw-einspruch-finanzamt | `unzulaessig`/`Bevollmaechtigter`/`waere`/`wuerde` → Umlaute |
| anw-kaltstart-interview | `unzulaessig` → `unzulässig` |
| anw-klage-finanzgericht | `urspruenglichen` → `ursprünglichen` |
| anw-selbstanzeige-371 (Body) | `Bevollmaechtigter`/`unzulaessig`/`waere`/`wuerde`/`koennen`/`moeglicherweise` → Umlaute |
| anw-verbindliche-auskunft | `Bevollmaechtigter`/`unzulaessig` → Umlaute |

**12 Änderungen in 7 Skills.** Frontmatter (anw-/fa- ASCII, stb- Umlaut) bleibt unverändert — entspricht dem Original-Konvent vor Konsolidierung.

### Stresstest-Vollergebnis (passed)

- ✓ Frontmatter `name == folder` (18 Skills)
- ✓ Plugin-Description ≤300, Skill-Descs ≤1024, kein `\d,\d`
- ✓ ELSTER/§ 87a AO konsistent in 7 Skills, beA-Verbot ggü Finanzamt, beA-Pflicht ggü FG (§ 52d FGO)
- ✓ § 153 AO als Berichtigungspflicht (KEIN Strafbefreiungsgrund), 3-Stufen-Bewertung dokumentiert
- ✓ DSGVO mit `Art.` (nicht `§`)
- ✓ FAO § 9 korrekt zitiert
- ✓ Keine stale Plugin-Pfade (alte Steuer-Plugins)
- ✓ Keine broken Cross-Refs (anw-/fa-/stb-Slugs)
- ✓ README + ASSET_INDEX Verweise korrekt
- ✓ Reform-Daten (JStG 2024, PostModG, WtcG, Nds. FG)
- ✓ ZIP-Build (51 Files, 96 KB)
- ✓ Validator: OK