### PR TITLE
docs(asset-index): Stand v7.1.0, 97 Plugins (Sanity-Sweep)

### DIFF
--- a/ASSET_INDEX.md
+++ b/ASSET_INDEX.md
@@ -2,7 +2,7 @@
 
 Übersicht aller Dateien, die der Release-Workflow (`.github/workflows/release-plugin-zips.yml`) pro Tag-Release `vX.Y.Z` an den GitHub-Release anhängt.
 
-**Stand:** v7.0.0
+**Stand:** v7.1.0
 
 ## Asset-Typen
 
@@ -12,7 +12,7 @@
 | **fallakte** | `testakte-<aktenname>.zip` | **Kein Plugin.** Mandatsunterlagen für Testzwecke. In den Chat ziehen, nicht zum Plugin-Upload geben. |
 | **manifest** | `marketplace.json` | **Kein Plugin.** Marketplace-Manifest für `/plugin marketplace add` und zur manuellen Inspektion. |
 
-## Plugin-Assets (99 Stück)
+## Plugin-Assets (97 Stück)
 
 Alphabetisch wie in `.claude-plugin/marketplace.json`. URL-Schema:
 `https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/<name>.zip`


### PR DESCRIPTION
## Sanity-Sweep gesamtes Repo

Vollständiger Repo-Check durchgeführt. Ergebnis:

### Saubere Bereiche
- ✅ Validator (`validate-plugin-structure.mjs`) — OK
- ✅ Release-ZIP-Validator — OK (97 Plugin-ZIPs)
- ✅ **97/97** Plugins haben Marketplace-Eintrag
- ✅ **97/97** Plugins haben `plugin.json`, `README.md`, valides Schema
- ✅ **1.643 Skills** strukturell sauber (alle haben SKILL.md mit Frontmatter `name` + `description`)
- ✅ Keine kaputten Symlinks, keine leeren Verzeichnisse
- ✅ Keine toten README-Referenzen auf nicht existierende Skills
- ✅ Marketplace-Plugin-Namen entsprechen Verzeichnisnamen

### Korrektur
- 📝 **ASSET_INDEX.md** war auf v7.0.0 / 99 Plugins. Aktualisiert auf v7.1.0 / 97 Plugins (Folge der Steuer-Plugin-Konsolidierung in PR #64/#68).

### Hinweis dist/ (nicht im PR)
`/dist/` ist via `.gitignore` ausgeschlossen — die ZIPs werden vom Release-Workflow beim Tag-Push frisch gebaut. Lokal aufgeräumt (3 Orphan-ZIPs entfernt: `fachanwalt-steuerrecht.zip`, `steuerberater-werkzeuge.zip`, `steuerrecht-kanzlei.zip`; 2 fehlende gebaut: `gesellschaftsgruender.zip`, `steuerrecht-anwalt-und-berater.zip`). Beim nächsten `vX.Y.Z`-Tag generiert der Workflow alles automatisch korrekt.
