### PR TITLE
fix(steuerrecht): GrESt-Konzernklausel § 6a (statt § 7) + GIR-Erstabgabe 18 Monate

### DIFF
--- a/steuerrecht-anwalt-und-berater/skills/anw-grunderwerbsteuer-share-deal-90-prozent/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/anw-grunderwerbsteuer-share-deal-90-prozent/SKILL.md
@@ -29,7 +29,7 @@ Anwaltliche Beratung bei Erwerb von Anteilen an Gesellschaften mit inländischem
 - **§ 1 Abs. 3 GrEStG** — Unmittelbare **Anteilsvereinigung** zu mindestens **90 %** durch eine Person.
 - **§ 1 Abs. 3a GrEStG** — Wirtschaftliche Beteiligung **mindestens 90 %** durch mehrstufige Beteiligungsketten.
 - **§ 5 / § 6 GrEStG** — Befreiungen bei Anteilsübertragungen zwischen Gesamthand/PersGes-Gesellschaftern (eingeschränkt).
-- **§ 7 GrEStG** — Befreiung bei Konzernerwerb (sehr eingeschränkt; bestimmte Voraussetzungen).
+- **§ 6a GrEStG** — **Konzernklausel** (Steuervergünstigung bei Umstrukturierungen im Konzern): Befreiung für Erwerbsvorgänge nach § 1 Abs. 1 Nr. 3, Abs. 2, 2a, 2b, 3 oder 3a GrEStG aufgrund einer Umwandlung (§ 1 Abs. 1 Nr. 1-3 UmwG) oder Einbringung im Konzern. Voraussetzungen: **herrschendes Unternehmen** hält am abhängigen Unternehmen mindestens **95 %** ununterbrochen während der **Vor- und Nachbehaltensfrist von je 5 Jahren**. § 7 GrEStG regelt dagegen die Steuermessung beim Übergang von Gesamthandsvermögen in Bruchteilseigentum, nicht Konzernsachverhalte.
 - **§ 8 GrEStG** — Bemessungsgrundlage: **Grundbesitzwert** § 138 BewG (nicht Kaufpreis Anteile; Sonderbewertung).
 - **§ 11 GrEStG** — Steuersatz: Ländersteuer, **zwischen 3,5 % und 6,5 %** je Bundesland.
 - **§ 19 GrEStG** — Anzeigepflicht: **2 Wochen** ab Tatbestandsverwirklichung; Verstoß bewehrt mit Säumniszuschlägen und ggf. Strafverfahren.
@@ -112,7 +112,7 @@ und wird zusätzlich zum Kaufpreis fällig.
 ### Option 4 — Befreiungstatbestände nutzen
 
 - § 5/§ 6 GrEStG bei Anteilsübertragung in PersGes (Gesamthand)
-- § 7 GrEStG bei Konzernerwerb (sehr eingeschränkt)
+- § 6a GrEStG bei konzerninternen Umstrukturierungen (Umwandlung/Einbringung; 95 %-Beteiligung + 5 Jahre Vor- und Nachbehaltensfrist)
 - Vorsicht: Behaltefristen!
 
 ## Anzeigepflicht § 19 GrEStG

--- a/steuerrecht-anwalt-und-berater/skills/anw-minbestg-pillar2-konzernbesteuerung/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/anw-minbestg-pillar2-konzernbesteuerung/SKILL.md
@@ -129,8 +129,8 @@ Top-Up Tax = (15 % - ETR) × (GloBE Income - Substance-Based Income Exclusion)
 ### Phase 4 — Erklärung
 
 - **GloBE Information Return** (GIR) — XML-Datei an BZSt.
-- **Erstabgabe** 15 Monate nach Ende des ersten Geschäftsjahrs (für GJ 2024: bis Ende März/Juni 2026).
-- Folgejahre: 15 Monate nach Geschäftsjahr-Ende.
+- **Erstabgabe (Übergangsregelung)** — **18 Monate** nach Ende des ersten in den Anwendungsbereich fallenden Geschäftsjahrs (§ 95 Abs. 1 MinStG i.V.m. Art. 44 Abs. 7 EU-RL 2022/2523). Für Konzerne mit kalenderjahrgleichem GJ 2024: Frist **30.6.2026**. Für abweichende Wirtschaftsjahre entsprechend 18 Monate nach Ende GJ 2024.
+- **Folgejahre** (ab dem zweiten in-scope GJ): **15 Monate** nach Geschäftsjahr-Ende (§ 95 Abs. 1 MinStG).
 
 ### Phase 5 — Bei Erkenntnis Top-Up Tax
 


### PR DESCRIPTION
## Zwei Codex-Befunde umgesetzt

### P1: GrESt-Konzernklausel ist § 6a GrEStG, nicht § 7
In `anw-grunderwerbsteuer-share-deal-90-prozent/SKILL.md` war zweimal fälschlich § 7 GrEStG als Konzernbefreiung referenziert. § 7 GrEStG regelt aber den Übergang von Gesamthandseigentum in Bruchteilseigentum. Die grunderwerbsteuerliche **Konzernklausel** ist **§ 6a GrEStG**.

**Korrektur:**
- § 6a GrEStG begünstigt Erwerbsvorgänge nach § 1 Abs. 1 Nr. 3, Abs. 2, 2a, 2b, 3, 3a GrEStG aufgrund Umwandlung (§ 1 Abs. 1 Nr. 1-3 UmwG) oder Einbringung im Konzern
- Herrschendes Unternehmen hält am abhängigen Unternehmen mind. 95 % ununterbrochen
- Vor- und Nachbehaltensfrist je 5 Jahre
- Klarstellung ergänzt, dass § 7 GrEStG keine Konzernsachverhalte regelt

### P2: GIR-Erstabgabe ist 18 Monate (nicht 15)
In `anw-minbestg-pillar2-konzernbesteuerung/SKILL.md` war für den ersten in-scope GIR pauschal eine 15-Monats-Frist genannt. Tatsächlich gilt für die **erste Abgabe** eine Übergangsregelung mit **18 Monaten** (§ 95 Abs. 1 MinStG i.V.m. Art. 44 Abs. 7 EU-RL 2022/2523).

**Korrektur:**
- Erstabgabe: 18 Monate nach Ende des ersten in-scope GJ
- Kalenderjahrgleicher Konzern GJ 2024 → Frist 30.6.2026
- Abweichende Wirtschaftsjahre entsprechend
- Folgejahre: 15 Monate nach GJ-Ende

## Validator
`node scripts/validate-plugin-structure.mjs` → OK
