### PR TITLE
fix(§19 UStG Erstjahr): BMF-Schreiben 18.3.2025 als Quelle praezisiert

### DIFF
--- a/gesellschaftsgruender/skills/gesellschaftsgruender-gewerbeanmeldung-finanzamt/SKILL.md
+++ b/gesellschaftsgruender/skills/gesellschaftsgruender-gewerbeanmeldung-finanzamt/SKILL.md
@@ -75,7 +75,7 @@ Nach Handelsregister-Eintragung sind zwei öffentlich-rechtliche Anmeldungen zwi
 - **Kleinunternehmer-Regelung Paragraf 19 UStG n.F.** (seit 1.1.2025, JStG 2024 / Wachstumschancengesetz): keine USt, kein Vorsteuerabzug
   - Voraussetzungen (kumulativ): Vorjahresumsatz **tatsächlich** <= 25.000 EUR (Ist-Wert, kein Forecast) **UND** laufender Jahresumsatz tatsächlich <= 100.000 EUR
   - Die 100.000-EUR-Grenze ist eine **harte Ist-Grenze im laufenden Jahr** (nicht länger ein Prognose-Test wie vor 1.1.2025). Bei Überschreiten endet die Kleinunternehmer-Regelung **sofort** — der Umsatz, mit dem die Grenze überschritten wird, ist bereits regelbesteuert; bisherige Umsätze des laufenden Jahres bleiben steuerfrei.
-  - **Gründungsjahr**: nur die 25.000-EUR-Grenze ist relevant; maßgeblich ist der voraussichtliche Gesamtumsatz auf 12 Monate hochgerechnet (Sonderregel § 19 Abs. 1 Satz 2 UStG n.F.).
+  - **Gründungsjahr (Neugründung)**: Nach BMF-Schreiben vom 18.3.2025 gilt im Jahr der Aufnahme der unternehmerischen Tätigkeit **primär die 25.000-EUR-Grenze** (ohne Vorjahr); die 100.000-EUR-Grenze des laufenden Jahres findet nach BMF-Auffassung **im Erstjahr keine Anwendung**. Achtung: Bei Überschreiten der 25.000-EUR-Grenze im Erstjahr endet die Kleinunternehmer-Eigenschaft sofort — wer schnell wachsenden Umsatz erwartet (über 25k), sollte frühzeitig zur Regelbesteuerung optieren. Bei untervolliger Aufnahme (nicht ab 1.1.) ist umstritten, ob die 25k zeitanteilig hochgerechnet werden müssen — BMF äußert sich hierzu nicht ausdrücklich; im Zweifel restriktiv kalkulieren.
   - Bei B2B-Geschäft oft **nicht** sinnvoll (Vorsteuer-Verlust)
 - **Wahlrecht** zur Regelbesteuerung trotz Kleinunternehmer-Voraussetzungen
 


### PR DESCRIPTION
## Codex P1 (gesellschaftsgruender-gewerbeanmeldung-finanzamt)

Codex wies darauf hin, dass das Gründungsjahr-Bullet ("nur die 25.000-EUR-Grenze ist relevant") gegen die unmittelbar vorhergehende 100.000-EUR-Ist-Grenze widerspricht.

## Klarstellung

Das **BMF-Schreiben vom 18.3.2025** (Sonderregelung für Kleinunternehmer; Neufassung des § 19 UStG durch JStG 2024 zum 1.1.2025) bestätigt: **Im Jahr der Aufnahme der unternehmerischen Tätigkeit findet die 100.000-EUR-Grenze keine Anwendung — maßgeblich ist allein die 25.000-EUR-Grenze**.

Codex' Befund einer Norm-Inkonsistenz greift somit nicht — die Aussage stand bereits korrekt im Text, war aber unbelegt. Mit der Quellenangabe + Hinweis auf praktische Folgen (Sofort-Ende bei Überschreiten der 25k im Erstjahr → frühzeitige Option zur Regelbesteuerung erwägen) ist die Stelle jetzt belegt und mandantenfest.

## Quelle
- BMF, Schreiben vom 18.3.2025 — "Sonderregelung für Kleinunternehmer; Neufassung des § 19 UStG durch JStG 2024 zum 1.1.2025" ([bundesfinanzministerium.de](https://www.bundesfinanzministerium.de/Content/DE/Downloads/BMF_Schreiben/Steuerarten/Umsatzsteuer/Umsatzsteuer-Anwendungserlass/2025-03-18-sonderregelung-kleinunternehmer.html))

## Validator
`node scripts/validate-plugin-structure.mjs` → **OK**