### PR TITLE
fix(pfaendungsrechner): Codex P2 Bekanntmachungs-Jahr aus Tabellenstart

### DIFF
--- a/zwangsvollstreckung/werkzeuge/pfaendungsrechner.py
+++ b/zwangsvollstreckung/werkzeuge/pfaendungsrechner.py
@@ -129,12 +129,16 @@ def gueltigkeits_warnung(heute: _dt.date | None = None) -> str | None:
     oder bereits abgelaufen ist. Pflicht-Selbstcheck nach § 850c Abs. 4 ZPO
     (jaehrliche Anpassung der Pfaendungsfreigrenzen)."""
     today = heute if heute is not None else _dt.date.today()
+    # Die jaehrliche Bekanntmachung knuepft an den Tabellenstart an,
+    # nicht an das Kalenderjahr des Tagesdatums (sonst wird bei spaeter
+    # Aktualisierung auf das falsche Veroeffentlichungsjahr verwiesen).
+    fehlendes_jahr = TABELLE_GUELTIG_AB.year + 1
     if today > TABELLE_GUELTIG_BIS:
         return (
             f"WARNUNG: Pfaendungstabelle ist seit {TABELLE_GUELTIG_BIS.strftime('%d.%m.%Y')} "
             f"abgelaufen. Aktuelles Tagesdatum {today.strftime('%d.%m.%Y')}. "
             f"Die hier hinterlegten Eckwerte (Stand 1.7.2025) duerfen nicht mehr verwendet werden. "
-            f"Pflicht: Pfaendungsfreigrenzenbekanntmachung {today.year} (BGBl. I) abrufen "
+            f"Pflicht: Pfaendungsfreigrenzenbekanntmachung {fehlendes_jahr} (BGBl. I) abrufen "
             f"und Modul aktualisieren. Verwendung alter Werte = Pfaendungsfehler mit Aufhebungsrisiko."
         )
     abstand = (TABELLE_GUELTIG_BIS - today).days


### PR DESCRIPTION
Setzt Codex-Befund P2 um.

**Problem:** gueltigkeits_warnung() baute das Jahr der erwarteten Bekanntmachung aus today.year. Lief der Rechner jenseits einer Jahresgrenze mit veralteter Tabelle (z. B. am 1.1.2027 mit Tabelle 1.7.2025-30.6.2026), wurde auf das falsche Veroeffentlichungsjahr verwiesen (2027 statt 2026).

**Fix:** fehlendes_jahr = TABELLE_GUELTIG_AB.year + 1. Damit wird immer auf die naechste turnusmaessige Bekanntmachung (Fruehjahr des Folgejahres) verwiesen, unabhaengig vom Tagesdatum.

**Verifikation:**
- 2027-01-01 -> WARNUNG mit '2026' (vorher: '2027' falsch)
- 2026-12-31 -> WARNUNG mit '2026'
- 2026-06-10 -> HINWEIS (in 20 Tagen)
- 2025-09-01 -> None