### PR TITLE
feat(steuerrecht): anw-insolvenzreife-Skill + StB-Eigenpflicht § 102 StaRUG

### DIFF
--- a/steuerrecht-anwalt-und-berater/README.md
+++ b/steuerrecht-anwalt-und-berater/README.md
@@ -42,6 +42,7 @@ Skills für steuerrechtliche Anwaltskanzleien — streitbezogene Folgebearbeitun
 | `/steuerrecht-anwalt-und-berater:anw-selbstanzeige-371` | Selbstanzeige § 371 AO — Hochrisikobereich, Pflichtprüfung mehrere Anwälte |
 | `/steuerrecht-anwalt-und-berater:anw-steuerstrafverteidigung-verstaendigung` | Strafverteidigung Steuerstrafsache (§§ 369 ff. AO) mit Einstellung § 153a StPO und Verständigung § 257c StPO — **NEU** |
 | `/steuerrecht-anwalt-und-berater:anw-haftungswarn-15a-inso-mandant` | Anwaltliche Belehrung GF bei Insolvenzreife (§ 15a InsO, § 15b InsO) — Schreibvorlage mit Eingangsbestätigung — **NEU** |
+| `/steuerrecht-anwalt-und-berater:anw-insolvenzreife-pruefung-17-19-inso` | Anwaltliche Insolvenzreife-Prüfung §§ 17, 19 InsO mit steuerspezifischem Schwerpunkt (§ 222 AO Stundung, § 361 AO AdV, § 69 AO GF-Haftung, § 266a StGB) — **NEU** |
 | `/steuerrecht-anwalt-und-berater:anw-verbindliche-auskunft` | Verbindliche Auskunft § 89 Abs. 2 AO |
 | `/steuerrecht-anwalt-und-berater:anw-fristenbuch-steuerrecht` | Fristenbuch: Einspruchsfrist, Klagefrist, Vorfristen |
 | `/steuerrecht-anwalt-und-berater:anw-betriebsausgaben-werbungskosten-pruefraster` | Prüfraster Betriebsausgaben/Werbungskosten § 4 Abs. 4 / § 9 EStG |
@@ -70,7 +71,7 @@ Skills für Steuerberater und GmbH-Geschäftsleitung — BWA-/SuSa-/Bilanzprüfu
 | `/steuerrecht-anwalt-und-berater:stb-ueberschuldungspruefung-19-inso` | Stichtagsbezogene Überschuldungsprüfung § 19 InsO mit Fortführungsprognose nach IDW S 6/S 11 — **NEU** |
 | `/steuerrecht-anwalt-und-berater:stb-warnschreiben-krisensignale` | Warnschreiben StB an Mandant-GF bei Krisensignalen — Pflichthinweis nach BGH IX ZR 285/14 zur eigenen Haftungsvermeidung — **NEU** |
 
-> **Haftungsvermeidungs-Workflow Steuerberater:** `stb-bwa-sus-bilanz-pruefung` identifiziert Krisensignale → `stb-ueberschuldungspruefung-19-inso` und `stb-liquiditaetsvorschau-3wochen` quantifizieren → bei gelber/roter Ampel triggert `stb-warnschreiben-krisensignale` das schriftliche Mandanten-Warnschreiben mit Empfehlung anwaltlicher Beratung. Der Anwalt kann dann mit `anw-haftungswarn-15a-inso-mandant` die rechtliche Beratung des GF dokumentieren.
+> **Haftungsvermeidungs-Workflow Steuerberater:** `stb-bwa-sus-bilanz-pruefung` identifiziert Krisensignale → `stb-ueberschuldungspruefung-19-inso` und `stb-liquiditaetsvorschau-3wochen` quantifizieren → bei gelber/roter Ampel triggert `stb-warnschreiben-krisensignale` das schriftliche Mandanten-Warnschreiben mit Empfehlung anwaltlicher Beratung. Hintergrund: Der Steuerberater ist nach BGH IX ZR 285/14 und § 102 StaRUG regelmäßig externer Bestandteil des Krisenfrüherkennungssystems der Mandantin — ohne seinen Hinweis kann die GF ihre eigene § 102 StaRUG-Pflicht nicht erfüllen. Der Anwalt kann dann über `anw-insolvenzreife-pruefung-17-19-inso` die rechtliche Beurteilung leisten und mit `anw-haftungswarn-15a-inso-mandant` die GF-Belehrung dokumentieren.
 
 > **Power-Plugin Liquidität:** Die vollständige Power-Version der Liquiditätsvorschau (BGH-Schema Passiva II, Excel-Vorlage, HTML-Padlet, insolvenzrechtliche Stichtagsbilanz) lebt im Plugin [`liquiditaetsplanung`](../liquiditaetsplanung/). Die `stb-`-Skills hier sind die Steuerberater-Sicht zur Krisenfrüherkennung und triggern die Power-Version bei tiefergehender Begutachtung.
 

--- a/steuerrecht-anwalt-und-berater/skills/anw-insolvenzreife-pruefung-17-19-inso/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/anw-insolvenzreife-pruefung-17-19-inso/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: anw-insolvenzreife-pruefung-17-19-inso
+description: "Anwaltliche Pruefung der Insolvenzreife einer GmbH/UG aus Steueranwalts-Sicht. Erstellt strukturiertes Pruefgutachten zu Zahlungsunfaehigkeit § 17 InsO (10-Prozent-/3-Wochen-Schema BGH IX ZB 50/03) und Ueberschuldung § 19 InsO (zweistufig nach IDW S 11 mit Fortbestehensprognose 24 Monate SanInsKG). Steuerspezifischer Schwerpunkt — wie Steuerschulden Lohnsteuer Umsatzsteuer Sozialversicherungsabgaben als Passiva I einzustellen sind und wie AdV nach § 361 AO bzw. Stundung § 222 AO die Faelligkeit beeinflusst. Trigger bei Mandant-GF einer Krisengesellschaft mit Steuerrueckstaenden. Endet mit Antragspflicht-Bewertung § 15a InsO und Belehrungs-Anschluss an anw-haftungswarn-15a-inso-mandant."
+---
+
+# Anwaltliche Insolvenzreife-Prüfung §§ 17, 19 InsO (Steueranwalts-Sicht)
+
+## Zweck
+
+Strukturiertes **anwaltliches Prüfgutachten** zur Insolvenzreife einer GmbH/UG, wenn der Steueranwalt im Mandat — typisch bei Einspruchsverfahren mit hohen Steuerrückständen, Selbstanzeige-Mandat oder AdV-Lage — erkennt, dass die Gesellschaft möglicherweise zahlungsunfähig oder überschuldet ist.
+
+Im Gegensatz zum StB-Skill `stb-ueberschuldungspruefung-19-inso` (technische Indikation mit Ampel als Grundlage für den Mandantenhinweis) liefert dieser Skill die **vollständige rechtliche Beurteilung** mit Subsumtion, Beweiswürdigung und unmittelbarer Antragspflicht-Bewertung.
+
+> ℹ️ **Abgrenzung Steueranwalt vs. Fachanwalt Insolvenzrecht:** Der Steueranwalt kann die Insolvenzreife rechtlich beurteilen und den Mandanten belehren (§ 3 BRAO, kein Vorbehalt für Fachanwalt). Für gerichtsfeste insolvenzrechtliche Sanierungsbegleitung, Schutzschirmverfahren (§ 270b InsO), StaRUG-Restrukturierungsplan oder Insolvenzantragstellung **Übergabe an Fachanwalt Insolvenz-/Sanierungsrecht** empfehlen. Das Power-Plugin `insolvenzrecht` (insbesondere `ueberschuldung-pruefung-19-inso`, `zahlungsunfaehigkeit-pruefung-17-inso`, `antragspflicht-15a-inso`) ist hier die fachliche Vertiefung.
+
+## Kaltstart-Rückfragen
+
+1. Welche Gesellschaftsform (GmbH, UG, AG, GmbH & Co. KG) — und wer ist antragspflichtig (§ 15a Abs. 1 vs. Abs. 2 InsO)?
+2. Stichtag der Prüfung (heutiger Tag, oder rückwirkend ab erkennbarem Krisensignal)?
+3. Bestehen aktuell Stundungsanträge oder AdV-Verfügungen für Steuerschulden? Wenn ja, welche Beträge und welche Bescheide?
+4. Liegen ungezahlte Lohnsteuer- oder Sozialversicherungsabgaben vor (Sonderfall — § 266a StGB zusätzlich relevant)?
+5. Aktuelle Liquiditätslage — kann die Gesellschaft die fälligen Verbindlichkeiten in den nächsten drei Wochen bedienen?
+6. Existieren Sanierungskonzept, Rangrücktrittserklärungen, Gesellschafterdarlehen, Patronate?
+7. Wurde durch Steuerberater oder Sanierungsberater bereits eine § 19 InsO-Prüfung durchgeführt? Wenn ja, mit welchem Ergebnis?
+
+## Rechtlicher Rahmen
+
+### Primärnormen
+
+- **§ 17 InsO** — Zahlungsunfähigkeit als Eröffnungsgrund: Schuldner nicht in der Lage, fällige Zahlungspflichten zu erfüllen. Vermutung bei Zahlungseinstellung (§ 17 Abs. 2 S. 2 InsO).
+- **§ 18 InsO** — Drohende Zahlungsunfähigkeit (nur bei Eigenantrag; ergibt Eigenantragsoption mit § 270b InsO Schutzschirm).
+- **§ 19 InsO** — Überschuldung: Vermögen deckt die bestehenden Verbindlichkeiten nicht, **es sei denn** Fortführung des Unternehmens ist nach den Umständen überwiegend wahrscheinlich.
+- **§ 19 Abs. 2 S. 1 InsO i.V.m. SanInsKG** — Prognosezeitraum 24 Monate für Anträge bis 31.12.2026.
+- **§ 15a Abs. 1 S. 1 InsO** — Antragspflicht GF/Liquidator: drei Wochen ab Zahlungsunfähigkeit, sechs Wochen ab Überschuldung.
+- **§ 15a Abs. 4 InsO** — Strafbarkeit der Insolvenzverschleppung (Freiheitsstrafe bis drei Jahre).
+- **§ 15b InsO** — Zahlungsverbote nach Eintritt der Insolvenzreife (löste § 64 GmbHG a.F. ab; SanInsFoG, 1.1.2021).
+
+### Steuer-spezifische Normen
+
+- **§ 222 AO** — Stundung von Steuerforderungen. **Wirkung auf Insolvenzreife:** Eine schriftlich bewilligte Stundung schiebt die Fälligkeit hinaus — entsprechend nicht als fällige Verbindlichkeit in den Liquiditätsstatus einzustellen. Mündliche Zusagen oder bloße Anträge ohne Bescheid genügen **nicht**.
+- **§ 361 AO** — Aussetzung der Vollziehung. **Wirkung:** Die Vollziehung wird gehemmt, die Steuerforderung bleibt aber materiell bestehen und entsteht. Im Liquiditätsstatus bleibt sie als Passivum I berücksichtigungspflichtig, soweit die AdV nicht zur Fälligkeitsverschiebung führt. Bei AdV mit Sicherheitsleistung ist die Liquiditätswirkung zusätzlich von der Sicherheitsleistung mitbeeinflusst.
+- **§ 226 AO i.V.m. § 387 BGB** — Aufrechnung im Steuerrecht. Vorsteuerguthaben können gegen Steuerforderungen aufgerechnet werden, im Insolvenznähebereich aber Anfechtungsrisiko nach §§ 129 ff. InsO.
+- **§ 69 AO** — Haftung des Geschäftsführers für Steuerschulden der Gesellschaft. Bleibt nach Eröffnung des Insolvenzverfahrens bestehen, ggf. zusätzlich zu § 15b InsO-Haftung.
+- **§ 266a Abs. 1 StGB** — Vorenthalten von Arbeitnehmer-Anteilen zur Sozialversicherung. **Strafbar** bereits bei Nichtabführung am Fälligkeitstag; trifft GF persönlich; Tatbestandsverwirklichung schon vor Insolvenzantragspflicht denkbar.
+- **§ 41a EStG** — Lohnsteueranmeldung und -abführung. Anmeldungspflicht bleibt auch in der Krise; Nichtabführung führt zur GF-Haftung nach § 69 AO und ggf. § 370 AO (Steuerhinterziehung).
+
+### Leitentscheidungen
+
+- BGH, Beschl. v. 19.7.2007 — **IX ZB 50/03**, BGHZ 173, 286 (Zahlungsunfähigkeit: 10-Prozent-Schwelle der fälligen Verbindlichkeiten; nicht erfüllt für Dauer von **3 Wochen** zum Stichtag).
+- BGH, Urt. v. 24.5.2005 — **IX ZR 123/04**, BGHZ 163, 134 (Zahlungseinstellung; auch ein einzelner gewichtiger Indizfall genügt; Forderungen der Sozialkasse besonders gewichtig).
+- BGH, Urt. v. 19.11.2019 — **II ZR 233/18**, NJW 2020, 1809 (Fortbestehensprognose: tragfähiges Unternehmenskonzept plus Finanzplan; Maßstab überwiegende Wahrscheinlichkeit).
+- BGH, Urt. v. 19.12.2017 — **II ZR 88/16**, BGHZ 217, 129 (Passiva II — verzahnt mit Liquiditätsprognose).
+- BGH, Urt. v. 9.10.2012 — **II ZR 298/11**, BGHZ 195, 42 (insolvenzrechtliche Überschuldung; Abgrenzung handelsbilanziell vs. insolvenzrechtlich).
+- BFH, Urt. v. 14.6.2016 — **VII R 24/15**, BStBl. II 2017, 88 (Haftung GF § 69 AO für Lohnsteuer in der Krise; Grundsatz anteiliger Tilgung).
+- BGH, Urt. v. 14.5.2020 — **IX ZR 207/18** (Anfechtung von Steuerzahlungen; § 130 Abs. 1 InsO bei Kenntnis der Zahlungsunfähigkeit).
+
+### Berufsständischer Hintergrund
+
+- **IDW S 11** (Beurteilung des Vorliegens von Insolvenzeröffnungsgründen, Stand 12.8.2021).
+- **IDW S 6** (Anforderungen an Sanierungskonzepte).
+
+## Prüfung Zahlungsunfähigkeit § 17 InsO
+
+### Schritt 1 — Liquiditätsstatus zum Stichtag
+
+| Aktiva I (sofort verfügbar) | Betrag |
+|---|---|
+| Kasse, Bankguthaben (Saldo nach Aufrechnung Kontokorrentlinie) | … EUR |
+| Bestehende Kreditlinien (Stand zum Stichtag, abzüglich gesperrter Beträge) | … EUR |
+| Fällige, unbestrittene Forderungen mit Eingangserwartung 14 Tage | … EUR |
+
+| Passiva I (fällig zum Stichtag) | Betrag |
+|---|---|
+| Verbindlichkeiten LuL — fällig | … EUR |
+| Lohn und Gehalt — laufende Periode | … EUR |
+| Sozialversicherungsabgaben — fällig (Drittelung Arbeitnehmer-/Arbeitgeber-Anteil dokumentieren) | … EUR |
+| Lohnsteuer und Solidaritätszuschlag — fällig nach § 41a EStG | … EUR |
+| Umsatzsteuer — fällig laut Voranmeldung | … EUR |
+| Sonstige Steuerverbindlichkeiten (ESt, KSt, GewSt) — fällig **abzüglich** schriftlich bewilligter Stundungen § 222 AO und AdV § 361 AO | … EUR |
+| Kreditraten und Zinsen — fällig | … EUR |
+| Sonstige fällige Verbindlichkeiten | … EUR |
+
+**Deckungslücke = Passiva I − Aktiva I.**
+
+### Schritt 2 — BGH-Schema anwenden
+
+| Deckungslücke | Klassifikation | Rechtsfolge |
+|---|---|---|
+| < 10 Prozent der Passiva I | **Zahlungsstockung** | Keine Zahlungsunfähigkeit, soweit Beseitigung binnen drei Wochen überwiegend wahrscheinlich |
+| ≥ 10 Prozent, beseitigbar binnen drei Wochen | **Zahlungsstockung** | Keine Zahlungsunfähigkeit, aber Liquiditätsplan dokumentieren |
+| ≥ 10 Prozent, **nicht** beseitigbar binnen drei Wochen | **Zahlungsunfähigkeit § 17 InsO** | **Antragspflicht GF binnen drei Wochen** |
+
+### Schritt 3 — Beweiswürdigung Zahlungseinstellung
+
+Auch ohne rechnerische Deckungslücke kann **Zahlungseinstellung** (§ 17 Abs. 2 S. 2 InsO) vorliegen. Indizien (BGH IX ZR 123/04):
+
+- Schleppende oder ausbleibende Sozialversicherungsabgaben über zwei und mehr Monate (besonders gewichtig).
+- Wiederholte Stundungsanträge oder Vollstreckungsabwehr Finanzamt.
+- Lohnzahlungen nur noch Teil-/Verspätet.
+- Lieferantenanforderungen nur gegen Vorkasse.
+- Kreditkündigungen oder Sperrungen.
+- Eigene Erklärung GF gegenüber Dritten, nicht mehr zahlen zu können.
+
+Bereits **ein** gewichtiges Indiz kann genügen, wenn nicht widerlegt.
+
+## Prüfung Überschuldung § 19 InsO
+
+### Stufe 1 — Fortbestehensprognose (Primärprüfung nach IDW S 11)
+
+Reihenfolge: **Erst Prognose, dann Status.** Bei positiver Prognose ist § 19 InsO ausgeschlossen.
+
+Voraussetzungen für positive Prognose:
+
+1. **Tragfähiges Unternehmenskonzept** (IDW S 6).
+2. **Integrierte Planung** über 24 Monate (Ertrag, Liquidität, Bilanz).
+3. **Überwiegende Wahrscheinlichkeit** (mehr als 50 Prozent), dass das Unternehmen seine fälligen Zahlungspflichten im Prognosezeitraum erfüllen kann.
+
+→ Bei negativer Prognose: Stufe 2 zwingend.
+
+Methodische Tiefe für die anwaltliche Begutachtung der Prognose siehe `insolvenzrecht/skills/ueberschuldung-pruefung-19-inso` und `fortbestehensprognose` (Power-Plugin) — dort gerichtsfest aufgebaut.
+
+### Stufe 2 — Rechnerische Überschuldung (Liquidationswerte)
+
+Bilanz wird zu Liquidationswerten umbewertet. Detail-Methode wie in `stb-ueberschuldungspruefung-19-inso`.
+
+**Steuerspezifische Besonderheiten der Passiva-Seite:**
+
+- **Steuerrückstände FA:** Nennwert anzusetzen, auch bei AdV (die AdV hemmt nur die Vollziehung, lässt die Forderung materiell bestehen). Bei schriftlicher Stundung § 222 AO mit Laufzeit **nach** dem Bewertungsstichtag entsprechend Bilanzierungsregel.
+- **Lohnsteuer und SV-Abgaben:** immer mit Nennwert, **keine** Aufrechnung mit Vorsteuerguthaben möglich (BGH-Anfechtungsrisiko).
+- **Vorsteuerguthaben:** als Aktivum (Forderung gegen FA) mit Realisierungswahrscheinlichkeit; Bedingung: kein Anfechtungstatbestand § 130, § 142 InsO.
+- **Gesellschafterdarlehen mit qualifiziertem Rangrücktritt** (§ 19 Abs. 2 S. 3 InsO): **nicht** anzusetzen. Klausel-Prüfung Pflicht — qualifiziert heißt: Rangrücktritt bis zur Beseitigung der Krise und nur aus freiem Vermögen rückzahlbar.
+
+## Wechselwirkung Antragspflicht § 15a InsO
+
+| § 17 | § 19 (Stufe 1 + 2) | Frist § 15a InsO | Hinweis |
+|---|---|---|---|
+| Zahlungsunfähig | (irrelevant) | **drei Wochen** ab Eintritt | Strafbarkeit § 15a Abs. 4 InsO; Belehrung Pflicht |
+| Nicht zahlungsunfähig | Überschuldet | **sechs Wochen** ab Eintritt | dito |
+| Zahlungsunfähig **und** überschuldet | beide | **drei Wochen** (kürzere greift) | dito |
+| Nur Krisenindikatoren, beide negativ | beide negativ | keine Frist | Beobachtungspflicht § 102 StaRUG |
+
+**Beachte:** Bei juristischen Personen ist die Antragspflicht des § 15a InsO auch bei drohender Zahlungsunfähigkeit (§ 18 InsO) **nicht** Pflicht — § 18 InsO ist **Eigenantragsoption** (mit Schutzschirm § 270b InsO oder StaRUG-Restrukturierung als Alternative).
+
+## Ergebnis-Klassifikation und Anschluss
+
+| Ergebnis | Folge im Mandat |
+|---|---|
+| Beide negativ | Krisenfrüherkennung dokumentieren (§ 102 StaRUG), Wiedervorlage 4 Wochen |
+| § 18 InsO drohende Zahlungsunfähigkeit | Schutzschirmverfahren § 270b InsO oder StaRUG-Restrukturierung prüfen — **Übergabe Fachanwalt Insolvenzrecht** |
+| § 17 InsO | **Sofortige** Belehrung GF (drei Wochen Frist) — `anw-haftungswarn-15a-inso-mandant` ausführen |
+| § 19 InsO | **Sofortige** Belehrung GF (sechs Wochen Frist) — `anw-haftungswarn-15a-inso-mandant` ausführen |
+| Beide | Belehrung mit dreiwöchiger Frist; gleichzeitig steuerstrafrechtliche Sonderlagen prüfen (§ 266a StGB, § 370 AO bei Lohnsteuer-Nichtabführung) |
+
+## Steuer-spezifische Sonderlagen
+
+### AdV nach § 361 AO und Insolvenzreife
+
+Eine erfolgreich gewährte AdV verschiebt die Vollziehung, nicht die Fälligkeit der materiellen Steuerforderung. Im Liquiditätsstatus § 17 InsO: **AdV-Beträge bleiben Passiva I**, sofern nicht zugleich eine Stundung § 222 AO mit Fälligkeitsverschiebung bewilligt ist. Anders herum: die AdV verhindert die Vollstreckung, beseitigt aber **nicht** den Insolvenzgrund. Mandant darauf hinweisen, dass eine AdV den Insolvenzantrag nicht abwendet.
+
+### Stundung § 222 AO und Insolvenzreife
+
+Schriftlich bewilligte Stundungsbescheide mit Fälligkeitstermin nach dem Bewertungsstichtag dürfen aus Passiva I herausgenommen werden — soweit die Stundung sicher gewährt und nicht widerruflich ist. **Mündliche Zusagen oder bloße Anträge ohne Bescheid genügen nicht** und sind voll als fällig zu führen.
+
+### Lohnsteuer und Sozialversicherungsabgaben in der Krise
+
+Auch bei Liquiditätsengpässen müssen Lohnsteuer und SV-Beiträge **vorrangig** bedient werden — sonst:
+
+- **§ 69 AO** GF-Haftung für Lohnsteuer (anteilige Tilgungsregel BFH VII R 24/15).
+- **§ 266a StGB** Strafbarkeit für vorenthaltene Arbeitnehmer-Anteile zur Sozialversicherung.
+- Bei späterer Insolvenz: Anfechtungsrisiko der Sozialkasse nach § 130 InsO ist gering (BGH erkennt Sozialkasse als bevorrechtigt im Krisenkontext).
+
+### Selbstanzeige und Insolvenzreife — Konfliktlage
+
+Ist der Mandant zugleich in Verhandlung über Selbstanzeige (§ 371 AO) und Insolvenzreife absehbar:
+
+- Selbstanzeige **vor** Insolvenzantrag wirkt als strafbefreiend (sofern Nachzahlung trotz Insolvenz binnen Frist § 371 Abs. 3 AO möglich).
+- Insolvenzanmeldung des FA als Sperrgrund § 371 Abs. 2 Nr. 1 AO prüfen.
+- Detail-Workflow `anw-selbstanzeige-371` und `anw-steuerstrafverteidigung-verstaendigung`.
+
+## Versand und Dokumentation
+
+- Internes Prüfgutachten zu Akte (datiert, mit Datengrundlage).
+- Bei festgestellter Insolvenzreife: Anwaltliches Belehrungsschreiben über `anw-haftungswarn-15a-inso-mandant` — schriftlich, mit Empfangsbestätigung (Einschreiben mit Rückschein oder beA an Mandantenvertretung; **kein ELSTER**, da nicht Empfänger Finanzbehörde).
+- Aktenvermerk Mandantengespräch über § 15a InsO-Belehrung mit Datum und ggf. Zeugen.
+
+## Querverweise
+
+### Innerhalb Steuer-Plugin
+
+- `stb-bwa-sus-bilanz-pruefung` — vorgelagerte Auswertung (StB-Seite).
+- `stb-ueberschuldungspruefung-19-inso` — StB-technische Indikation; löst diesen Anwalts-Skill aus, wenn Mandant zum Steueranwalt kommt.
+- `stb-liquiditaetsvorschau-3wochen` — Datengrundlage § 17 InsO.
+- `anw-haftungswarn-15a-inso-mandant` — nachgelagerte anwaltliche Belehrung GF.
+- `anw-aussetzung-vollziehung` — Wechselwirkung AdV mit Insolvenzreife.
+- `anw-selbstanzeige-371` — Konfliktlage Selbstanzeige und Insolvenz.
+
+### Power-Plugins (fachliche Vertiefung — Übergabe-Empfehlung)
+
+- `insolvenzrecht/skills/ueberschuldung-pruefung-19-inso` — gerichtsfeste insolvenzrechtliche Prüfung Stufe 1 plus Stufe 2.
+- `insolvenzrecht/skills/zahlungsunfaehigkeit-pruefung-17-inso` — vollständiges § 17 InsO-Gutachten.
+- `insolvenzrecht/skills/antragspflicht-15a-inso` — vertiefte § 15a InsO-Antragspflicht- und Verschleppungs-Analyse.
+- `fortbestehensprognose` — separates Power-Plugin: IDW S 6/S 11-konforme Prognose mit Kaltstart bis Zusammenführung.
+- `krisenfrueherkennung-starug` — § 102 StaRUG Krisenfrüherkennung und Hinweispflichten.
+- `liquiditaetsplanung/skills/liquiditaetsvorschau-insolvenzrechtlich` — gerichtsfeste insolvenzrechtliche Liquiditätsbilanz BGH-Passiva-II-Schema.
+- `fachanwalt-insolvenz-sanierungsrecht` — Übergabe für Fachanwalt-Tätigkeit (Schutzschirm, Antragstellung, Plan).
+
+## Quellen und Updates
+
+Stand: 05/2026. Maßgebliche Reformen berücksichtigt: SanInsKG (24-Monats-Prognose bis 31.12.2026), SanInsFoG (§ 15b InsO statt § 64 GmbHG a.F.), JStG 2024 (§ 87a Abs. 1 S. 2 AO n.F. — ELSTER-Pflicht gegenüber Finanzbehörde). Bei Verlängerung oder Auslaufen des SanInsKG ab 1.1.2027 Prognosezeitraum-Default zurück auf 12 Monate — bitte Stichtag prüfen.

--- a/steuerrecht-anwalt-und-berater/skills/stb-warnschreiben-krisensignale/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/stb-warnschreiben-krisensignale/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stb-warnschreiben-krisensignale
-description: Schreibvorlage Steuerberater an Mandanten-Geschaeftsfuehrung bei Krisensignalen aus Bilanz BWA SuSa Liquiditaet. Pflichthinweis nach BGH IX ZR 285/14 und IX ZR 64/12 (Steuerberater-Hinweispflicht bei erkennbarer Krise) zur eigenen Haftungsvermeidung. Klare Bezugnahme auf § 15a InsO Antragspflicht (3 Wochen Zahlungsunfaehigkeit 6 Wochen Ueberschuldung) und § 102 StaRUG Krisenfrueherkennung. Empfehlung anwaltlicher Beratung. Keine eigene Rechtsberatung (§ 5 RDG). Eingangsbestaetigung dokumentiert.
+description: Schreibvorlage Steuerberater an Mandanten-Geschaeftsfuehrung bei Krisensignalen aus Bilanz BWA SuSa Liquiditaet. Pflichthinweis nach BGH IX ZR 285/14 IX ZR 64/12 IX ZR 104/18 IX ZR 70/07 (Steuerberater-Hinweispflicht bei erkennbarer Krise) zur eigenen Haftungsvermeidung. Steuerberater ist regelmaessig externer Bestandteil des Krisenfrueherkennungssystems der Mandantin nach § 102 StaRUG — ohne seinen Hinweis kann die Geschaeftsleitung ihrer eigenen Pflicht nicht nachkommen. Bezug § 15a InsO Antragspflicht (drei Wochen Zahlungsunfaehigkeit sechs Wochen Ueberschuldung). Empfehlung anwaltlicher Beratung. Keine eigene Rechtsberatung (§ 5 RDG). Eingangsbestaetigung dokumentiert.
 ---
 
 # Warnschreiben Steuerberater an Mandant bei Krisensignalen
@@ -10,6 +10,12 @@ description: Schreibvorlage Steuerberater an Mandanten-Geschaeftsfuehrung bei Kr
 Dieser Skill erstellt das **schriftliche Warnschreiben** des Steuerberaters an die Geschäftsführung einer GmbH/UG, wenn aus der laufenden Buchhaltungsbetreuung Krisensignale erkennbar werden — typisch im Anschluss an `stb-bwa-sus-bilanz-pruefung`, `stb-ueberschuldungspruefung-19-inso` oder `stb-liquiditaetsvorschau-3wochen` mit gelber oder roter Ampel.
 
 > Der Hinweis ist **keine Rechtsberatung** (§ 5 RDG). Er erfüllt die **Sorgfaltspflicht des Steuerberaters** nach BGH IX ZR 285/14 und IX ZR 64/12 — wer Krisensignale erkennt und nicht hinweist, haftet für die Verschleppungsschäden.
+
+### Warum gerade der Steuerberater
+
+Der Steuerberater ist in der Mandatsbetreuung in der Regel **derjenige Berater, der laufend über die wirtschaftlichen Verhältnisse der Mandantin informiert ist** — durch monatliche BWA, SuSa-Auswertungen, Lohnsteuer- und Umsatzsteuer-Voranmeldungen, Bilanzaufstellung und ggf. Liquiditätsplanung. Damit ist er **strukturell der erste**, der Krisensignale erkennt — oft Wochen oder Monate vor dem anwaltlichen Berater.
+
+Die Geschäftsleitung haftungsbeschränkter Gesellschaften ist nach **§ 102 StaRUG** verpflichtet, bestandsgefährdende Entwicklungen früh zu erkennen und Gegenmaßnahmen einzuleiten. Der Steuerberater ist regelmäßig der zentrale **externe Informationsgeber** dieses Krisenfrüherkennungssystems — ohne seinen Hinweis kann die GF ihrer eigenen § 102 StaRUG-Pflicht oft nicht nachkommen. Aus dieser tatsächlichen Schlüsselstellung folgt nach ständiger BGH-Rechtsprechung (IX ZR 285/14, IX ZR 64/12, IX ZR 104/18) die **eigene Hinweispflicht** des Steuerberaters bei erkennbaren Krisensignalen. Ihr Verletzen führt zu eigener Haftung für Verschleppungsschäden.
 
 ## Eingaben
 
@@ -28,21 +34,31 @@ Dieser Skill erstellt das **schriftliche Warnschreiben** des Steuerberaters an d
 - **§ 5 RDG** — Nebenleistungspflicht: rechtliche Hinweise sind zulässig, soweit sie zur Erfüllung der steuerberatenden Hauptleistung gehören. **Keine eigene Rechtsberatung** zur Insolvenzantragspflicht — Empfehlung anwaltlicher Beratung ist Pflichtbestandteil.
 - **§ 15a Abs. 1 InsO** — Insolvenzantragspflicht der GmbH-Geschäftsführung: bei Zahlungsunfähigkeit **drei Wochen**, bei Überschuldung **sechs Wochen** ab Eintritt.
 - **§ 15b InsO** — Zahlungsverbote nach Insolvenzreife (löste § 64 GmbHG a.F. ab; SanInsFoG, 1.1.2021).
-- **§ 102 StaRUG** — Krisenfrüherkennungspflicht der Geschäftsleitung haftungsbeschränkter Gesellschaften; ergänzt § 91 Abs. 2 AktG analog.
+- **§ 102 StaRUG** — Krisenfrüherkennungspflicht der Geschäftsleitung haftungsbeschränkter Gesellschaften; ergänzt § 91 Abs. 2 AktG analog. Der Steuerberater ist als laufender Buchhaltungs- und Bilanzbetreuer regelmäßig **wesentlicher externer Bestandteil** des Krisenfrüherkennungssystems. Versäumt er einen rechtzeitigen Hinweis, bricht das System praktisch zusammen — daraus folgt die eigene Hinweispflicht (siehe BGH IX ZR 285/14).
 - **§ 627 BGB** — Vertrauensstellung Steuerberatungsvertrag; Hinweis-/Aufklärungspflicht als Hauptpflicht.
 
 ### Leitentscheidungen
 
 - BGH, Urt. v. 26.1.2017 — **IX ZR 285/14** ("Steuerberater-Haftung wegen unterlassener Krisenwarnung"): Steuerberater haftet für Insolvenzverschleppungsschäden, wenn er aus der Buchhaltung Krisensignale erkennt und nicht hinweist. Maßstab: erkennbarer rechnerischer Überschuldungsstatus oder anhaltende Zahlungsstockung.
 - BGH, Urt. v. 7.3.2013 — **IX ZR 64/12** (Hinweispflicht bei drohender Insolvenzreife): Bereits **drohende** Insolvenzreife begründet die Hinweispflicht — nicht erst die manifeste Antragspflicht.
-- BGH, Urt. v. 6.6.2019 — **IX ZR 104/18** (Maßstab der erkennbaren Krisensignale; Substantiierungslast Steuerberater).
+- BGH, Urt. v. 6.6.2019 — **IX ZR 104/18** (Maßstab der erkennbaren Krisensignale; Substantiierungslast Steuerberater bei späterer Streitlage zur Hinweiserteilung).
 - BGH, Urt. v. 14.10.2010 — **IX ZR 153/09** (Steuerberater muss auf Schäden aus Geschäftsführerhaftung hinweisen).
+- BGH, Urt. v. 18.2.2010 — **IX ZR 70/07** (Inhalt und Maßstab der Hinweispflicht; ausdrückliche Warnung erforderlich, allgemeine Andeutungen genügen nicht).
+
+### § 102 StaRUG als Auslöser der StB-Hinweispflicht
+
+§ 102 StaRUG verpflichtet die Geschäftsleitung haftungsbeschränkter Gesellschaften zur fortlaufenden Krisenfrüherkennung und zum Ergreifen geeigneter Gegenmaßnahmen. In der Praxis stützt sich die GF auf die laufende Datenversorgung durch den Steuerberater. Daraus folgt:
+
+1. **Datenpflicht des Steuerberaters** — BWA, SuSa, Liquiditätsvorschau müssen so aufbereitet sein, dass Krisensignale für die GF erkennbar sind.
+2. **Aktive Hinweispflicht** — Erkennt der Steuerberater Krisensignale, muss er sie **ausdrücklich benennen**; bloße Übersendung der Zahlen genügt nicht (BGH IX ZR 70/07).
+3. **Empfehlung zum Aufbau des Krisenfrüherkennungssystems** — Wenn die Mandantin noch kein § 102 StaRUG-System hat, soll der Steuerberater auf die Pflicht zur Einrichtung hinweisen und die eigene Datenlieferung als Baustein anbieten.
+4. **Dokumentation** — Jedes Warnschreiben dient zugleich als Nachweis, dass die § 102 StaRUG-Pflicht der GF durch den Berater ordnungsgemäß unterstützt wurde.
 
 ## Vorgehen
 
-### 1. Krisensignale benennen
+### 1. Krisensignale benennen — § 102 StaRUG-tauglich
 
-Auflisten, **welche konkreten Befunde** der Steuerberater ermittelt hat. Beispiele:
+Auflisten, **welche konkreten Befunde** der Steuerberater ermittelt hat. Die Aufstellung soll so beziffert sein, dass die GF sie unmittelbar in das eigene § 102 StaRUG-System übernehmen kann. Beispiele:
 
 - Negatives Eigenkapital seit Stichtag XX.XX.XXXX (Aktiva EUR …, Passiva EUR …, Differenz EUR …).
 - Anhaltende Unterdeckung Lohnsteuer-/Sozialversicherungsbeiträge.
@@ -53,7 +69,7 @@ Auflisten, **welche konkreten Befunde** der Steuerberater ermittelt hat. Beispie
 
 ### 2. Rechtliche Einordnung — bewusst zurückhaltend
 
-Steuerberater **nennt** § 15a InsO, § 102 StaRUG und § 15b InsO als anwendbare Normen, **beurteilt sie aber nicht eigenständig**. Die anwaltliche Beratungsempfehlung ist Pflichtbestandteil.
+Steuerberater **nennt** § 15a InsO, § 102 StaRUG und § 15b InsO als anwendbare Normen, **beurteilt sie aber nicht eigenständig**. Die anwaltliche Beratungsempfehlung ist Pflichtbestandteil. Zusätzlich wird die GF auf ihre eigene § 102 StaRUG-Dokumentationspflicht hingewiesen und gebeten, das vorliegende Warnschreiben in das interne Krisenfrüherkennungssystem aufzunehmen.
 
 ### 3. Empfehlung mit Frist
 
@@ -104,13 +120,18 @@ sind als Geschaeftsfuehrer/in nach § 15a Abs. 1 InsO verpflichtet, bei
 Zahlungsunfaehigkeit innerhalb von drei Wochen, bei Ueberschuldung
 innerhalb von sechs Wochen Insolvenzantrag zu stellen. Zudem trifft Sie
 nach § 102 StaRUG die Pflicht zur Krisenfrueherkennung und zum Ergreifen
-geeigneter Gegenmassnahmen.
+geeigneter Gegenmassnahmen — wir empfehlen Ihnen, dieses Schreiben
+unmittelbar in Ihr internes Krisenfrueherkennungssystem aufzunehmen und
+den Eingang sowie die ergriffenen Massnahmen schriftlich zu dokumentieren.
 
 Wir leisten Ihnen mit diesem Schreiben den uns als Steuerberater nach
 staendiger Rechtsprechung des Bundesgerichtshofs obliegenden Hinweis
-(zuletzt BGH, Urt. v. 26.01.2017 — IX ZR 285/14). Eine rechtliche
-Beurteilung der Insolvenzantragspflicht ist uns als Steuerberater nach
-§ 5 RDG nicht erlaubt.
+(BGH IX ZR 285/14, IX ZR 64/12, IX ZR 104/18, IX ZR 70/07). Als Ihr
+laufender Steuerberater sind wir in tatsaechlicher Hinsicht regelmaessig
+derjenige Berater, der wirtschaftliche Schieflagen zuerst erkennt, und
+damit wesentlicher Bestandteil Ihres Krisenfrueherkennungssystems nach
+§ 102 StaRUG. Eine rechtliche Beurteilung der Insolvenzantragspflicht
+ist uns als Steuerberater nach § 5 RDG nicht erlaubt.
 
 Wir empfehlen Ihnen mit Nachdruck, **binnen einer Woche**:
 
@@ -150,6 +171,8 @@ Mit freundlichen Gruessen
 - `stb-liquiditaetsvorschau-3wochen` — Liquiditätsdaten als Beleg
 - `liquiditaetsplanung` (separates Power-Plugin) — gerichtsfeste insolvenzrechtliche Liquiditätsbilanz
 - `anw-haftungswarn-15a-inso-mandant` — anwaltliche Spiegelvariante (typisch nachgelagert, wenn Mandant anwaltlich vertreten ist)
+- `anw-insolvenzreife-pruefung-17-19-inso` — anwaltliche Beurteilung der Insolvenzreife (steuerspezifischer Schwerpunkt)
+- `krisenfrueherkennung-starug` (separates Power-Plugin) — vertiefte § 102 StaRUG-Pflicht und Aufbau des Krisenfrüherkennungssystems
 
 ## Quellen und Updates
 


### PR DESCRIPTION
## Was

- **Neuer Anwalts-Skill** `anw-insolvenzreife-pruefung-17-19-inso` (210 Zeilen): anwaltliches Pruefgutachten zur Insolvenzreife einer GmbH/UG aus Steueranwalts-Sicht. Schwerpunkt: wie § 222 AO Stundung, § 361 AO AdV, § 69 AO GF-Haftung Lohnsteuer und § 266a StGB die §§ 17, 19 InsO-Pruefung beeinflussen. BGH IX ZB 50/03, BFH VII R 24/15, IDW S 11. SanInsKG 24-Monats-Prognose. Antragspflicht § 15a InsO. Endet mit Belehrungs-Anschluss an `anw-haftungswarn-15a-inso-mandant`.

- **`stb-warnschreiben-krisensignale` erweitert** um neuen Abschnitt **"Warum gerade der Steuerberater"** und **"§ 102 StaRUG als Ausloeser der StB-Hinweispflicht"**: Der StB ist als laufender Buchhaltungs- und Bilanzbetreuer **regelmaessig externer Bestandteil des Krisenfrueherkennungssystems der Mandantin**. Ohne seinen Hinweis kann die GF ihre eigene § 102 StaRUG-Pflicht nicht erfuellen. Daraus folgt nach staendiger BGH-Rechtsprechung (IX ZR 285/14, IX ZR 64/12, IX ZR 104/18, IX ZR 70/07) die eigene StB-Hinweispflicht.

- **Mustertext im Warnschreiben** entsprechend erweitert (eigene Schluesselstellung explizit ausgesprochen, GF-Aufforderung zur Aufnahme in eigenes Krisenfrueherkennungssystem).

- **Description `stb-warnschreiben-krisensignale`** angepasst auf neue Begruendungslage (681 Zeichen, ≤ 1024).

- **README** erweitert: neuer anw-Skill in Tabelle, Workflow-Hinweis mit § 102 StaRUG-Rolle und Verweis auf anw-insolvenzreife.

## Hintergrund

User-Wunsch in Anschluss an PR #68/#69: "Gerade der Steuerberater ist ja haeufig derjenige, der dann nach der Rechtsprechung und nach § 102 StaRUG dieses Warnschreiben machen muss". Die anwaltliche Pruefperspektive (§§ 17, 19 InsO mit Steuerschwerpunkt) fehlte und die StB-Eigenpflicht war im Warnschreiben-Skill nur als Mandantenpflicht angesprochen.

## Validator

- `node scripts/validate-plugin-structure.mjs` → OK
- Plugin-Description weiter ≤ 300 Zeichen (293)
- Neue Skill-Description ASCII-Frontmatter konform mit Plugin-Konvent (§ und — erlaubt; Umlaute/ß nicht)
- Keine \d,\d-Verstoesse in Descriptions
- Body mit Umlauten (Plugin-Konvent: ASCII-Frontmatter, UTF-8-Body)

## Stand Steuer-Plugin nach PR

- 17 anw-Skills + 6 stb-Skills = **23 Skills**