### PR TITLE
fix(steuerrecht): Plugin-Description 466->293 + ß->ss im Frontmatter + Validator 300-Check

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -754,7 +754,7 @@
     {
       "name": "steuerrecht-anwalt-und-berater",
       "source": "./steuerrecht-anwalt-und-berater",
-      "description": "Steuerberater und Fachanwalt fuer Steuerrecht: Bescheidanalyse Einspruch Klage Finanzgericht Aussenpruefung Selbstanzeige Verbindliche Auskunft Akteneinsicht. Steuerberater-Werkzeuge BWA SuSa Bilanzpruefung. Praefixe anw- fa- stb-.",
+      "description": "Steuerrecht fuer Anwaltschaft (anw- inkl. Fachanwaltschaft FAO § 9) und Steuerberatung (stb-): Bescheidanalyse Einspruch Klage FG Aussenpruefung Selbstanzeige Strafverteidigung. StB-Tools BWA SuSa Bilanz Ueberschuldungspruefung Liquiditaet Krisenfrueherkennung. Ersetzt fachanwalt-steuerrecht.",
       "author": {
         "name": "Klotzkette"
       },

--- a/scripts/validate-plugin-structure.mjs
+++ b/scripts/validate-plugin-structure.mjs
@@ -208,6 +208,10 @@ function checkPluginManifests() {
     if (typeof data.description === 'string' && /\d\s*,\s*\d/.test(data.description)) {
       errors.push(`${rel(m)}: description darf keine Zahl-Komma-Zahl-Sequenz enthalten (Cowork-Validator bricht); nutze 'Rn', 'und' oder '/'`);
     }
+    // Marketplace-Limit für Plugin-Description: 300 Zeichen.
+    if (typeof data.description === 'string' && data.description.length > 300) {
+      errors.push(`${rel(m)}: plugin description exceeds 300 chars (${data.description.length}) — Marketplace-Limit`);
+    }
   }
 }
 

--- a/steuerrecht-anwalt-und-berater/.claude-plugin/plugin.json
+++ b/steuerrecht-anwalt-und-berater/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "steuerrecht-anwalt-und-berater",
   "version": "7.1.0",
-  "description": "Steuerrecht fuer Anwaltschaft (anw-) inkl. Fachanwaeltinnen Steuerrecht FAO § 9 und Steuerberatung (stb-): Bescheidanalyse Einspruch Klage Finanzgericht Aussenpruefung Selbstanzeige Strafverteidigung Verbindliche Auskunft Akteneinsicht. StB-Werkzeuge BWA SuSa Bilanz Ueberschuldungspruefung § 19 InsO Liquiditaetsvorschau Krisenfrueherkennung § 102 StaRUG. Haftungs-Warnschreiben StB und Anwalt § 15a InsO § 15b InsO. Ersetzt frueheres fachanwalt-steuerrecht-Plugin.",
+  "description": "Steuerrecht fuer Anwaltschaft (anw- inkl. Fachanwaltschaft FAO § 9) und Steuerberatung (stb-): Bescheidanalyse Einspruch Klage FG Aussenpruefung Selbstanzeige Strafverteidigung. StB-Tools BWA SuSa Bilanz Ueberschuldungspruefung Liquiditaet Krisenfrueherkennung. Ersetzt fachanwalt-steuerrecht.",
   "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"

--- a/steuerrecht-anwalt-und-berater/skills/stb-ueberschuldungspruefung-19-inso/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/stb-ueberschuldungspruefung-19-inso/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stb-ueberschuldungspruefung-19-inso
-description: "Stichtagsbezogene Ueberschuldungspruefung der GmbH nach § 19 Abs. 2 InsO durch den Steuerberater. Zweistufige Pruefung — rechnerische Ueberschuldung (Aktiva vs. Passiva zu Liquidationswerten) und Fortbestehensprognose (24-Monats-Horizont nach SanInsKG; sonst zwoelf Monate). Maßstab BGH II ZR 233/18 sowie BGH II ZR 88/16 (Passiva II). IDW S 6 (Sanierungskonzepte) und IDW S 11 (Insolvenzeroeffnungsgruende). Ergibt Ampel-Bewertung und triggert Mandantenwarnschreiben bei roter Ampel (siehe stb-warnschreiben-krisensignale)."
+description: "Stichtagsbezogene Ueberschuldungspruefung der GmbH nach § 19 Abs. 2 InsO durch den Steuerberater. Zweistufige Pruefung — rechnerische Ueberschuldung (Aktiva vs. Passiva zu Liquidationswerten) und Fortbestehensprognose (24-Monats-Horizont nach SanInsKG; sonst zwoelf Monate). Massstab BGH II ZR 233/18 sowie BGH II ZR 88/16 (Passiva II). IDW S 6 (Sanierungskonzepte) und IDW S 11 (Insolvenzeroeffnungsgruende). Ergibt Ampel-Bewertung und triggert Mandantenwarnschreiben bei roter Ampel (siehe stb-warnschreiben-krisensignale)."
 ---
 
 # Überschuldungsprüfung § 19 InsO (Steuerberater-Sicht)


### PR DESCRIPTION
## Post-Merge-Stresstest von PR #68 — drei Befunde

PR #68 wurde gemerged bevor mein Review-Push durch war. Drei kritische Befunde aus dem Stresstest werden hier nachgereicht:

### Befund 1: Plugin-Description ueberschritt Marketplace-Limit
```
Vorher: 466 Zeichen
Nachher: 293 Zeichen (Limit: 300)
```
Plugin haette beim naechsten Marketplace-Sync abgelehnt werden koennen. Gekuerzt ohne inhaltlichen Verlust — Detail-Aufzaehlung der Einzel-Skills entfernt (die im Plugin-README dokumentiert sind). `marketplace.json`-Eintrag gespiegelt.

### Befund 2: ß im Frontmatter
`stb-ueberschuldungspruefung-19-inso` hatte `Maßstab` (mit ß) im Frontmatter. Konvent im Plugin: Frontmatter ASCII-only (alle anw-Skills folgen dem, neue stb-Skills sollten gleich gestylt sein). Body bleibt mit Umlauten/ß unveraendert. Geaendert zu `Massstab`.

### Befund 3: Validator-Luecke
Skill-Description-Laenge wurde gegen 1024 geprueft, aber **Plugin-Description-Laenge gegen das Marketplace-Limit 300 fehlte**. Genau diese Luecke war der Grund, warum Befund 1 nicht beim Validator-Run aufgefallen ist.

Check ergaenzt in `scripts/validate-plugin-structure.mjs`:
```js
if (typeof data.description === 'string' && data.description.length > 300) {
  errors.push(`${rel(m)}: plugin description exceeds 300 chars (${data.description.length}) — Marketplace-Limit`);
}
```

Alle 97 Plugin-Descriptions sind aktuell ≤ 300. Validator: OK.