### PR TITLE
fix: Kleinunternehmer-Grenzen Paragraf 19 UStG n.F. (25k/100k, ab 1.1.2025)

### DIFF
--- a/gesellschaftsgruender/skills/gesellschaftsgruender-gewerbeanmeldung-finanzamt/SKILL.md
+++ b/gesellschaftsgruender/skills/gesellschaftsgruender-gewerbeanmeldung-finanzamt/SKILL.md
@@ -73,7 +73,7 @@ Nach Handelsregister-Eintragung sind zwei öffentlich-rechtliche Anmeldungen zwi
 
 - **Regelbesteuerung**: 19 % Standard, 7 % bei begünstigten Leistungen
 - **Kleinunternehmer-Regelung Paragraf 19 UStG**: keine USt, kein Vorsteuerabzug
-  - Voraussetzung: voraussichtlicher Umsatz im Gründungsjahr < 22.000 EUR, im Folgejahr < 50.000 EUR
+  - Voraussetzung (seit 1.1.2025, JStG 2024 / Wachstumschancengesetz): Vorjahresumsatz <= 25.000 EUR und voraussichtlicher Umsatz im laufenden Jahr <= 100.000 EUR (im Gründungsjahr: voraussichtlicher Gesamtumsatz <= 25.000 EUR, hochgerechnet auf 12 Monate)
   - Bei B2B-Geschäft oft **nicht** sinnvoll (Vorsteuer-Verlust)
 - **Wahlrecht** zur Regelbesteuerung trotz Kleinunternehmer-Voraussetzungen
 


### PR DESCRIPTION
## Kontext

Wachstumschancengesetz / JStG 2024, in Kraft seit 1.1.2025:
- Vorjahresumsatz: 22.000 EUR -> **25.000 EUR**
- laufendes Jahr: 50.000 EUR -> **100.000 EUR**
- Gruendungsjahr: voraussichtlicher Gesamtumsatz <= 25.000 EUR (hochgerechnet auf 12 Monate)

## Geaendert

- gesellschaftsgruender/skills/gesellschaftsgruender-gewerbeanmeldung-finanzamt/SKILL.md

## Sweep-Befund

Repo-weiter Scan auf 22.000/50.000 + Kleinunternehmer/Paragraf 19 UStG durchgefuehrt:
- Andere 22.000-Hits sind echte Geldbetraege (SV-Beitrag-Beispielrechnung, Furnierlieferung u.a.)
- Andere Kleinunternehmer-Skills (kanzlei-cowork RVG, steuerrecht USt) nennen keine konkreten Schwellen

## Validator
validate-plugin-structure: OK