### PR TITLE
fix(liquiditaet): AdV § 361 AO ist keine Stundung - bleibt Passiva I (5 Skills)

### DIFF
--- a/insolvenzrecht/skills/liquiditaetsvorschau-insolvenzrechtlich/SKILL.md
+++ b/insolvenzrecht/skills/liquiditaetsvorschau-insolvenzrechtlich/SKILL.md
@@ -269,6 +269,13 @@ Die bloße Duldung durch einen Gläubiger (kein Mahn-, kein Vollstreckungsschrei
 begründet keine Stundung im Sinne von BGH IX ZR 92/04 Rn. 22. Fehlendes Stundungs-
 nachweis führt zur Aufnahme der Position in die Passivseite.
 
+**2a. Aussetzung der Vollziehung (§ 361 AO / § 69 FGO) fälschlich als Stundung werten**
+AdV-Verfügungen hemmen nur die Vollziehung; die Fälligkeit der Steuerforderung bleibt
+unberührt. AdV-Beträge sind weiter **Passiva I**, soweit nicht zusätzlich eine schriftliche
+§ 222 AO-Stundung mit Fälligkeitsverschiebung über den Stichtag hinaus vorliegt. Eine
+Herausnahme von AdV-Beträgen aus den Passiva I führt zu einer methodisch falschen
+"nicht zahlungsunfähig"-Feststellung.
+
 **3. Einbeziehung nicht fälliger Verbindlichkeiten**
 Verbindlichkeiten mit Fälligkeit außerhalb des 3-Wochen-Fensters dürfen nach
 Mock, in: Uhlenbruck, InsO, 16. Aufl. 2024, § 17 Rn. 44 nicht in die Liquiditätsbilanz

--- a/insolvenzrecht/skills/zahlungsunfaehigkeit-pruefung-17-inso/SKILL.md
+++ b/insolvenzrecht/skills/zahlungsunfaehigkeit-pruefung-17-inso/SKILL.md
@@ -105,6 +105,13 @@ oder fälliger Teile), Lohn- und Gehaltsrückstände, Sozialversicherungsbeiträ
 Steuerschulden mit abgelaufener Zahlungsfrist, sonstige fällige Forderungen. Stundungen sind auf
 ihre rechtliche Wirksamkeit hin zu überprüfen (s. BGH IX ZR 92/04).
 
+> **Aussetzung der Vollziehung (§ 361 AO / § 69 FGO) ist keine Stundung.** AdV-Verfügungen
+> hemmen nur die Vollziehung, lassen die Fälligkeit der Steuerforderung aber unberührt. Im
+> Liquiditätsstatus bleiben AdV-Beträge **Passiva I**, soweit nicht zusätzlich eine
+> schriftliche Stundung nach § 222 AO mit Verschiebung der Fälligkeit über den Stichtag
+> hinaus vorliegt. Sonst wird die Liquiditätslücke unterzeichnet und es droht eine
+> falsche "nicht zahlungsunfähig"-Feststellung.
+
 **Schritt 3 – Aktiva-Erfassung**
 - *Aktiva I*: sofort verfügbare liquide Mittel zum Stichtag (Kassenbestand, Bankguthaben,
   debitorische Konten ohne Ausschöpfung des Rahmens)

--- a/liquiditaetsplanung/skills/liquiditaetsvorschau-3wochen/SKILL.md
+++ b/liquiditaetsplanung/skills/liquiditaetsvorschau-3wochen/SKILL.md
@@ -150,6 +150,7 @@ Zitierweise: Pinpoint mit Randnummer; Reihenfolge BGH-Datum (jüngere zuerst), k
 
 - **Voll ausgeschöpften Kontokorrent als Liquidität ansetzen**: Nur ungenutzter, zugesagter und ziehungsfähiger Teil zählt.
 - **Faktische Duldung des Zahlungsverzugs als Stundung werten**: Beseitigt die Fälligkeit nicht — BGH, Urt. v. 14.07.2006 – IX ZR 92/04, BGHZ 168, 158 Rn. 21 ff.
+- **Aussetzung der Vollziehung (§ 361 AO / § 69 FGO) als Stundung behandeln**: AdV hemmt nur die Vollziehung, lässt die Fälligkeit der Steuerforderung unberührt. AdV-Beträge bleiben **Passiva I**, soweit nicht zusätzlich eine schriftliche Stundung nach § 222 AO mit Fälligkeitsverschiebung über den Stichtag hinaus vorliegt.
 - **Großeingänge zu 100 % ansetzen**: Realistische Ausfall- und Skontoquote, im Zweifel Worst Case.
 - **3-Wochen-Frist statisch ab Planerstellung rechnen**: Sie läuft ab Eintritt der Zahlungsunfähigkeit.
 - **SV- und Lohnsteuer-Rückstände kleinreden**: Starke Indizien und persönlich haftungsauslösend.

--- a/liquiditaetsplanung/skills/liquiditaetsvorschau-insolvenzrechtlich/SKILL.md
+++ b/liquiditaetsplanung/skills/liquiditaetsvorschau-insolvenzrechtlich/SKILL.md
@@ -127,6 +127,7 @@ Siehe Schwester-Skill `liquiditaetsvorschau-3wochen` (Beispielfall Edelholz Manu
 ## Typische Fehler
 
 - **Stundungen fälschlich aus Passiva I herausnehmen**: nur echte, beiderseits vereinbarte und dokumentierte Stundungen — BGH IX ZR 92/04.
+- **Aussetzung der Vollziehung (§ 361 AO / § 69 FGO) als Stundung behandeln**: AdV hemmt nur die Vollziehung; die Fälligkeit der Steuerforderung bleibt unberührt. AdV-Beträge sind weiter **Passiva I**, soweit nicht zusätzlich eine schriftliche § 222 AO-Stundung mit Fälligkeitsverschiebung über den Stichtag hinaus vorliegt.
 - **SV-Beiträge oder Lohnsteuer übersehen**: gesetzlich sofort fällig, zugleich Indizien.
 - **Künftige Verträge / hypothetische Verwertungserlöse einbeziehen**: nicht zulässig in Aktiva I/II.
 - **Stichtag im Haftungskontext zu spät ansetzen**: tatsächlicher Eintritt maßgeblich.

--- a/steuerrecht-anwalt-und-berater/skills/stb-liquiditaetsvorschau-3wochen/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/stb-liquiditaetsvorschau-3wochen/SKILL.md
@@ -109,6 +109,7 @@ Wenn Daten fehlen: Annahmen explizit dokumentieren und im Worst Case rechnen.
 
 - **Kontokorrent voll als Liquidität ansetzen**: Nur ungenutzter, zugesagter und ziehungsfähiger Teil zählt.
 - **Stundungen als Liquidität werten**: Verschieben die Fälligkeit, sind aber Indiz für Zahlungsunfähigkeit (BGH NJW 2007, 78 Rn. 18).
+- **Aussetzung der Vollziehung (§ 361 AO / § 69 FGO) wie eine Stundung behandeln**: AdV hemmt nur die Vollziehung; die Fälligkeit der Steuerforderung bleibt unberührt. AdV-Beträge sind weiter **Passiva I**, soweit nicht zusätzlich eine schriftliche § 222 AO-Stundung mit Fälligkeitsverschiebung über den Stichtag hinaus vorliegt. Eine Herausnahme von AdV-Beträgen aus Passiva I führt zu falschem "nicht zahlungsunfähig"-Ergebnis.
 - **3-Wochen-Frist statisch ab Planerstellung rechnen**: Sie läuft ab **Eintritt** der Zahlungsunfähigkeit.
 - **Erwartete Großeingänge zu 100 % ansetzen**: Realistische Ausfall- und Skontoquote, im Zweifel Worst Case.
 - **SV-Rückstände kleinreden**: Starkes Indiz und Anzeigequelle (§ 15a Abs. 4 InsO; BGH NJW 2007, 78).


### PR DESCRIPTION
## Codex P1-Befund (übertragen aus anw-insolvenzreife)

> Keep AdV amounts in Passiva I when computing § 17 status

Der Befund aus PR #72 (anw-insolvenzreife) wird auf alle weiteren Liquiditätsprüfer-Skills ausgeweitet, damit kein Skill mehr suggeriert, AdV nach § 361 AO wirke wie eine Stundung nach § 222 AO.

## Hintergrund

§ 361 AO (Aussetzung der Vollziehung) hemmt nur die **Vollziehung**, lässt aber die **Fälligkeit** der Steuerforderung unberührt. AdV-Beträge bleiben also Verbindlichkeit der Passiva I bei der § 17 InsO-Prüfung. Nur die **echte Stundung nach § 222 AO** verschiebt die Fälligkeit und darf bei der Liquiditätsbilanz abgezogen werden.

## Geänderte Skills

- `insolvenzrecht/skills/zahlungsunfaehigkeit-pruefung-17-inso/SKILL.md`
- `insolvenzrecht/skills/liquiditaetsvorschau-insolvenzrechtlich/SKILL.md`
- `liquiditaetsplanung/skills/liquiditaetsvorschau-3wochen/SKILL.md`
- `liquiditaetsplanung/skills/liquiditaetsvorschau-insolvenzrechtlich/SKILL.md`
- `steuerrecht-anwalt-und-berater/skills/stb-liquiditaetsvorschau-3wochen/SKILL.md`

## Validator
`node scripts/validate-plugin-structure.mjs` → OK
