### PR TITLE
docs(asset-index): Verifikations-Counts konsistent auf 97 Plugins / 141 Assets

### DIFF
--- a/ASSET_INDEX.md
+++ b/ASSET_INDEX.md
@@ -180,10 +180,10 @@ URL-Schema: `https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/
 
 | Typ | Anzahl | Summe |
 | --- | --- | --- |
-| plugin | 99 | |
+| plugin | 97 | |
 | fallakte | 43 | |
 | manifest | 1 | |
-| **gesamt** | | **143** |
+| **gesamt** | | **141** |
 
 ## Verifikation eines Release
 
@@ -192,4 +192,4 @@ curl -s "https://api.github.com/repos/Klotzkette/claude-fuer-deutsches-recht/rel
   | python3 -c "import json,sys; d=json.load(sys.stdin); print('Tag:', d['tag_name']); print('Assets:', len(d['assets'])); [print(' -', a['name']) for a in d['assets']]"
 ```
 
-Erwartet: 143 Assets, davon 99 Plugin-ZIPs, 43 Fallakten-ZIPs mit `testakte-`-Prefix und eine `marketplace.json`.
+Erwartet: 141 Assets, davon 97 Plugin-ZIPs, 43 Fallakten-ZIPs mit `testakte-`-Prefix und eine `marketplace.json`.


### PR DESCRIPTION
## Codex P2-Befund

> Keep plugin count consistent across asset index sections
>
> The commit updates the headline to Plugin-Assets (97 Stück) but leaves later verification totals at 99 plugins / 143 assets in the same document, creating contradictory release expectations.

## Korrektur

In `ASSET_INDEX.md` waren nach PR #77 nur Header und Plugin-Sektion auf 97 Plugins aktualisiert, aber die Verifikations-Abschnitte weiter unten enthielten noch die alten Zahlen:

- "Asset-Anzahl pro Release"-Tabelle: `plugin 99` → **97**, `gesamt 143` → **141**
- "Erwartet: 143 Assets, davon 99 Plugin-ZIPs ..." → **141 Assets, davon 97 Plugin-ZIPs**

Fallakten (43) und Manifest (1) bleiben unverändert. Gesamt = 97 + 43 + 1 = **141**.

## Validator
`node scripts/validate-plugin-structure.mjs` → OK
