### PR TITLE
fix(weg+steuerrecht): WEG-Reform 2020 + Claude-Review P2/P3 Befunde

### DIFF
--- a/mietrecht/skills/weg-beschluss-anfechten/SKILL.md
+++ b/mietrecht/skills/weg-beschluss-anfechten/SKILL.md
@@ -43,7 +43,7 @@ Bei einem unliebsamen WEG-Beschluss prüfen, ob Anfechtungs- oder Nichtigkeitskl
 
 ### Einberufung
 
-- **Frist § 24 Abs. 4 WEG** zwei Wochen vor Versammlung
+- **Frist § 24 Abs. 4 S. 2 WEG n.F.** drei Wochen vor Versammlung (seit WEMoG 1.12.2020; davor zwei Wochen)
 - **Form** schriftlich (Brief E-Mail mit Zustimmung)
 - **Inhalt** Tagesordnung Zeit Ort
 
@@ -52,23 +52,25 @@ Bei einem unliebsamen WEG-Beschluss prüfen, ob Anfechtungs- oder Nichtigkeitskl
 - Beschlussgegenstand klar bezeichnet
 - "Verschiedenes" als Sammelpunkt unzulässig für eigentliche Beschlüsse
 
-### Beschlussfähigkeit
+### Beschlussfähigkeit (§ 25 Abs. 1 WEG n.F.)
 
-- **§ 25 Abs. 4 WEG** Beschlussfähig wenn mehr als die Hälfte der Miteigentumsanteile (Standard wenn nichts anderes in Gemeinschaftsordnung)
-- Bei Beschlussunfähigkeit nicht beschlussfähige Versammlung — Wiederholungsversammlung
-- **Vorgehensweise** der Versammlung dokumentieren
+- **Seit WEMoG 1.12.2020 kein Quorum mehr** — § 25 Abs. 3 WEG a.F. (Beschlussfähigkeit nur bei > 50 % MEA) wurde gestrichen.
+- Jede Versammlung ist beschlussfähig, unabhängig von der Zahl der anwesenden / vertretenen Eigentümer; Wiederholungsversammlungen entfallen.
+- **Für Beschlüsse vor dem 1.12.2020**: alte Rechtslage § 25 Abs. 3 WEG a.F. (Quorum > 50 % MEA) noch maßgeblich.
+- Abweichende Quoren in der Gemeinschaftsordnung weiterhin zulässig (§ 10 Abs. 1 S. 2 WEG).
 
 ### Mehrheitserfordernisse
 
-- **Einfache Mehrheit** Standard
-- **Doppelt qualifizierte Mehrheit** bei baulichen Veränderungen § 20 WEG (Mehrheit nach Köpfen und nach Miteigentumsanteilen)
-- **Allstimmig** bei Änderung der Gemeinschaftsordnung
-- **Stimmrecht** ein Eigentümer eine Stimme — abweichend in Gemeinschaftsordnung möglich
+- **Einfache Mehrheit** der abgegebenen Stimmen Standard (§ 25 Abs. 1 WEG n.F.)
+- **Bauliche Veränderungen § 20 Abs. 1 WEG n.F.**: einfache Mehrheit ausreichend (Vereinfachung durch WEMoG).
+- **Doppelt qualifizierte Mehrheit** nur für Kostentragung durch alle Eigentümer bei baulichen Maßnahmen (§ 21 Abs. 2 Nr. 1 WEG n.F.): > 2/3 der abgegebenen Stimmen und > 50 % der Miteigentumsanteile.
+- **Allstimmig** bei Änderung der Gemeinschaftsordnung (Vereinbarung § 10 WEG).
+- **Stimmrecht** Kopfprinzip — jeder Eigentümer eine Stimme (§ 25 Abs. 2 WEG, unverändert durch WEMoG); abweichende Stimmprinzipien (Objekt-, Wertprinzip) in der Gemeinschaftsordnung zulässig.
 
-### Stimmrechtsausschluss
+### Stimmrechtsausschluss (§ 25 Abs. 4 WEG n.F.)
 
-- § 25 Abs. 5 WEG bei Beschlüssen, die ihn selbst betreffen — Geschäft mit ihm, Rechtsstreit
-- Bei Verletzung Beschluss anfechtbar
+- § 25 Abs. 4 WEG n.F. (entspricht § 25 Abs. 5 WEG a.F.) bei Beschlüssen, die ihn selbst betreffen — Rechtsgeschäft mit ihm, Rechtsstreit gegen ihn, rechtskräftige Verurteilung nach § 17 WEG.
+- Bei Verletzung Beschluss anfechtbar.
 
 ### Protokoll § 24 Abs. 6 WEG
 

--- a/steuerrecht-anwalt-und-berater/README.md
+++ b/steuerrecht-anwalt-und-berater/README.md
@@ -84,15 +84,68 @@ Skills für Steuerberater und GmbH-Geschäftsleitung — BWA-/SuSa-/Bilanzprüfu
 
 ---
 
+## Skill-Workflows
+
+### A) Krisen-Workflow (Steuerberater → Anwalt)
+
+```
+  [stb-bwa-sus-bilanz-pruefung]
+            ↓  Krisensignal erkannt
+  [stb-ueberschuldungspruefung-19-inso] + [stb-liquiditaetsvorschau-3wochen]
+            ↓  gelbe / rote Ampel
+  [stb-warnschreiben-krisensignale]    — BGH IX ZR 285/14 / § 102 StaRUG
+            ↓  Mandantin sucht Anwalt auf
+  [anw-insolvenzreife-pruefung-17-19-inso]  — Diagnose
+            ↓
+  [anw-haftungswarn-15a-inso-mandant]      +  [anw-gf-haftung-69-ao-nicht-abgefuehrte-steuern]
+  (§ 11 BORA-Belehrung)                       (§§ 34, 69 AO, § 266a StGB)
+            ↓  bei Vollmandat Sanierung / Antrag
+  Übergabe an Fachanwalt Insolvenz-/Sanierungsrecht (Plugin `insolvenzrecht`)
+```
+
+### B) Außenprüfung-Workflow
+
+```
+  [anw-aussenpruefung-strategien]
+            ↓  Prüfungsanordnung / Schlussbesprechung mit Mehrergebnis
+  [anw-einspruch-finanzamt]
+            ↓  Vollziehung droht
+  [anw-aussetzung-vollziehung]  (§ 361 AO / § 69 FGO)
+            ↓  Einspruch erfolglos
+  [anw-klage-finanzgericht]
+            ↓  parallel bei Strafverdacht (z. B. § 370 AO, § 26c UStG)
+  [anw-selbstanzeige-371]  (§ 393 Abs. 1 S. 2 AO, BGH 5 StR 191/04)
+```
+
+### C) M&A-Steuer-Workflow
+
+```
+  [anw-mandat-triage-steuerrecht]
+            ↓
+  [anw-verbindliche-auskunft]   — § 89 Abs. 2 AO, vor Strukturmaßnahme
+            ↓
+  [anw-organschaft-konzern-grundlagen]   — ertragst. / USt-/GewSt-Organschaft (§ 14 KStG, § 2 Abs. 2 UStG, § 2 Abs. 2 GewStG)
+            ↓  bei Immobilien im Organkreis / share-deal
+  [anw-grunderwerbsteuer-share-deal-90-prozent]   — § 1 Abs. 2a/3/3a GrEStG, Konzernklausel § 6a GrEStG
+            ↓  bei Konzern ≥ 750 Mio. EUR Konzernumsatz
+  [anw-minbestg-pillar2-konzernbesteuerung]   — Pillar 2 / MinBestG, GIR-Erstabgabe 18 Monate (§ 95 Abs. 1 MinStG)
+            ↓  bei grenzüberschreitenden Konstellationen
+  Plugin [`aussenwirtschaft-zoll-sanktionen`](../aussenwirtschaft-zoll-sanktionen/)   — DBA-Klauseln, APAs, Verrechnungspreise, Sanktionscompliance
+```
+
+---
+
 ## Testakten
 
 Drei fiktive Mandatsakten zum Ausprobieren der Skills:
 
 | Testakte | Inhalt | Passt besonders zu |
 |---|---|---|
-| [`beispielakte-edelholz-berlin`](../testakten/beispielakte-edelholz-berlin/) | Edelholz Manufaktur Berlin GmbH — BWA, SuSa, Liquiditätslage, Steuern/SV-Rückstände | `stb-bwa-sus-bilanz-pruefung`, `stb-liquiditaetsvorschau-3wochen` |
-| [`fortbestehensprognose-paragrafix-gmbh`](../testakten/fortbestehensprognose-paragrafix-gmbh/) | Paragrafix GmbH — Legal-AI-Startup, § 102-StaRUG-Hinweis, BWA, SuSa, 13-Wochen-Liquiditätsplanung | `stb-bwa-sus-bilanz-pruefung`, `stb-liquiditaetsvorschau-3-6-12-monate` |
-| [`grosskanzlei-corporate-ma-datenraum`](../testakten/grosskanzlei-corporate-ma-datenraum/) | Projekt Silberfalke — Umwandlungs- und Steuerstruktur, verbindliche Auskunft, Außenprüfung im M&A-Kontext | `anw-verbindliche-auskunft`, `anw-aussenpruefung-strategien` |
+| [`beispielakte-edelholz-berlin`](../testakten/beispielakte-edelholz-berlin/) | Edelholz Manufaktur Berlin GmbH — BWA, SuSa, Liquiditätslage, Steuern/SV-Rückstände | `stb-bwa-sus-bilanz-pruefung`, `stb-liquiditaetsvorschau-3wochen`, `stb-ueberschuldungspruefung-19-inso`, `stb-drv-sozialversicherungspruefung`, `stb-warnschreiben-krisensignale`, `anw-insolvenzreife-pruefung-17-19-inso`, `anw-haftungswarn-15a-inso-mandant`, `anw-gf-haftung-69-ao-nicht-abgefuehrte-steuern` |
+| [`fortbestehensprognose-paragrafix-gmbh`](../testakten/fortbestehensprognose-paragrafix-gmbh/) | Paragrafix GmbH — Legal-AI-Startup, § 102-StaRUG-Hinweis, BWA, SuSa, 13-Wochen-Liquiditätsplanung | `stb-bwa-sus-bilanz-pruefung`, `stb-liquiditaetsvorschau-3-6-12-monate`, `stb-ueberschuldungspruefung-19-inso`, `anw-insolvenzreife-pruefung-17-19-inso`, `anw-stundung-erlass-vollstreckungsaufschub`, `anw-organschaft-konzern-grundlagen` (Holding-Strukturierung), `anw-dac7-dac8-plattformen-krypto` (falls Plattform-/Krypto-Bezug) |
+| [`grosskanzlei-corporate-ma-datenraum`](../testakten/grosskanzlei-corporate-ma-datenraum/) | Projekt Silberfalke — Umwandlungs- und Steuerstruktur, verbindliche Auskunft, Außenprüfung im M&A-Kontext | `anw-verbindliche-auskunft`, `anw-aussenpruefung-strategien`, `anw-organschaft-konzern-grundlagen`, `anw-grunderwerbsteuer-share-deal-90-prozent`, `anw-minbestg-pillar2-konzernbesteuerung` (ab Konzernschwelle 750 Mio. EUR), `anw-einspruch-finanzamt`, `anw-klage-finanzgericht` |
+
+> **Hinweis zum Testakten-Mapping:** Die obenstehende Spalte ist nicht abschließend. Die drei Akten decken jeweils mehrere Phasen des Krisen-/Außenprüfungs-/M&A-Workflows ab — ein passender Skill ist meistens über das Stichwortverzeichnis („Mandatsanlass“) der jeweiligen Akte schnell zu finden. Skills, die nicht direkt zu einer Akte mappen (z. B. `anw-minbestg-pillar2-konzernbesteuerung` ohne 750 Mio. EUR-Konzern in der Akte), werden anhand ihrer eigenen Beispieldaten innerhalb des Skills demonstriert.
 
 ---
 

--- a/steuerrecht-anwalt-und-berater/skills/anw-haftungswarn-15a-inso-mandant/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/anw-haftungswarn-15a-inso-mandant/SKILL.md
@@ -9,6 +9,8 @@ description: Anwaltliche Beratung und Warnschreiben an GmbH-Geschaeftsfuehrung b
 
 Anwaltliche Beratung und schriftliche Dokumentation gegenüber der Geschäftsführung einer GmbH/UG, wenn die Mandantin (häufig nach Hinweis des Steuerberaters via `stb-warnschreiben-krisensignale`) bei dem Anwalt vorspricht und sich Insolvenzreife verdichtet. Anders als der Steuerberater **darf und muss** der Anwalt die rechtliche Beurteilung der Antragspflicht treffen — und sich dabei selbst absichern.
 
+> ℹ️ **Rollenabgrenzung zu `anw-insolvenzreife-pruefung-17-19-inso`:** Dieser Skill ist **präventiv-belehrend** — erstellt das schriftliche Warn-/Belehrungsschreiben an den GF nach erfolgter Reife-Analyse. Die vorgeschaltete **analytische** Prüfung der Insolvenzreife (§§ 17, 19 InsO Subsumtion, Beweiswürdigung) leistet `anw-insolvenzreife-pruefung-17-19-inso`. Standardablauf: erst `anw-insolvenzreife-pruefung-17-19-inso` (Diagnose), dann dieser Skill (Mandantenbelehrung + Dokumentation).
+
 > Dieses Schreiben dokumentiert die Beratungsleistung. Es ist **kein** anwaltliches Mahn-/Warnschreiben gegen den Mandanten, sondern eine schriftliche **Belehrung über die Antragspflicht und ihre Folgen** mit Bestätigung der Beratung — Pflicht aus § 11 BORA und Selbstschutz vor späteren Regressansprüchen.
 
 ## Eingaben

--- a/steuerrecht-anwalt-und-berater/skills/anw-insolvenzreife-pruefung-17-19-inso/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/anw-insolvenzreife-pruefung-17-19-inso/SKILL.md
@@ -11,6 +11,8 @@ Strukturiertes **anwaltliches Prüfgutachten** zur Insolvenzreife einer GmbH/UG,
 
 Im Gegensatz zum StB-Skill `stb-ueberschuldungspruefung-19-inso` (technische Indikation mit Ampel als Grundlage für den Mandantenhinweis) liefert dieser Skill die **vollständige rechtliche Beurteilung** mit Subsumtion, Beweiswürdigung und unmittelbarer Antragspflicht-Bewertung.
 
+> ℹ️ **Rollenabgrenzung zu `anw-haftungswarn-15a-inso-mandant`:** Dieser Skill ist **analytisch-diagnostisch** (Prüfgutachten Insolvenzreife). Das nachgelagerte **präventiv-belehrende** Warnschreiben an den GF (§ 11 BORA-Dokumentation der Belehrung über § 15a InsO-Antragspflicht und ihre Folgen) erstellt `anw-haftungswarn-15a-inso-mandant`. Standardablauf: erst dieser Skill (Diagnose Insolvenzreife), dann `anw-haftungswarn-15a-inso-mandant` (Mandantenbelehrung + Dokumentation).
+
 > ℹ️ **Abgrenzung Steueranwalt vs. Fachanwalt Insolvenzrecht:** Der Steueranwalt kann die Insolvenzreife rechtlich beurteilen und den Mandanten belehren (§ 3 BRAO, kein Vorbehalt für Fachanwalt). Für gerichtsfeste insolvenzrechtliche Sanierungsbegleitung, Schutzschirmverfahren (§ 270b InsO), StaRUG-Restrukturierungsplan oder Insolvenzantragstellung **Übergabe an Fachanwalt Insolvenz-/Sanierungsrecht** empfehlen. Das Power-Plugin `insolvenzrecht` (insbesondere `ueberschuldung-pruefung-19-inso`, `zahlungsunfaehigkeit-pruefung-17-inso`, `antragspflicht-15a-inso`) ist hier die fachliche Vertiefung.
 
 ## Kaltstart-Rückfragen

--- a/steuerrecht-anwalt-und-berater/skills/anw-organschaft-konzern-grundlagen/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/anw-organschaft-konzern-grundlagen/SKILL.md
@@ -141,6 +141,8 @@ Folgt grundsätzlich der KSt-Organschaft (Akzessorietät). Eigenständige Voraus
 - Rückwirkende Aberkennung-Risiko abklären.
 - Übergangsbesteuerung (Schlussbesteuerung Organgesellschaft).
 - USt-Voranmeldung wieder getrennt.
+- **GrESt-Trigger bei Immobilien im Organkreis:** Anteilsveräußerung / Anteilsübertragung an Organgesellschaften mit Grundbesitz kann § 1 Abs. 2a / Abs. 3 / Abs. 3a GrEStG auslösen — vor jeder Strukturmaßnahme Skill `anw-grunderwerbsteuer-share-deal-90-prozent` durchlaufen. Prüfung Konzernklausel § 6a GrEStG (5-Jahres-Vor-/Nachbehaltensfrist, 95-%-Schwelle).
+- **Asset-Deal in Organkreis:** Bei Übertragung von Grundstücken zwischen Organträger und Organgesellschaft GrESt-Pflicht nach § 1 Abs. 1 Nr. 1 GrEStG — ggf. § 6a GrEStG (Konzernklausel).
 
 ## Risiken und Red Flags
 


### PR DESCRIPTION
## WEG-Reform 2020 (WEMoG, 1.12.2020)

`mietrecht/skills/weg-beschluss-anfechten/SKILL.md`:
- § 24 Abs. 4 WEG n.F.: Einberufungsfrist 2 → 3 Wochen
- § 25 Abs. 3 a.F. gestrichen: **kein Quorum mehr**, jede Versammlung beschlussfähig
- § 25 Abs. 5 a.F. → § 25 Abs. 4 n.F. (Stimmrechtsausschluss)
- § 20 WEG n.F.: einfache Mehrheit Regel, doppelt qualifiziert nur § 21 Abs. 2 (Kostentragung)

## Claude-Review v8.0.0 P2/P3

**P2:**
- `anw-organschaft-konzern-grundlagen`: Phase 5 GrESt-Trigger (§ 1 Abs. 2a/3/3a GrEStG, § 6a Konzernklausel)
- `anw-haftungswarn-15a-inso-mandant`: Rollenabgrenzung präventiv-belehrend
- `anw-insolvenzreife-pruefung-17-19-inso`: Rollenabgrenzung analytisch-diagnostisch
- `steuerrecht-anwalt-und-berater/README.md`: 3 Workflow-Diagramme (Krise/Außenprüfung/M&A)

**P3:**
- Testakten-Mapping erweitert
- MinBestG → außenwirtschaft Cross-Ref existiert bereits (Zeile 172)

## Validator
`node scripts/validate-plugin-structure.mjs` → **OK**