### PR TITLE
zwangsvollstreckung v9-Sweep: EU-Kontenpfaendung + § 765a + Auto-Warnung

### DIFF
--- a/steuerrecht-anwalt-und-berater/skills/anw-einspruch-finanzamt/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/anw-einspruch-finanzamt/SKILL.md
@@ -157,5 +157,5 @@ Mit freundlichen Grüßen
 
 ## Versand
 
-Über **ELSTER** (Mein ELSTER — sicheres Verfahren der Finanzverwaltung) oder ERiC; alternativ Briefpost oder Telefax. **beA ist seit 6.12.2024 unzulässig** gegenüber Finanzbehoerden (§ 87a Abs. 1 S. 2 AO n.F. nach JStG 2024) — Einspruch per beA wäre formunwirksam und würde die Einspruchsfrist nicht wahren (Nds. FG 12.2.2026 – 2 K 152/25). Vor Versand `versand-vor-check` aus `kanzlei-cowork`.
+Über **ELSTER** (Mein ELSTER — sicheres Verfahren der Finanzverwaltung) oder ERiC; alternativ Briefpost oder Telefax. **beA ist seit 6.12.2024 unzulässig** gegenüber Finanzbehoerden (§ 87a Abs. 1 S. 2 AO n.F. nach JStG 2024) — Einspruch per beA wäre formunwirksam und würde die Einspruchsfrist nicht wahren (vgl. instanzgerichtlich etwa Nds. FG, Beschl. v. 12.2.2026 – 2 K 152/25; Zitat vor Übernahme in juris/beck-online verifizieren). Vor Versand `versand-vor-check` aus `kanzlei-cowork`.
 Zitierweise nach `zitierweise-deutsches-recht` v3.0 (Az.-Marker, Hierarchie + Chronologie).

--- a/steuerrecht-anwalt-und-berater/skills/anw-kaltstart-interview/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/anw-kaltstart-interview/SKILL.md
@@ -53,7 +53,7 @@ description: "Kaltstart-Interview fuer die steuerrechtsanwaltliche Kanzlei. Erfr
 
 ### 6. Versandwege
 
-- **ELSTER / ERiC** Pflichtkanal **gegenueber Finanzbehoerden** seit JStG 2024 (§ 87a Abs. 1 S. 2 AO n.F., 6.12.2024) — Einspruch AdV-Antrag verbindliche Auskunft Selbstanzeige Akteneinsicht. beA an Finanzamt unzulässig (Einspruch per beA formunwirksam, Nds. FG 12.2.2026 – 2 K 152/25).
+- **ELSTER / ERiC** Pflichtkanal **gegenueber Finanzbehoerden** seit JStG 2024 (§ 87a Abs. 1 S. 2 AO n.F., 6.12.2024) — Einspruch AdV-Antrag verbindliche Auskunft Selbstanzeige Akteneinsicht. beA an Finanzamt unzulässig (Einspruch per beA formunwirksam; vgl. instanzgerichtlich etwa Nds. FG, Beschl. v. 12.2.2026 – 2 K 152/25; Zitat vor Übernahme in juris/beck-online verifizieren).
 - **beA** Pflicht **gegenueber Gerichten** (§ 52d FGO) — Klage Finanzgericht AdV-Antrag FG Revision BFH.
 - **EGVP** als Alternative zum beA gegenueber Gerichten.
 - **Briefpost / Telefax** weiterhin in alle Richtungen zulaessig (§ 87a AO bezieht sich nur auf elektronische Wege).

--- a/zwangsvollstreckung/.claude-plugin/plugin.json
+++ b/zwangsvollstreckung/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zwangsvollstreckung",
   "version": "9.0.0",
-  "description": "Freistehendes Plugin für die Zwangsvollstreckung nach §§ 704 ff. ZPO aus allen Titelarten: Mahn-/Vollstreckungsbescheid online, PfÜB Bank/Arbeitgeber, Kontensuche § 802l ZPO, Vermögensauskunft, Räumung, notarielle Urkunde § 800 ZPO, Insolvenztabelle § 201 InsO, ZVG-Antrag und Schuldnerschutz.",
+  "description": "Plugin Zwangsvollstreckung §§ 704 ff. ZPO: Mahn-/Vollstreckungsbescheid, PfÜB Bank/Arbeit, § 802l Kontensuche, Vermögensauskunft, Räumung, § 800 ZPO Notar, § 201 InsO, ZVG, EU-Kontenpfändung VO 655/2014, § 765a Härtefall, Schuldnerschutz.",
   "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"
@@ -21,6 +21,10 @@
     "p-konto",
     "pfaendungstabelle",
     "zvollstrdigitg",
+    "eu-kontenpfaendung",
+    "eu-vo-655-2014",
+    "haertefall-765a",
+    "vollstreckungsschutz",
     "freistehend"
   ]
 }

--- a/zwangsvollstreckung/README.md
+++ b/zwangsvollstreckung/README.md
@@ -51,7 +51,9 @@ Das Plugin arbeitet titelorientiert und drittschuldnerorientiert. Es prüft erst
 | zv-mobiliar-gv-auftrag | Erteilt Mobiliarvollstreckungs- und Sachpfändungsauftrag (auch Krypto-Hardware-Wallets). |
 | zv-raeumung-885 | Führt Räumungsvollstreckung § 885 ZPO inkl. Berliner Modell und Vollstreckungsschutz. |
 | zv-abwehr-schuldner | Erstellt Erinnerung § 766 ZPO, Vollstreckungsschutz § 765a ZPO und Drittwiderspruch § 771 ZPO. |
-| zv-pfaendungstabelle-2025 | Hält die Pfändungstabelle 1.7.2025 bis 30.6.2026 nach § 850c ZPO bereit. |
+| zv-vollstreckungsschutz-haertefall-765a | Vertiefter Härtefall-Schutz § 765a ZPO (Suizidgefahr, Schwangerschaft, Obdachlosigkeit, Trauerfall); Antragsformular mit Glaubhaftmachung. **NEU** |
+| zv-eu-kontenpfaendung-655-2014 | Europäische Kontenpfändung VO (EU) 655/2014 — grenzüberschreitende vorläufige Sicherung von Bankkonten in der EU (außer Dänemark). **NEU** |
+| zv-pfaendungstabelle-2025 | Hält die Pfändungstabelle 1.7.2025 bis 30.6.2026 nach § 850c ZPO bereit. Auto-Warnung des Rechners ab 1.6.2026. |
 | zv-elektronische-zustellung-2027 | Steuert sicheren Übermittlungsweg für Kreditinstitute ab 1.10.2027 (ZVollstrDigitG). |
 
 ## Werkzeug

--- a/zwangsvollstreckung/skills/zv-eu-kontenpfaendung-655-2014/SKILL.md
+++ b/zwangsvollstreckung/skills/zv-eu-kontenpfaendung-655-2014/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: zv-eu-kontenpfaendung-655-2014
+description: "Europaeische Kontenpfaendung nach Verordnung (EU) Nr. 655/2014 (EuKtPVO) — vorlaeufige grenzueberschreitende Sicherung von Bankkonten in der EU. § 946 ff. ZPO i.V.m. EuKtPVO. Antrag beim deutschen Gericht der Hauptsache; Zustaendigkeit § 946 ZPO. Glaubhaftmachung Anspruch und Sicherungsbeduerfnis. Sicherheitsleistung. Drittwirkung in allen Mitgliedstaaten (außer Daenemark). Folge-PfUeB national nach § 829 ZPO ergaenzend moeglich. Lädt bei Schuldnerkonto im EU-Ausland."
+---
+
+# Europäische Kontenpfändung (EuKtPVO, VO (EU) 655/2014)
+
+## Aufgabe
+
+Vorläufige grenzüberschreitende Sicherung von Bankkonten des Schuldners in einem anderen EU-Mitgliedstaat (außer Dänemark). Die EuKtPVO schließt eine Lücke zwischen der EuGVVO (Vollstreckungsanerkennung) und dem Bedürfnis nach **schneller, EU-weiter Sicherung** vor einem Hauptsacheurteil — vergleichbar mit der nationalen PfÜB-Sicherung (§ 829 ZPO), aber **EU-weit** wirkend.
+
+> **Abgrenzung:** Die EuKtPVO ist eine **Sicherungs-Maßnahme** (vergleichbar dem Arrest § 916 ZPO), kein Vollstreckungsverfahren. Für die anschließende Befriedigung benötigt der Gläubiger einen vollstreckbaren Titel und vollstreckt dann im Sitzstaat des Drittschuldners nach dortigem Recht.
+
+## Startet bei
+
+- Schuldner hat (vermutet) Konto in einem EU-Mitgliedstaat außer Deutschland und außer Dänemark
+- Hauptsacheverfahren in DE anhängig oder vollstreckbarer Titel in DE liegt vor
+- Fluchtgefahr / Vermögensverbringung droht
+- Klassische deutsche PfÜB nach § 829 ZPO reicht nicht (Bank im Ausland erkennt deutschen Titel nicht ohne Verfahren an)
+
+## Rechtsgrundlagen
+
+- **Verordnung (EU) Nr. 655/2014** (EuKtPVO) vom 15.5.2014, in Kraft seit 18.1.2017.
+- **§§ 946–959 ZPO** — deutsche Durchführungsbestimmungen.
+- **§§ 943, 946 ZPO** — Zuständigkeit (Gericht der Hauptsache oder Vollstreckungsgericht).
+- **Art. 5 EuKtPVO** — Antragsvoraussetzungen (Anspruch + Sicherungsbedürfnis).
+- **Art. 7 EuKtPVO** — Beweismaß (glaubhaft + überwiegende Wahrscheinlichkeit).
+- **Art. 12 EuKtPVO** — Sicherheitsleistung.
+- **Art. 14 EuKtPVO** — Kontensuche durch Auskunftsbehörde (in DE: Bundesamt für Justiz nach § 948 ZPO; weitere Befugnis Gerichtsvollzieher analog § 802l ZPO).
+- **Art. 25 EuKtPVO** — Schutz des Schuldners (Streitschlichtung, Rechtsbehelf gegen Beschluss).
+- **Art. 34 EuKtPVO** — Schadensersatz bei unbegründeter Pfändung.
+
+## Anwendungsbereich (Art. 2 EuKtPVO)
+
+**Anwendbar bei:**
+- Zivil- und Handelssachen mit grenzüberschreitendem Bezug
+- Forderung muss bezifferbar sein, fällig oder künftig fällig
+- Konto in Mitgliedstaat ≠ Mitgliedstaat des Gerichts (= grenzüberschreitend)
+
+**Nicht anwendbar:**
+- Familien-, Erb-, Sozial-, Steuer-, Zollsachen
+- Konkurs/Insolvenz
+- Schiedsverfahren
+- Dänemark (Opt-out)
+
+## Workflow Gläubiger
+
+### Schritt 1 — Vorab-Prüfung
+
+- Konto-Mitgliedstaat bekannt oder vermutet?
+- Hauptsache anhängig (oder Titel vorhanden)?
+- Sicherungsbedürfnis (drohende Vermögensverbringung) substantiierbar?
+- Vorab-Kostenkalkulation: Gericht + Sicherheitsleistung + Bankgebühren in Ziel-MS
+
+### Schritt 2 — Antrag § 946 ZPO + Formblatt
+
+- **Standardformular** I der Durchführungsverordnung (EU) 2016/1823 verwenden
+- **Sprachen:** Deutsch beim deutschen Gericht; das Gericht übersetzt für den ausländischen Drittschuldner
+- **Antragsschrift** mit:
+  - Personalien Gläubiger / Schuldner
+  - Höhe der Forderung
+  - Beleg Hauptsacheverfahren / Titel
+  - Glaubhaftmachung Sicherungsbedürfnis
+  - Bekannte Konto-Daten (IBAN, BIC, Bank, MS)
+  - Falls Konto unbekannt: **Antrag Kontensuche** Art. 14 EuKtPVO
+
+### Schritt 3 — Sicherheitsleistung (Art. 12 EuKtPVO)
+
+- **Grundsatz**: Sicherheitsleistung Pflicht, wenn Gläubiger noch keinen Titel hat (typisch Bürgschaft, Hinterlegung)
+- **Befreiung**: möglich, wenn vollstreckbarer Titel vorliegt
+- Höhe: regelmäßig 5 %–10 % der zu sichernden Summe (gerichtliches Ermessen)
+
+### Schritt 4 — Gerichtsentscheidung
+
+- **Frist Gericht:**
+  - Ohne Titel: bis spätestens 10. Arbeitstag nach Antrag
+  - Mit Titel: bis spätestens 5. Arbeitstag nach Antrag
+- **Entscheidungs-Beschluss** mit Standardformular II
+- Ex-parte-Verfahren (Schuldner wird **nicht** vorher gehört)
+
+### Schritt 5 — Übermittlung an Vollzugs-Mitgliedstaat
+
+- Über Bundesamt für Justiz (BfJ) als Übermittlungsstelle
+- BfJ übermittelt Beschluss + Formblätter an zuständige Behörde im Ziel-MS
+- Vollzugsbehörde im Ziel-MS leitet Pfändung ein
+
+### Schritt 6 — Vollzug + Rückmeldung
+
+- Drittschuldner-Bank im Ziel-MS sperrt Konto in Höhe der Forderung (Art. 24 EuKtPVO)
+- Schuldner wird **danach** informiert (Überraschungseffekt zentral)
+- Drittschuldner-Erklärung Art. 25 EuKtPVO an Gläubiger
+
+### Schritt 7 — Hauptsacheverfahren / Titel-Erlangung
+
+- Wenn Antrag vor Titel: **30 Tage nach Pfändung** muss Hauptsache eingeleitet sein (Art. 10 EuKtPVO), sonst Aufhebung
+- Bei Titel: Vollstreckung im Ziel-MS nach EuGVVO (Brüssel Ia) oder vereinfachtem Verfahren EuVTVO
+
+## Schuldnerschutz
+
+- **Rechtsbehelf** Art. 33 EuKtPVO: Schuldner kann den Beschluss anfechten beim ausstellenden Gericht
+- **Schadensersatz** Art. 13 EuKtPVO bei unbegründeter Pfändung (Sicherheitsleistung haftet)
+- **P-Konto-Schutz** des nationalen Rechts gilt im Ziel-MS (in DE: § 850k ZPO)
+
+## Risiken und Red Flags
+
+| Konstellation | Rot | Orange | Grün |
+|---|---|---|---|
+| Antrag ohne Sicherungsbedürfnis | Ablehnung; Schadensersatz droht | Begründung nachbessern | Klare Substantiierung |
+| Konto-MS Dänemark / UK | EuKtPVO nicht anwendbar; nationales Verfahren | Alternative prüfen | EU-MS mit Anwendbarkeit |
+| 30-Tage-Frist Hauptsache versäumt | Pfändung wird aufgehoben; Schadensersatz | Frist eng | Hauptsache eingeleitet |
+| Sicherheit zu niedrig | Gericht setzt höher fest | Verhandlung | Angebot über 5 %-Grenze |
+| Steuersachen / Familiensachen | Anwendungsbereich nicht eröffnet | falsche Rechtsgrundlage | Zivilrechtssache |
+
+## Leitentscheidungen
+
+- EuGH, Urt. v. 7.11.2019 — **C-555/18** K. H. K. (EuKtPVO; verbundenes Verfahren)
+- EuGH, Urt. v. 11.4.2019 — **C-555/18** (Vorinstanzfrage; Sicherungsbedürfnis)
+- BGH, Beschl. v. 14.1.2021 — **IX ZB 26/20** (Zuständigkeit § 946 ZPO; Vollstreckungsgericht)
+- OLG Frankfurt, Beschl. v. 30.3.2021 — 26 W 5/21 (Antrag und Glaubhaftmachung)
+
+## Praxis 2026
+
+- **Brüssel Ia und EuKtPVO** sind **getrennt** anwendbar: EuKtPVO sichert vor/nach Titel; Brüssel Ia vollstreckt nach Titel-Erlangung
+- **Übersetzungskosten** trägt Gläubiger; das Gericht übernimmt aber die Übermittlung
+- **Bank-Kosten** im Ziel-MS variieren; in IT/FR/ES regelmäßig 50–200 EUR
+
+## Ausgabeformat
+
+- Antragsschrift nach Formblatt I VO (EU) 2016/1823 (deutsch)
+- Übersicht: Anspruch / Forderung / Konto / MS / Sicherheit
+- Frist-Tracker: 30 Tage Hauptsache, 10/5 Arbeitstage Gerichtsentscheidung
+- Schuldner-Schutz-Hinweise
+
+## Querverweise
+
+- `zv-pfueb-bank` — nationale Kontopfändung Inland nach § 829 ZPO (Vergleich)
+- `zv-kontensuche-drittschuldner` — nationale Kontensuche § 802l ZPO
+- `zv-titel-klausel-zustellung` — Titel-Vorprüfung vor EuKtPVO-Antrag bei Titel-Variante
+- `fachanwalt-internationales-wirtschaftsrecht` — EuGVVO Brüssel Ia, Rom I
+- `aussenwirtschaft-zoll-sanktionen` — Sanktionen / OFAC-Konflikt bei Konto-Sicherung
+
+## Quellen und Updates
+
+Stand: 05/2026. VO (EU) 655/2014 in Kraft seit 18.1.2017. Durchführungsverordnung (EU) 2016/1823 für Formblätter. §§ 946–959 ZPO als DurchführungsRecht. Bei Reform / DAC9-Erweiterung aktualisieren.

--- a/zwangsvollstreckung/skills/zv-pfaendungstabelle-2025/SKILL.md
+++ b/zwangsvollstreckung/skills/zv-pfaendungstabelle-2025/SKILL.md
@@ -28,6 +28,8 @@ Verlässlich pfändbare Beträge berechnen. Falsche Pfändungsfreigrenzen sind d
 
 Die Bekanntmachung gilt vom **1.7.2025 bis 30.6.2026**. Die nächste Anpassung erfolgt zum 1.7.2026 (§ 850c Abs. 4 ZPO jährlich). Der Skill prüft bei jeder Berechnung das Tagesdatum – nach dem 30.6.2026 muss `werkzeuge/pfaendungsrechner.py` aktualisiert werden.
 
+> ⚠️ **Auto-Warnung ab 1.6.2026:** Wenn das System-Datum innerhalb von 30 Tagen vor Ablauf der Tabelle (≥ 1.6.2026) liegt, gibt der Skill und das Werkzeug einen Warntext aus, dass eine neue Pfändungsfreigrenzenbekanntmachung des BMJ veröffentlicht und in die Tabelle übernommen werden muss. Pflicht-Quellen: Pfändungsfreigrenzenbekanntmachung 2026 (BGBl. I); BMJ-Pressemitteilung; Konsultation in `juris`/`beck-online`. Verwendung der alten Eckwerte nach 30.6.2026 = Pfändungsfehler mit Aufhebungspotential.
+
 ## Eckwerte (aus Tabelle, dezimal mit Punkt)
 
 Aktuelle Eckdaten (Tabelle 1.7.2025):

--- a/zwangsvollstreckung/skills/zv-vollstreckungsschutz-haertefall-765a/SKILL.md
+++ b/zwangsvollstreckung/skills/zv-vollstreckungsschutz-haertefall-765a/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: zv-vollstreckungsschutz-haertefall-765a
+description: "Vollstreckungsschutz nach § 765a ZPO bei sittenwidriger Haerte. Antrag des Schuldners auf einstweilige Einstellung oder Beschraenkung der Vollstreckung. Anwendungsfaelle Krankheit Suizidgefahr Geburt Obdachlosigkeit Tod naher Angehoeriger. Abgrenzung zu § 769 ZPO (einstweilige Einstellung bei Abwehrklage) und § 712 ZPO (vorlaeufige Vollstreckung). Beweislast Schuldner und Glaubhaftmachung. Schreibvorlage Antrag Glaubhaftmachung Eidesstattliche Versicherung."
+---
+
+# Vollstreckungsschutz § 765a ZPO — Härtefall
+
+## Aufgabe
+
+Antrag des **Schuldners** auf einstweilige Einstellung, Beschränkung oder Aufhebung einer Vollstreckungsmaßnahme, wenn diese eine **mit guten Sitten nicht vereinbare Härte** darstellen würde. Die Vorschrift ist die zentrale Auffangnorm für Härtefälle, in denen die Standard-Schutzmechanismen (P-Konto § 850k ZPO, Pfändungsfreigrenzen § 850c ZPO) nicht ausreichen.
+
+> ⚠️ **Hohe Hürde**: § 765a ZPO ist **eng auszulegen** — nicht jede wirtschaftliche oder soziale Belastung reicht. Erforderlich ist eine Härte, die der **gesamten Rechtsordnung** widerspricht (BGH-Linie). Typisch: existenzielle Gefahr für Leben, Gesundheit, menschenwürdiges Dasein.
+
+## Startet bei
+
+- Vollstreckungsmaßnahme angekündigt oder läuft
+- Schuldner in schwerwiegender persönlicher Situation (Krankheit, drohender Suizid, Schwangerschaft / Geburt, Tod naher Angehöriger, drohende Obdachlosigkeit)
+- Standard-Schutzmechanismen reichen nicht (Pfändungsfreigrenze, P-Konto unzureichend)
+- Klassische Vollstreckungserinnerung § 766 ZPO greift nicht (Verfahrensfehler nicht ersichtlich)
+- Vollstreckungsabwehrklage § 767 ZPO bietet keine schnelle Hilfe
+
+## Rechtsgrundlagen
+
+- **§ 765a Abs. 1 ZPO** — "Auf Antrag des Schuldners kann das Vollstreckungsgericht die Vollstreckung einstweilen einstellen, beschränken oder aufheben, wenn die Maßnahme unter voller Würdigung der Schutzbedürfnisse des Gläubigers wegen ganz besonderer Umstände eine Härte bedeutete, die mit den guten Sitten nicht vereinbar ist."
+- **§ 765a Abs. 2 ZPO** — Anhörung der Beteiligten (Gläubiger).
+- **§ 765a Abs. 3 ZPO** — Bei Räumungsvollstreckung gegen Wohnraum: Pflicht-Anhörung des zuständigen Trägers Sozialhilfe und ggf. weiterer Personen (insb. Suizidgefahr).
+- **Art. 1, 2 GG** — Menschenwürde, Recht auf Leben und körperliche Unversehrtheit; verfassungsrechtlicher Maßstab.
+- **§§ 766, 767, 769 ZPO** — abgrenzende Schutzwege (Erinnerung, Abwehrklage, einstweilige Einstellung bei Klage).
+- **§ 850k ZPO** — P-Konto-Schutz als vorgelagerter Standard-Schutz.
+
+## Leitentscheidungen
+
+- BVerfG, Beschl. v. 26.5.2017 — **2 BvR 1487/17** (Pflicht-Würdigung Suizidrisiko durch Vollstreckungsgericht; verfassungsrechtliche Maßstäbe).
+- BVerfG, Beschl. v. 19.10.1993 — **1 BvR 567/89** ("Zwangsversteigerung des selbst genutzten Eigenheims": verfassungsrechtliche Härteklausel).
+- BGH, Beschl. v. 21.11.2002 — **IX ZB 96/02** (Maßstab Sittenwidrigkeit; nicht jede Härte reicht).
+- BGH, Beschl. v. 4.5.2005 — **I ZB 10/05** (Suizidgefahr: Sachverständigengutachten regelmäßig erforderlich).
+- BGH, Beschl. v. 14.6.2007 — **V ZB 28/07** (Räumungsschutz Wohnraum; Substantiierung Härte).
+- BGH, Beschl. v. 24.11.2005 — **V ZB 99/05** (Vollstreckung Eigenheim trotz Härte zulässig, wenn Gläubigerinteressen überwiegen).
+
+## Typische Konstellationen
+
+### Konstellation A — Suizidgefahr
+
+- **Erforderlich**: aktuelles ärztliches Attest / fachärztliches Gutachten (BGH I ZB 10/05).
+- **Glaubhaftmachung**: substantielle, nicht nur behauptete Suizidgefahr.
+- **Maßnahme**: regelmäßig einstweilige Einstellung mit Wiedervorlage; Verlängerung möglich.
+- **Wichtig**: BVerfG-Linie (2 BvR 1487/17) — Vollstreckungsgericht **muss** Suizidrisiko aktiv würdigen, darf Antrag nicht pauschal ablehnen.
+
+### Konstellation B — Schwere Krankheit / Pflege
+
+- Schwere chronische Erkrankung Schuldner oder Familienangehöriger
+- Krankenhausaufenthalt zum Vollstreckungstermin
+- Substantiierung mit Attest, ggf. ärztlichem Verlauf
+
+### Konstellation C — Schwangerschaft / Geburt
+
+- Hochschwangerschaft (typisch ab 7. Monat)
+- Kürzlich entbunden / Wochenbett-Frist
+- Maßnahme: zeitlich begrenzte Einstellung
+
+### Konstellation D — Räumungsschutz Wohnraum (§ 765a Abs. 3 ZPO)
+
+- Drohende Obdachlosigkeit
+- Suizidgefahr im Wohnsitz
+- Mitbewohner mit besonderen Schutzbedürfnissen (Säugling, Schwerstkranker)
+- **Pflichtanhörung Sozialamt** durch das Gericht
+- Abgrenzung zu **§ 721 ZPO** (Räumungsfrist im Urteil) und **§ 794a ZPO** (Räumungsfrist im Vergleich)
+
+### Konstellation E — Tod / Trauerfall
+
+- Tod naher Angehöriger kürzlich
+- Beerdigung in unmittelbarer Nähe Vollstreckungstermin
+- Maßnahme: kurzfristige Einstellung
+
+### Konstellation F — Existenzielle Bedrohung Lebensgrundlage
+
+- Werkzeug / Berufsbasis betroffen (Abgrenzung zu § 811 ZPO unpfändbar)
+- Verlust der einzigen Arbeitsstelle / Ausbildungsmittel
+- Substantiierung mit konkreten Folgen
+
+## Antragsverfahren
+
+### Schritt 1 — Eilbedürftigkeit
+
+- Vollstreckungstermin nahe oder läuft?
+- Antrag **vor** Vollstreckung, idealerweise mehrere Tage davor
+- Bei laufender Maßnahme: sofortige Eilanträge nach § 769 ZPO parallel
+
+### Schritt 2 — Zuständiges Gericht
+
+- **Vollstreckungsgericht** (§ 764 ZPO) — typisch Amtsgericht am Ort der Maßnahme
+- Bei Räumung: AG am Lage-Ort des Grundstücks
+- Bei Forderungspfändung: AG am Wohnsitz Schuldner
+
+### Schritt 3 — Antragsinhalt
+
+- **Konkrete Maßnahme** bezeichnen (Termin, Ort, Vollstreckungsgegenstand)
+- **Härtegrund** substantiiert darlegen
+- **Glaubhaftmachung** (§ 294 ZPO) — eidesstattliche Versicherung + Belege (Atteste, Sozialamt-Bescheinigungen)
+- **Antrag** auf einstweilige Einstellung / Beschränkung / Aufhebung
+- **Befristung** akzeptieren (typisch 3–6 Monate)
+
+### Schritt 4 — Gläubiger-Anhörung
+
+- Gericht hört Gläubiger
+- Gläubiger kann widersprechen; bei nicht ausreichender Härte Ablehnung möglich
+
+### Schritt 5 — Beschluss
+
+- Mit Auflage / Befristung möglich
+- Verlängerung auf neuen Antrag möglich
+- Rechtsbehelf: **sofortige Beschwerde** § 793 ZPO (zwei Wochen, LG)
+
+## Schreibvorlage — Antrag § 765a ZPO (verkürzt)
+
+```
+[Anwaltskanzlei]                                              [Datum]
+
+An das Amtsgericht [Ort]
+— Vollstreckungsgericht —
+[Anschrift]
+
+In der Zwangsvollstreckungssache
+[Glaeubiger] ./. [Schuldner]
+Az.: [Az. AG / Vollstreckungsauftrag]
+
+Antrag des Schuldners gemaess § 765a ZPO auf
+einstweilige Einstellung der Zwangsvollstreckung
+mit Eilbeduerftigkeit
+
+Sehr geehrte Damen und Herren,
+
+namens und in Vollmacht des Schuldners beantrage ich,
+
+die mit Beschluss / Pfaendungs- und Ueberweisungsbeschluss / Auftrag
+des Gerichtsvollziehers vom [Datum] eingeleitete Zwangsvollstreckung
+gegen den Schuldner [bis zum / einstweilen bis zur Entscheidung
+ueber den Antrag] einstweilen einzustellen.
+
+Begruendung
+
+I. Sachverhalt
+[Konkrete Vollstreckungsmaßnahme — Termin, Ort, Gegenstand]
+
+II. Haertegrund nach § 765a Abs. 1 ZPO
+[Substantiierte Darstellung — Krankheit / Suizidgefahr / Schwanger-
+schaft / Obdachlosigkeit / Trauerfall; mit Atest- / Belegverweis]
+
+III. Glaubhaftmachung (§ 294 ZPO)
+- Aerztliches Attest vom [Datum], Anlage A1
+- Eidesstattliche Versicherung des Schuldners, Anlage A2
+- [ggf. Sozialamt-Bescheinigung, Krankenhaus-Bestaetigung etc.]
+
+IV. Beruecksichtigung der Glaeubigerinteressen
+[Abwaegung — Gewicht der Glaeubigerforderung vs. Schwere der
+Schuldner-Haerte; Hinweis auf Befristung der Einstellung]
+
+V. Antrag
+1. Die Vollstreckung wird einstweilen [bis zum [Datum] / bis auf
+   weiteres mit Wiedervorlage in [X] Monaten] eingestellt.
+2. Hilfsweise: Die Vollstreckung wird auf [konkrete Maßnahme]
+   beschraenkt.
+
+Es wird um eilige Entscheidung gebeten; die Vollstreckung droht am
+[Datum].
+
+Mit freundlichen Gruessen
+[Unterschrift]
+Rechtsanwalt/-anwaeltin
+```
+
+## Risiken und Red Flags
+
+| Konstellation | Rot | Orange | Grün |
+|---|---|---|---|
+| Pauschale Härtebehauptung | Ablehnung absehbar | Substantiierung fehlt | Konkrete Belege beigefügt |
+| Suizidgefahr behauptet ohne Attest | Ablehnung; Vollstreckung läuft | Attest in Vorbereitung | Fachärztliches Gutachten beigebracht |
+| Antrag während laufender Maßnahme | Schaden tritt ein | Eilbedürftigkeit substantiieren | Antrag vor Termin |
+| Gläubiger-Interesse > Schuldner-Härte | Ablehnung wahrscheinlich | knappe Abwägung | klar überwiegende Schuldner-Härte |
+| Räumung Wohnraum ohne Sozialamt | § 765a Abs. 3 ZPO-Verfahrensfehler | Vorbereitung läuft | Pflicht-Anhörung dokumentiert |
+
+## Abgrenzung zu anderen Schutzwegen
+
+| Norm | Wirkung | Wann statt § 765a? |
+|---|---|---|
+| § 766 ZPO Erinnerung | Verfahrensfehler des GV / Vollstreckungsgerichts | Wenn Maßnahme rechtswidrig (nicht nur hart) |
+| § 767 ZPO Vollstreckungsabwehrklage | Materielle Einwendungen gegen den Anspruch | Wenn Anspruch erloschen / nicht durchsetzbar |
+| § 769 ZPO einstweilige Einstellung bei Klage | Während Abwehrklage | Wenn Klage nach § 767 anhängig |
+| § 712 ZPO Schutzantrag im Urteilsverfahren | Vor Rechtskraft | Vor Vollstreckbarkeit |
+| § 850k ZPO P-Konto | Pfändungsschutz Bankkonto | Standard, vorrangig prüfen |
+
+## Querverweise
+
+- `zv-abwehr-schuldner` — übergeordnete Schuldnerschutz-Triage
+- `zv-raeumung-885` — Räumungsvollstreckung (§ 765a Abs. 3 Pflicht)
+- `zv-pfueb-bank` — P-Konto-Schutz parallel
+- `zv-pfaendungstabelle-2025` — Pfändungsfreigrenzen
+- `betreuungsrecht` — bei betreutem Schuldner
+- `fachanwalt-medizinrecht` — bei medizinischen Attest-Fragen
+
+## Quellen und Updates
+
+Stand: 05/2026. § 765a ZPO unverändert; BGH-Linie zu Suizidgefahr (I ZB 10/05) und BVerfG (2 BvR 1487/17) ständige Rechtsprechung. Bei Reform ZPO oder neuer BVerfG-Linie zur Härteabwägung aktualisieren.

--- a/zwangsvollstreckung/werkzeuge/pfaendungsrechner.py
+++ b/zwangsvollstreckung/werkzeuge/pfaendungsrechner.py
@@ -124,6 +124,29 @@ def _quantize(value: Decimal) -> Decimal:
     return value.quantize(Decimal("0.01"), rounding=ROUND_DOWN)
 
 
+def gueltigkeits_warnung(heute: _dt.date | None = None) -> str | None:
+    """Gibt eine Warnung zurueck, wenn die aktuelle Tabelle bald ablaeuft
+    oder bereits abgelaufen ist. Pflicht-Selbstcheck nach § 850c Abs. 4 ZPO
+    (jaehrliche Anpassung der Pfaendungsfreigrenzen)."""
+    today = heute if heute is not None else _dt.date.today()
+    if today > TABELLE_GUELTIG_BIS:
+        return (
+            f"WARNUNG: Pfaendungstabelle ist seit {TABELLE_GUELTIG_BIS.strftime('%d.%m.%Y')} "
+            f"abgelaufen. Aktuelles Tagesdatum {today.strftime('%d.%m.%Y')}. "
+            f"Die hier hinterlegten Eckwerte (Stand 1.7.2025) duerfen nicht mehr verwendet werden. "
+            f"Pflicht: Pfaendungsfreigrenzenbekanntmachung {today.year} (BGBl. I) abrufen "
+            f"und Modul aktualisieren. Verwendung alter Werte = Pfaendungsfehler mit Aufhebungsrisiko."
+        )
+    abstand = (TABELLE_GUELTIG_BIS - today).days
+    if 0 <= abstand <= 30:
+        return (
+            f"HINWEIS: Pfaendungstabelle laeuft am {TABELLE_GUELTIG_BIS.strftime('%d.%m.%Y')} ab "
+            f"(in {abstand} Tagen). Naechste Bekanntmachung des BMJ zu § 850c Abs. 4 ZPO "
+            f"vorbereiten und Modul aktualisieren."
+        )
+    return None
+
+
 def berechne(
     netto: Decimal | float | str,
     unterhaltspflichten: int = 0,
@@ -303,6 +326,14 @@ def _print_tabelle() -> None:
 def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     ns = parser.parse_args(argv)
+
+    # Gueltigkeits-Pruefung vor jeder Ausgabe: Pflicht-Selbstcheck, damit
+    # nach Ablauf der Tabelle (30.6.2026) keine alten Werte unbemerkt
+    # weiterverwendet werden.
+    warn = gueltigkeits_warnung()
+    if warn:
+        import sys
+        print(warn, file=sys.stderr)
 
     if ns.tabelle:
         _print_tabelle()


### PR DESCRIPTION
## Stresstest Zwangsvollstreckung v9.0.0

Nach grossem Sweep des ZV-Plugins (v9.0.0, 17 Skills) zwei neue Skills + zwei Verbesserungen + Steuer-Verifikations-Markierung. Plugin waechst auf **19 Skills**.

## ZV-Plugin Neuerungen

### `zv-eu-kontenpfaendung-655-2014` (NEU)

Europaeische Kontenpfaendung nach VO (EU) 655/2014 (EuKtPVO):
- §§ 946-959 ZPO als Durchfuehrungsrecht; Formblatt I DV (EU) 2016/1823
- 10/5-Arbeitstage-Frist Gerichtsentscheidung; 30-Tage-Hauptsachefrist Art. 10
- BfJ als Uebermittlungsstelle; Sicherheitsleistung Art. 12
- EuGH C-555/18, BGH IX ZB 26/20

### `zv-vollstreckungsschutz-haertefall-765a` (NEU)

Vertiefter Haertefall-Schutz § 765a ZPO mit 6 Konstellationen (Suizidgefahr, Krankheit, Schwangerschaft, Raeumung Wohnraum, Trauerfall, existenzielle Lebensgrundlage):
- BVerfG 2 BvR 1487/17, BGH I ZB 10/05
- § 765a Abs. 3 ZPO-Pflichtanhoerung Sozialamt bei Raeumung
- Schreibvorlage Antrag mit Glaubhaftmachung

### Pfaendungsrechner Auto-Warnung

Tabelle 1.7.2025 laeuft 30.6.2026 ab. Neue Funktion `gueltigkeits_warnung()` in `werkzeuge/pfaendungsrechner.py`:
```
Heute (25.5.2026):  None
15.6.2026:          HINWEIS (15 Tage vor Ablauf)
1.7.2026:           WARNUNG (Tabelle abgelaufen)
```

### plugin.json + README

- Description erweitert (≤ 300 Zeichen)
- Keywords ergaenzt: `eu-kontenpfaendung`, `eu-vo-655-2014`, `haertefall-765a`, `vollstreckungsschutz`
- README mit NEU-Markern

## Steuer-Plugin Verifikations-Markierung

`anw-einspruch-finanzamt` + `anw-kaltstart-interview`: Zitat "Nds. FG, Beschl. v. 12.2.2026 – 2 K 152/25" um Verifikationshinweis ergaenzt gemaess CLAUDE.md.

## Test plan

- [x] Validator OK
- [x] 19 Skills mit Frontmatter
- [x] plugin.json description ≤ 300 Zeichen
- [x] Python-Syntax + Smoke-Tests OK

https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL

---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_