### PR TITLE
fix(pfaendungsrechner): § 850c-konforme Quote, 5-Personen-Cap, Eckwerte korrigiert (Codex-Befunde P1/P1/P2)

### DIFF
--- a/testakten/vollstreckungsmappe-mueller-sparkasse-niederrhein/02_kontopfaendung_kuechen-mueller-gmbh/03_lohnpfaendung_berechnung.md
+++ b/testakten/vollstreckungsmappe-mueller-sparkasse-niederrhein/02_kontopfaendung_kuechen-mueller-gmbh/03_lohnpfaendung_berechnung.md
@@ -9,9 +9,10 @@ Berechnet mit `zwangsvollstreckung/werkzeuge/pfaendungsrechner.py`. Tabelle guel
 | Drittschuldner | Mueller Kuechen GmbH (AG Krefeld HRB 14 432) |
 | Nettogehalt | 4.200,00 EUR / Monat |
 | Unterhaltspflichten | 3 (Ehefrau Dorothea, Kinder Vincent und Leah) |
-| Freibetrag Paragraf 850c | 2.797,30 EUR |
-| Pfaendbar / Monat | 981,89 EUR |
-| Schuldneranteil | 3.218,11 EUR |
+| Freibetrag Paragraf 850c | 2.792,31 EUR |
+| Pfaendbarkeitsquote (Paragraf 850c Abs. 3 ZPO, 3 UP) | 3/10 |
+| Pfaendbar / Monat | 422,30 EUR |
+| Schuldneranteil | 3.777,70 EUR |
 
 Aufruf:
 
@@ -28,7 +29,7 @@ Anmerkung: Da Bernd Mueller zugleich Geschaeftsfuehrer und mittelbarer Gesellsch
 | Drittschuldnerin | Helios Klinik Krefeld GmbH |
 | Nettogehalt | 2.350,00 EUR / Monat (75 Prozent Stelle Krankenschwester) |
 | Unterhaltspflichten | 2 (Kinder Vincent und Leah) |
-| Freibetrag Paragraf 850c | 2.471,26 EUR |
+| Freibetrag Paragraf 850c | 2.466,27 EUR |
 | Pfaendbar / Monat | 0,00 EUR |
 | Schuldneranteil | 2.350,00 EUR |
 
@@ -54,9 +55,9 @@ Beide Schuldner benoetigen fuer den hoeheren Schutz eine Bescheinigung der Famil
 
 | Strang | Erwarteter Ertrag / Monat |
 | --- | --- |
-| Lohnpfaendung Bernd Mueller (GmbH) | 981,89 EUR |
+| Lohnpfaendung Bernd Mueller (GmbH) | 422,30 EUR |
 | Kontopfaendung Postbank (Eingaenge ueber Gehaltsauszahlung) | aufgehend in der Lohnpfaendung, keine doppelte Belastung |
 | Kontopfaendung DKB Dorothea | nur Spitzenwerte ueber 1.560 EUR P-Konto-Sockel; nach Familienkasse-Bescheinigung 2.471,27 EUR |
 | Lohnpfaendung Dorothea Mueller | 0 EUR - nicht durchfuehren |
 
-Tilgung allein aus Lohnpfaendung B. Mueller braucht 272 Monate fuer 267.569,33 EUR - die dingliche ZVG-Vollstreckung ist der wirtschaftlich entscheidende Strang.
+Tilgung allein aus Lohnpfaendung B. Mueller braucht ca. 634 Monate fuer 267.569,33 EUR (422,30 EUR/Monat). Die dingliche ZVG-Vollstreckung in das Grundstueck (Grundschuld 380.000 EUR) ist damit der wirtschaftlich entscheidende Strang, die Lohnpfaendung sichert nur die laufende Verzinsung ab.

--- a/zwangsvollstreckung/README.md
+++ b/zwangsvollstreckung/README.md
@@ -56,7 +56,7 @@ Das Plugin arbeitet titelorientiert und drittschuldnerorientiert. Es prüft erst
 
 ## Werkzeug
 
-`werkzeuge/pfaendungsrechner.py` berechnet den pfändbaren Betrag nach § 850c ZPO mit der Tabelle 1.7.2025 bis 30.6.2026 (BGBl. 2025 I Nr. 110 vom 11.4.2025). Hartcodierte Eckwerte: Grundfreibetrag 1.559,99 EUR, Erhöhung erste Unterhaltspflicht 585,23 EUR, jede weitere 326,04 EUR, Vollpfändungsgrenze 4.766,99 EUR, P-Konto-Sockel 1.560,00 EUR. CLI: `python pfaendungsrechner.py --netto 4200 --unterhalt 3` gibt den pfändbaren Betrag, den verbleibenden P-Konto-Sockel und die Tabellenherleitung aus.
+`werkzeuge/pfaendungsrechner.py` berechnet den pfändbaren Betrag nach § 850c ZPO mit der Tabelle 1.7.2025 bis 30.6.2026 (BGBl. 2025 I Nr. 110 vom 11.4.2025). Hartcodierte Eckwerte: Grundfreibetrag 1.555,00 EUR, Erhöhung erste Unterhaltspflicht 585,23 EUR, jede weitere bis zur 5. Person 326,04 EUR, Vollpfändungsgrenze 4.766,99 EUR, P-Konto-Sockel 1.560,00 EUR. Pfändbarkeitsquote nach § 850c Abs. 3 ZPO unterhaltsabhängig (7/10 / 5/10 / 4/10 / 3/10 / 2/10 / 1/10). CLI: `python pfaendungsrechner.py --netto 4200 --unterhalt 3` gibt den pfändbaren Betrag, den verbleibenden P-Konto-Sockel und die Tabellenherleitung aus.
 
 ## Testakte
 

--- a/zwangsvollstreckung/skills/zv-pfaendungstabelle-2025/SKILL.md
+++ b/zwangsvollstreckung/skills/zv-pfaendungstabelle-2025/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zv-pfaendungstabelle-2025
-description: "Berechnet pfändbare Beträge nach Pfändungsfreigrenzenbekanntmachung 1.7.2025 (gültig bis 30.6.2027). Liefert Freibetrag nach § 850c ZPO inklusive Unterhaltsstaffel, Pfändungsstufen, P-Konto-Sockel § 850k ZPO und privilegierte Berechnung § 850d ZPO. Ruft das Python-Werkzeug werkzeuge/pfaendungsrechner.py auf. Lädt bei jeder Berechnung pfändbarer Bezüge."
+description: "Berechnet pfändbare Beträge nach Pfändungsfreigrenzenbekanntmachung 1.7.2025 (gültig bis 30.6.2026; danach jährliche Anpassung nach § 850c Abs. 4 ZPO). Liefert Freibetrag nach § 850c ZPO inklusive Unterhaltsstaffel, Pfändungsstufen, P-Konto-Sockel § 850k ZPO und privilegierte Berechnung § 850d ZPO. Ruft das Python-Werkzeug werkzeuge/pfaendungsrechner.py auf. Lädt bei jeder Berechnung pfändbarer Bezüge."
 ---
 
 # Pfändungstabelle 1.7.2025
@@ -32,12 +32,15 @@ Die Bekanntmachung gilt vom **1.7.2025 bis 30.6.2026**. Die nächste Anpassung e
 
 Aktuelle Eckdaten (Tabelle 1.7.2025):
 
-- Grundfreibetrag ohne Unterhaltspflichten: 1.559,99 EUR netto / Monat (§ 850c Abs. 1 ZPO i.V.m. Aufrundung Abs. 5).
-- Erhöhung erste unterhaltsberechtigte Person: 585,23 EUR.
-- Erhöhung jede weitere Person: 326,04 EUR.
-- Vollpfändungsgrenze: 4.766,99 EUR.
-- Pfändbar nur der den Freibetrag übersteigende Teil, stufenweise mit den Quoten 3/10, 5/10, 7/10 bis zur Kappungsgrenze (alle exakten Werte im `werkzeuge/pfaendungsrechner.py`).
+- Grundfreibetrag ohne Unterhaltspflichten: 1.555,00 EUR netto / Monat (§ 850c Abs. 1 Nr. 1 ZPO i.V.m. Pfändungsfreigrenzenbekanntmachung 2025).
+- Erhöhung erste unterhaltsberechtigte Person: 585,23 EUR (§ 850c Abs. 2 Satz 1 ZPO).
+- Erhöhung jede weitere Person (2. bis 5. Person): 326,04 EUR (§ 850c Abs. 2 Satz 2 ZPO).
+- Vollpfändungsgrenze: 4.766,99 EUR (§ 850c Abs. 3 Satz 3 ZPO).
+- Pfändbarkeitsquote im Tabellenbereich – unterhaltsabhängig nach § 850c Abs. 3 Sätze 1 und 2 ZPO: 0 Unterhaltspflichten 7/10; 1 UP 5/10; 2 UP 4/10; 3 UP 3/10; 4 UP 2/10; 5 UP 1/10. Ab der 6. Person Anpassung durch das Vollstreckungsgericht (§ 850f ZPO); das Werkzeug rechnet ab 6 UP mit den Tabellenwerten für 5 Personen und gibt einen Hinweis aus.
+- Netto wird vor Berechnung auf den nächsten vollen 10-EUR-Schritt abgerundet (§ 850c Abs. 5 ZPO).
 - P-Konto-Sockel § 850k ZPO: 1.560,00 EUR (AG SBV-Bescheinigung Stand 1.7.2025).
+- Pfändbarer Betrag wird nach unten gerundet (§ 850c Abs. 5 ZPO i.V.m. Tabellenmethode).
+- Alle exakten Werte im `werkzeuge/pfaendungsrechner.py` (Single Source of Truth).
 
 Die Werte sind dimensions- und kommageführt im Werkzeug Single-Source-of-Truth; dieses SKILL.md nennt sie zur Orientierung. Komma-Zahlen sind im Body erlaubt, nicht im Frontmatter `description`.
 

--- a/zwangsvollstreckung/werkzeuge/pfaendungsrechner.py
+++ b/zwangsvollstreckung/werkzeuge/pfaendungsrechner.py
@@ -13,11 +13,16 @@ Grundlagen:
 
 Quelle: NWB Datenbank, Finanztip, BGBl 2025 I Nr. 110.
 
-Eckwerte (Tabelle 1.7.2025):
-- Grundfreibetrag (0 Unterhaltspflichtige): 1.559,99 EUR / Monat
+Eckwerte (Tabelle 1.7.2025; BGBl 2025 I Nr. 110 vom 11.4.2025):
+- Grundfreibetrag (0 Unterhaltspflichtige): 1.555,00 EUR / Monat
 - Erhoehung 1. unterhaltsberechtigte Person: 585,23 EUR
-- Erhoehung je weitere Person: 326,04 EUR
+- Erhoehung je weitere Person (bis 5. Person): 326,04 EUR
 - Vollpfaendungsgrenze: 4.766,99 EUR (darueber alles pfaendbar)
+
+Die Berechnung folgt der Methode der amtlichen Tabelle: Netto wird auf den
+naechsten vollen 10-EUR-Schritt nach unten abgerundet (Paragraf 850c Abs. 5 ZPO);
+vom Ueberschuss ueber den nach Tabelle erhoehten Freibetrag wird der pfaendbare
+Anteil mit unterhaltsabhaengiger Quote berechnet.
 
 Benutzung:
     python3 pfaendungsrechner.py --netto 2500 --unterhalt 1
@@ -39,25 +44,33 @@ from decimal import Decimal, ROUND_DOWN
 TABELLE_GUELTIG_AB = _dt.date(2025, 7, 1)
 TABELLE_GUELTIG_BIS = _dt.date(2026, 6, 30)
 
-GRUNDFREIBETRAG = Decimal("1559.99")          # Paragraf 850c Abs. 1 ZPO
+GRUNDFREIBETRAG = Decimal("1555.00")          # Paragraf 850c Abs. 1 ZPO
 ERHOEHUNG_ERSTE_PERSON = Decimal("585.23")    # Paragraf 850c Abs. 2 Satz 1 ZPO
 ERHOEHUNG_WEITERE_PERSON = Decimal("326.04")  # Paragraf 850c Abs. 2 Satz 2 ZPO
 VOLLPFAENDUNGSGRENZE = Decimal("4766.99")     # Paragraf 850c Abs. 3 Satz 3 ZPO
 
-# Quoten gemaess Paragraf 850c Abs. 3 ZPO
-# 0   bis Freibetrag                  unpfaendbar
-# 1   3/10 des den Freibetrag uebersteigenden Teils gehen an den Schuldner
-# 2   weitere 2/10 fuer 1. Unterhaltspflichtigen
-# 3   weitere 1/10 fuer jede weitere Person (bis 5)
-# In der vereinfachten praktischen Berechnung des BMJ wird mit gestaffelten
-# Sockelbetraegen pro Unterhaltspflichtigem gearbeitet. Diese Implementierung
-# folgt der Tabellenmethode: Freibetrag = Sockel + n * Erhoehung, darueber
-# 7/10 pfaendbar (Schuldneranteil 3/10), ab Vollpfaendungsgrenze 100 % pfaendbar.
+# Quoten gemaess Paragraf 850c Abs. 3 ZPO (auf den den Grundfreibetrag
+# uebersteigenden Teil bis zur Vollpfaendungsgrenze):
+# - 0 Unterhaltspflichten:  3/10 unpfaendbar -> 7/10 pfaendbar
+# - 1 Unterhaltspflicht:    3/10 + 2/10 unpfaendbar -> 5/10 pfaendbar
+# - 2 Unterhaltspflichten:  6/10 unpfaendbar -> 4/10 pfaendbar
+# - 3 Unterhaltspflichten:  7/10 unpfaendbar -> 3/10 pfaendbar
+# - 4 Unterhaltspflichten:  8/10 unpfaendbar -> 2/10 pfaendbar
+# - 5 Unterhaltspflichten:  9/10 unpfaendbar -> 1/10 pfaendbar
+# Ab der 6. Person erfolgt keine automatische weitere Reduktion mehr;
+# Anpassung durch das Vollstreckungsgericht nach Paragraf 850f ZPO.
 
-QUOTE_SCHULDNER = Decimal("0.3")  # 3/10 bleiben Schuldner
-QUOTE_GLAEUBIGER = Decimal("0.7")  # 7/10 sind pfaendbar
+QUOTE_GLAEUBIGER_NACH_UP: dict[int, Decimal] = {
+    0: Decimal("0.7"),
+    1: Decimal("0.5"),
+    2: Decimal("0.4"),
+    3: Decimal("0.3"),
+    4: Decimal("0.2"),
+    5: Decimal("0.1"),
+}
 
-# P-Konto Sockel Paragraf 850k ZPO (AG SBV Bescheinigung Stand 1.7.2025)
+# P-Konto Sockel Paragraf 850k ZPO (AG SBV Bescheinigung Stand 1.7.2025).
+# Aufrundung des Grundfreibetrags auf naechsten vollen 10er.
 P_KONTO_SOCKEL = Decimal("1560.00")
 P_KONTO_ERHOEHUNG_ERSTE = Decimal("585.23")
 P_KONTO_ERHOEHUNG_WEITERE = Decimal("326.04")
@@ -141,6 +154,13 @@ def berechne(
 
     hinweise: list[str] = []
 
+    # Paragraf 850c Abs. 5 ZPO: Netto auf naechsten vollen 10-EUR-Schritt
+    # nach unten abrunden (Tabellenmethode). Nur fuer die regulaere
+    # Tabellenberechnung; Paragraf 850d ZPO laeuft separat.
+    netto_abger = (netto_d / Decimal("10")).to_integral_value(
+        rounding=ROUND_DOWN
+    ) * Decimal("10")
+
     if privileg_850d:
         selbst = Decimal(str(selbstbehalt)) if selbstbehalt is not None else SELBSTBEHALT_PRIVILEG
         freibetrag = selbst
@@ -163,35 +183,42 @@ def berechne(
         )
 
     # Regulaere Berechnung Paragraf 850c ZPO
+    # Freibetrag fuer die Anzeige (Sockel + Tabellen-Erhoehungen bis 5 Personen).
     freibetrag = GRUNDFREIBETRAG
     if unterhaltspflichten >= 1:
         freibetrag += ERHOEHUNG_ERSTE_PERSON
     if unterhaltspflichten >= 2:
-        freibetrag += ERHOEHUNG_WEITERE_PERSON * (unterhaltspflichten - 1)
+        bis_fuenf = min(unterhaltspflichten, 5) - 1
+        freibetrag += ERHOEHUNG_WEITERE_PERSON * bis_fuenf
 
-    ueber = max(netto_d - freibetrag, Decimal("0"))
+    if unterhaltspflichten > 5:
+        hinweise.append(
+            "Tabelle stuft bis 5 Unterhaltspflichtige; ab der 6. Person erfolgt "
+            "Anpassung durch das Vollstreckungsgericht (Paragraf 850f ZPO). "
+            "Werkzeug rechnet hier mit Tabellenwerten fuer 5 Personen."
+        )
 
-    if netto_d >= VOLLPFAENDUNGSGRENZE:
+    ueber = max(netto_abger - freibetrag, Decimal("0"))
+
+    # Pfaendbarkeitsquote im Tabellenbereich nach Unterhaltsstaffel
+    # Paragraf 850c Abs. 3 Saetze 1 und 2 ZPO.
+    quote_glaeubiger = QUOTE_GLAEUBIGER_NACH_UP[min(unterhaltspflichten, 5)]
+
+    if netto_abger >= VOLLPFAENDUNGSGRENZE:
         # alles oberhalb Vollpfaendungsgrenze ist 100 % pfaendbar,
-        # darunter quotal
+        # darunter quotal mit unterhaltsabhaengiger Quote
         teil_unter_grenze = max(VOLLPFAENDUNGSGRENZE - freibetrag, Decimal("0"))
-        teil_ueber_grenze = netto_d - VOLLPFAENDUNGSGRENZE
-        pfaendbar_quotal = teil_unter_grenze * QUOTE_GLAEUBIGER
+        teil_ueber_grenze = netto_abger - VOLLPFAENDUNGSGRENZE
+        pfaendbar_quotal = teil_unter_grenze * quote_glaeubiger
         pfaendbar = _quantize(pfaendbar_quotal + teil_ueber_grenze)
         hinweise.append(
             f"Netto liegt ueber der Vollpfaendungsgrenze {VOLLPFAENDUNGSGRENZE} EUR; "
             "darueber 100 Prozent pfaendbar."
         )
     else:
-        pfaendbar = _quantize(ueber * QUOTE_GLAEUBIGER)
+        pfaendbar = _quantize(ueber * quote_glaeubiger)
 
     schuldneranteil = _quantize(netto_d - pfaendbar)
-
-    if unterhaltspflichten > 5:
-        hinweise.append(
-            "Tabelle stuft bis 5 Unterhaltspflichtige; ab der 6. Person erfolgt "
-            "Anpassung durch das Vollstreckungsgericht (Paragraf 850f ZPO)."
-        )
 
     return Berechnungsergebnis(
         netto=_quantize(netto_d),
@@ -206,14 +233,16 @@ def berechne(
 
 
 def p_konto_freibetrag(unterhaltspflichten: int = 0) -> Decimal:
-    """Sockelbetrag Paragraf 850k ZPO inkl. Erhoehungen."""
+    """Sockelbetrag Paragraf 850k ZPO inkl. Erhoehungen (bis 5 Personen tabelliert;
+    ab der 6. Person Anpassung durch das Vollstreckungsgericht)."""
     if unterhaltspflichten < 0:
         raise ValueError("Unterhaltspflichten darf nicht negativ sein")
     betrag = P_KONTO_SOCKEL
     if unterhaltspflichten >= 1:
         betrag += P_KONTO_ERHOEHUNG_ERSTE
     if unterhaltspflichten >= 2:
-        betrag += P_KONTO_ERHOEHUNG_WEITERE * (unterhaltspflichten - 1)
+        bis_fuenf = min(unterhaltspflichten, 5) - 1
+        betrag += P_KONTO_ERHOEHUNG_WEITERE * bis_fuenf
     return _quantize(betrag)
 
 
@@ -252,7 +281,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--tabelle",
         action="store_true",
-        help="Druckt eine kompakte Tabelle (0-4 Unterhaltspflichten, 1500-5000 EUR).",
+        help="Druckt eine kompakte Tabelle (0-5 Unterhaltspflichten / 1500-5000 EUR).",
     )
     return p
 
@@ -260,12 +289,12 @@ def _build_parser() -> argparse.ArgumentParser:
 def _print_tabelle() -> None:
     print("Pfaendungstabelle (Auszug) - Tabelle 1.7.2025")
     print()
-    kopf = ["Netto"] + [f"U={n}" for n in range(0, 5)]
+    kopf = ["Netto"] + [f"U={n}" for n in range(0, 6)]
     print(" | ".join(f"{c:>10}" for c in kopf))
     print("-" * (12 * len(kopf)))
     for netto in range(1500, 5001, 100):
         zeile = [f"{netto:>10}"]
-        for n in range(0, 5):
+        for n in range(0, 6):
             r = berechne(Decimal(netto), n)
             zeile.append(f"{r.pfaendbar:>10}")
         print(" | ".join(zeile))


### PR DESCRIPTION
Codex-Review zu PR #90 hat drei Befunde gefunden – alle umgesetzt.

## P1: Unterhaltsabhängige Pfändbarkeitsquote

Vorher hat der Rechner für jeden Fall fix 7/10 als Pfändbarkeitsquote angewendet. § 850c Abs. 3 Sätze 1 und 2 ZPO stuft die Quote aber nach Unterhaltspflichten:

| UP | unpfändbar | pfändbar |
| --- | --- | --- |
| 0 | 3/10 | 7/10 |
| 1 | 5/10 | 5/10 |
| 2 | 6/10 | 4/10 |
| 3 | 7/10 | 3/10 |
| 4 | 8/10 | 2/10 |
| 5 | 9/10 | 1/10 |

Neu via `QUOTE_GLAEUBIGER_NACH_UP`-Mapping.

## P1: Cap bei 5 Unterhaltspflichten

§ 850c Abs. 2 Satz 2 ZPO normiert die Erhöhungsstaffel ausdrücklich nur bis zur 5. Person. Ab der 6. Person erfolgt Anpassung durch das Vollstreckungsgericht (§ 850f ZPO). Sowohl `berechne()` als auch `p_konto_freibetrag()` cappen Freibetrag und Quote bei 5 Personen und geben einen Hinweis aus.

## P2: Frontmatter-Datum

`zv-pfaendungstabelle-2025/SKILL.md` description: 30.6.2026 (war 30.6.2027). Body hatte schon 30.6.2026.

## Zusätzliche Korrekturen beim Verifizieren

Beim Cross-Check gegen Bürgergeld.org-Tabelle (4.200 EUR + 3 UP → 422,31 EUR) fiel auf, dass mein Grundfreibetrag falsch hartkodiert war:

- **Grundfreibetrag 1.555,00 EUR** (war: 1.559,99 – das war ein 2024-Wert). Quellen: [BRAK](https://www.brak.de), Lohnsteuer-Kompakt, Berlin.de-PDF zu BGBl 2025 I Nr. 110.
- **Netto-Abrundung auf nächsten 10-EUR-Schritt** vor Berechnung (§ 850c Abs. 5 ZPO).
- Vollpfändungsgrenze 4.766,99 EUR unverändert.

## Verifikation

| Netto | UP | Werkzeug | Bürgergeld-Tabelle | Δ |
| --- | --- | --- | --- | --- |
| 4.200 | 0 | 1.851,50 | 1.851,50 | 0 |
| 4.200 | 3 | 422,30 | 422,31 | -0,01 (ROUND_DOWN) |
| 2.500 | 0 | 661,50 | 661,50 | 0 |
| 2.350 | 2 | 0,00 | 0,00 | 0 |

Cent-Differenzen entstehen durch `ROUND_DOWN` (zugunsten Schuldner, § 850c Abs. 5 ZPO erlaubt Abrundung).

## Testakte angepasst

`testakten/.../02_kontopfaendung_kuechen-mueller-gmbh/03_lohnpfaendung_berechnung.md`: Bernd Mueller jetzt korrekt 422,30 EUR/Monat statt vorher fehlerhaft 981,89 EUR. Wirtschaftliche Konsequenz (Tilgungsdauer 634 Monate statt 272) und Bedeutung der ZVG-Vollstreckung neu eingeordnet.

## Validator

`node scripts/validate-plugin-structure.mjs` → OK.