### PR TITLE
fix(bav-versorgungsordnung): Codex P1 Haertefall-Bedingung § 16 BetrAVG wiederhergestellt

### DIFF
--- a/bav-strategie-konzern/skills/versorgungsordnung-und-betriebsvereinbarung-drafting/SKILL.md
+++ b/bav-strategie-konzern/skills/versorgungsordnung-und-betriebsvereinbarung-drafting/SKILL.md
@@ -166,7 +166,7 @@ Verbraucherpreisindex für Deutschland (Statistisches Bundesamt).
 BetrAVG, wenn die laufenden Renten jährlich um mindestens 1 % erhöht werden.
 (3) Die wirtschaftliche Lage des Unternehmens ist gem. § 16 Abs. 1 BetrAVG zu
 berücksichtigen. Eine Anpassung kann unterbleiben, soweit sie die wirtschaftliche
-für Prüfungsschema).
+Lage des Unternehmens überfordert (Schema im Skill `anpassungspruefung-paragraph-16-betravg`).
 
 § 10 Widerrufsvorbehalte
 (1) Das Unternehmen behält sich vor, die Versorgungsordnung mit Wirkung für die


### PR DESCRIPTION
Setzt Codex-Befund P1 um.

**Problem (entstanden in PR #97):** Beim Slug-Praefix-Cleanup wurden in § 9 Abs. 3 der Muster-Versorgungsordnung mehr Woerter entfernt als beabsichtigt. Die materielle Voraussetzung Lage des Unternehmens ueberfordert (Kernbestandteil der Haertefallklausel nach § 16 BetrAVG) fiel weg; uebrig blieb ein Fragment fuer Pruefungsschema)..

**Fix:** Klausel wiederhergestellt:
Eine Anpassung kann unterbleiben, soweit sie die wirtschaftliche Lage des Unternehmens ueberfordert (Schema im Skill anpassungspruefung-paragraph-16-betravg).

Damit ist sowohl die materielle Voraussetzung als auch der Cross-Ref auf das Pruefungsschema erhalten.