### PR TITLE
fix(steuerrecht): anw-insolvenzreife — AdV § 361 AO bleibt Passiva I

### DIFF
--- a/steuerrecht-anwalt-und-berater/skills/anw-insolvenzreife-pruefung-17-19-inso/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/anw-insolvenzreife-pruefung-17-19-inso/SKILL.md
@@ -76,7 +76,7 @@ Im Gegensatz zum StB-Skill `stb-ueberschuldungspruefung-19-inso` (technische Ind
 | Sozialversicherungsabgaben — fällig (Drittelung Arbeitnehmer-/Arbeitgeber-Anteil dokumentieren) | … EUR |
 | Lohnsteuer und Solidaritätszuschlag — fällig nach § 41a EStG | … EUR |
 | Umsatzsteuer — fällig laut Voranmeldung | … EUR |
-| Sonstige Steuerverbindlichkeiten (ESt, KSt, GewSt) — fällig **abzüglich** schriftlich bewilligter Stundungen § 222 AO und AdV § 361 AO | … EUR |
+| Sonstige Steuerverbindlichkeiten (ESt, KSt, GewSt) — fällig **abzüglich** schriftlich bewilligter Stundungen § 222 AO (Stundungsbescheid muss Fälligkeit über den Stichtag hinaus verschieben). **AdV nach § 361 AO bleibt Passiva I** — sie hemmt nur die Vollziehung, lässt die Forderung materiell fällig (siehe Abschnitt "AdV nach § 361 AO und Insolvenzreife" unten). | … EUR |
 | Kreditraten und Zinsen — fällig | … EUR |
 | Sonstige fällige Verbindlichkeiten | … EUR |
 


### PR DESCRIPTION
Codex-Review-Folgebefund (P1) zu PR #70:

Die Tabellenzeile Passiva I im neuen `anw-insolvenzreife-pruefung-17-19-inso` sagte 'abzueglich schriftlich bewilligter Stundungen § 222 AO und AdV § 361 AO'. Das widersprach dem spaeteren Skill-Abschnitt 'AdV nach § 361 AO und Insolvenzreife', der korrekt feststellt: AdV hemmt nur die Vollziehung und veraendert die Faelligkeit nicht.

**Materielles Risiko:** Mandate mit AdV-Verfuegung, aber ohne separate § 222 AO-Stundung haetten bei wortgetreuer Anwendung zu einer unterzeichneten Liquiditaetsluecke gefuehrt — und damit zu falschem 'nicht zahlungsunfaehig'-Ergebnis nach § 17 InsO. Bei realer Zahlungsunfaehigkeit waere die Drei-Wochen-Antragsfrist verstrichen, mit § 15a Abs. 4 InsO-Strafbarkeit und persoenlicher Haftung.

**Fix:** Nur § 222 AO-Stundung wird abgezogen, und nur wenn der Bescheid die Faelligkeit ueber den Stichtag hinaus verschiebt. AdV § 361 AO bleibt Passiva I; Querverweis auf den ausfuehrlichen Abschnitt unten ergaenzt.

Validator OK.