### PR TITLE
feat(fachanwalt): 72 generische Skills (Erstgespraech + Vergleich + Schriftsatz)

### DIFF
--- a/fachanwalt-agrarrecht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-agrarrecht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Agrar-, Forst- und Lebensmittelrecht: Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Agrar-, Forst- und Lebensmittelrecht
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Agrar-, Forst- und Lebensmittelrecht (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Agrar-, Forst- und Lebensmittelrecht:
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: Hofnachfolge, GAP-Direktzahlungen, Landpachtvertrag, Tierhaltung/TierSchG, Lebensmittelrecht
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Klage/Widerspruch im Agrarverwaltungs- oder Pachtprozess). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Agrar-, Forst- und Lebensmittelrecht:
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Agrar-, Forst- und Lebensmittelrecht.
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- §§ 585 ff. BGB, GAP-DZ-VO, BTSchG, BNatSchG, BImSchG, LFGB (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Agrar-, Forst- und Lebensmittelrecht). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Agrar-, Forst- und Lebensmittelrecht: Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-agrarrecht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-agrarrecht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Klage/Widerspruch im Agrarverwaltungs- oder Pachtprozess: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Agrar-, Forst- und Lebensmittelrecht
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Agrar-, Forst- und Lebensmittelrecht erstellt werden, typischerweise: Klage/Widerspruch im Agrarverwaltungs- oder Pachtprozess.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in §§ 585 ff. BGB, GAP-DZ-VO, BTSchG, BNatSchG, BImSchG, LFGB eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Agrar-, Forst- und Lebensmittelrecht typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Agrar-, Forst- und Lebensmittelrecht
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Agrar-, Forst- und Lebensmittelrecht.
+- §§ 585 ff. BGB, GAP-DZ-VO, BTSchG, BNatSchG, BImSchG, LFGB sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Agrar-, Forst- und Lebensmittelrecht
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus §§ 585 ff. BGB, GAP-DZ-VO, BTSchG, BNatSchG, BImSchG, LFGB und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Agrar-, Forst- und Lebensmittelrecht (Klage/Widerspruch im Agrarverwaltungs- oder Pachtprozess):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Agrar-, Forst- und Lebensmittelrecht-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Agrar-, Forst- und Lebensmittelrecht ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-agrarrecht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-agrarrecht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Agrar-, Forst- und Lebensmittelrecht: ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Agrar-, Forst- und Lebensmittelrecht
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Agrar-, Forst- und Lebensmittelrecht, in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Pachtaufhebung, Hofuebergabe-Streit, Direktzahlungs-Rueckforderung.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Agrar-, Forst- und Lebensmittelrecht typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus §§ 585 ff. BGB, GAP-DZ-VO, BTSchG, BNatSchG, BImSchG, LFGB verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Agrar-, Forst- und Lebensmittelrecht
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> §§ 585 ff. BGB und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von §§ 585 ff. BGB und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Agrar-, Forst- und Lebensmittelrecht oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Agrar-, Forst- und Lebensmittelrecht:
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-arbeitsrecht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-arbeitsrecht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Individual- und kollektives Arbeitsrecht: Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Individual- und kollektives Arbeitsrecht
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Individual- und kollektives Arbeitsrecht (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Individual- und kollektives Arbeitsrecht:
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: Kuendigung, Abmahnung, Befristung, Aufhebungsvertrag, Lohn, Urlaub, BR-Sachen
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Kuendigungsschutzklage, Befristungskontrollklage, Zahlungsklage Arbeitsgericht). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Individual- und kollektives Arbeitsrecht:
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Individual- und kollektives Arbeitsrecht.
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- KSchG, TzBfG, BetrVG, BGB, EFZG, BUrlG, AGG, NachwG (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Individual- und kollektives Arbeitsrecht). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Individual- und kollektives Arbeitsrecht: Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-arbeitsrecht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-arbeitsrecht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Kuendigungsschutzklage, Befristungskontrollklage, Zahlungsklage Arbeitsgericht: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Individual- und kollektives Arbeitsrecht
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Individual- und kollektives Arbeitsrecht erstellt werden, typischerweise: Kuendigungsschutzklage, Befristungskontrollklage, Zahlungsklage Arbeitsgericht.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in KSchG, TzBfG, BetrVG, BGB, EFZG, BUrlG, AGG, NachwG eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Individual- und kollektives Arbeitsrecht typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Individual- und kollektives Arbeitsrecht
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Individual- und kollektives Arbeitsrecht.
+- KSchG, TzBfG, BetrVG, BGB, EFZG, BUrlG, AGG, NachwG sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Individual- und kollektives Arbeitsrecht
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus KSchG, TzBfG, BetrVG, BGB, EFZG, BUrlG, AGG, NachwG und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Individual- und kollektives Arbeitsrecht (Kuendigungsschutzklage, Befristungskontrollklage, Zahlungsklage Arbeitsgericht):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Individual- und kollektives Arbeitsrecht-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Individual- und kollektives Arbeitsrecht ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-arbeitsrecht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-arbeitsrecht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Individual- und kollektives Arbeitsrecht: ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Individual- und kollektives Arbeitsrecht
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Individual- und kollektives Arbeitsrecht, in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Aufhebungsvertrag/Abfindung, Betriebsuebergangsstreit, Mobbing/Schadensersatz.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Individual- und kollektives Arbeitsrecht typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus KSchG, TzBfG, BetrVG, BGB, EFZG, BUrlG, AGG, NachwG verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Individual- und kollektives Arbeitsrecht
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> KSchG und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von KSchG und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Individual- und kollektives Arbeitsrecht oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Individual- und kollektives Arbeitsrecht:
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-bank-kapitalmarktrecht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-bank-kapitalmarktrecht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Bank-, Kapitalmarkt- und Wertpapierrecht: Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Bank-, Kapitalmarkt- und Wertpapierrecht
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Bank-, Kapitalmarkt- und Wertpapierrecht (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Bank-, Kapitalmarkt- und Wertpapierrecht:
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: Anlageberatung, Verbraucherdarlehen, Widerruf, Phishing, AGB-Banken, Geldwaesche
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Klage auf Schadensersatz aus Falschberatung, Widerrufsklage Verbraucherdarlehen). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Bank-, Kapitalmarkt- und Wertpapierrecht:
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Bank-, Kapitalmarkt- und Wertpapierrecht.
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- §§ 488 ff. BGB, WpHG, KWG, ZAG, GwG, MiFID II, PRIIPs-VO, MaComp (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Bank-, Kapitalmarkt- und Wertpapierrecht). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Bank-, Kapitalmarkt- und Wertpapierrecht: Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-bank-kapitalmarktrecht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-bank-kapitalmarktrecht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Klage auf Schadensersatz aus Falschberatung, Widerrufsklage Verbraucherdarlehen: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Bank-, Kapitalmarkt- und Wertpapierrecht
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Bank-, Kapitalmarkt- und Wertpapierrecht erstellt werden, typischerweise: Klage auf Schadensersatz aus Falschberatung, Widerrufsklage Verbraucherdarlehen.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in §§ 488 ff. BGB, WpHG, KWG, ZAG, GwG, MiFID II, PRIIPs-VO, MaComp eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Bank-, Kapitalmarkt- und Wertpapierrecht typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Bank-, Kapitalmarkt- und Wertpapierrecht
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Bank-, Kapitalmarkt- und Wertpapierrecht.
+- §§ 488 ff. BGB, WpHG, KWG, ZAG, GwG, MiFID II, PRIIPs-VO, MaComp sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Bank-, Kapitalmarkt- und Wertpapierrecht
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus §§ 488 ff. BGB, WpHG, KWG, ZAG, GwG, MiFID II, PRIIPs-VO, MaComp und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Bank-, Kapitalmarkt- und Wertpapierrecht (Klage auf Schadensersatz aus Falschberatung, Widerrufsklage Verbraucherdarlehen):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Bank-, Kapitalmarkt- und Wertpapierrecht-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Bank-, Kapitalmarkt- und Wertpapierrecht ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-bank-kapitalmarktrecht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-bank-kapitalmarktrecht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Bank-, Kapitalmarkt- und Wertpapierrecht: ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Bank-, Kapitalmarkt- und Wertpapierrecht
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Bank-, Kapitalmarkt- und Wertpapierrecht, in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Rueckabwicklung Anlageberatung, Phishing/Online-Banking-Streit.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Bank-, Kapitalmarkt- und Wertpapierrecht typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus §§ 488 ff. BGB, WpHG, KWG, ZAG, GwG, MiFID II, PRIIPs-VO, MaComp verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Bank-, Kapitalmarkt- und Wertpapierrecht
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> §§ 488 ff. BGB und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von §§ 488 ff. BGB und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Bank-, Kapitalmarkt- und Wertpapierrecht oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Bank-, Kapitalmarkt- und Wertpapierrecht:
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-bau-architektenrecht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Privates Baurecht, Architekten- und Ingenieurrecht: Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Privates Baurecht, Architekten- und Ingenieurrecht
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Privates Baurecht, Architekten- und Ingenieurrecht (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Privates Baurecht, Architekten- und Ingenieurrecht:
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: Werkvertrag, BGB-/VOB-Bau, Maengel, Abnahme, HOAI, Sicherheiten, Bauhandwerker
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Klage auf Werklohn, Schadensersatzklage Baumangel, Honorarklage HOAI). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Privates Baurecht, Architekten- und Ingenieurrecht:
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Privates Baurecht, Architekten- und Ingenieurrecht.
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- §§ 631 ff. BGB, VOB/B, HOAI, MaBV, BauFordSiG (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Privates Baurecht, Architekten- und Ingenieurrecht). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Privates Baurecht, Architekten- und Ingenieurrecht: Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-bau-architektenrecht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Klage auf Werklohn, Schadensersatzklage Baumangel, Honorarklage HOAI: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Privates Baurecht, Architekten- und Ingenieurrecht
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Privates Baurecht, Architekten- und Ingenieurrecht erstellt werden, typischerweise: Klage auf Werklohn, Schadensersatzklage Baumangel, Honorarklage HOAI.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in §§ 631 ff. BGB, VOB/B, HOAI, MaBV, BauFordSiG eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Privates Baurecht, Architekten- und Ingenieurrecht typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Privates Baurecht, Architekten- und Ingenieurrecht
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Privates Baurecht, Architekten- und Ingenieurrecht.
+- §§ 631 ff. BGB, VOB/B, HOAI, MaBV, BauFordSiG sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Privates Baurecht, Architekten- und Ingenieurrecht
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus §§ 631 ff. BGB, VOB/B, HOAI, MaBV, BauFordSiG und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Privates Baurecht, Architekten- und Ingenieurrecht (Klage auf Werklohn, Schadensersatzklage Baumangel, Honorarklage HOAI):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Privates Baurecht, Architekten- und Ingenieurrecht-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Privates Baurecht, Architekten- und Ingenieurrecht ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-bau-architektenrecht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Privates Baurecht, Architekten- und Ingenieurrecht: ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Privates Baurecht, Architekten- und Ingenieurrecht
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Privates Baurecht, Architekten- und Ingenieurrecht, in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Baumangel/Nacherfuellung, Bauverzug, HOAI-Honorar, Abnahmestreit.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Privates Baurecht, Architekten- und Ingenieurrecht typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus §§ 631 ff. BGB, VOB/B, HOAI, MaBV, BauFordSiG verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Privates Baurecht, Architekten- und Ingenieurrecht
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> §§ 631 ff. BGB und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von §§ 631 ff. BGB und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Privates Baurecht, Architekten- und Ingenieurrecht oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Privates Baurecht, Architekten- und Ingenieurrecht:
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-erbrecht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-erbrecht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Erb- und Pflichtteilsrecht: Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Erb- und Pflichtteilsrecht
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Erb- und Pflichtteilsrecht (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Erb- und Pflichtteilsrecht:
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: Testament, Erbschein, Pflichtteil, Erbauseinandersetzung, Vermaechtnis, ErbStG
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Pflichtteilsklage, Erbschein-Antrag/Beschwerde, Erbenfeststellungsklage). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Erb- und Pflichtteilsrecht:
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Erb- und Pflichtteilsrecht.
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- §§ 1922 ff. BGB, FamFG, ErbStG, BeurkG (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Erb- und Pflichtteilsrecht). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Erb- und Pflichtteilsrecht: Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-erbrecht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-erbrecht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Pflichtteilsklage, Erbschein-Antrag/Beschwerde, Erbenfeststellungsklage: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Erb- und Pflichtteilsrecht
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Erb- und Pflichtteilsrecht erstellt werden, typischerweise: Pflichtteilsklage, Erbschein-Antrag/Beschwerde, Erbenfeststellungsklage.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in §§ 1922 ff. BGB, FamFG, ErbStG, BeurkG eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Erb- und Pflichtteilsrecht typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Erb- und Pflichtteilsrecht
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Erb- und Pflichtteilsrecht.
+- §§ 1922 ff. BGB, FamFG, ErbStG, BeurkG sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Erb- und Pflichtteilsrecht
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus §§ 1922 ff. BGB, FamFG, ErbStG, BeurkG und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Erb- und Pflichtteilsrecht (Pflichtteilsklage, Erbschein-Antrag/Beschwerde, Erbenfeststellungsklage):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Erb- und Pflichtteilsrecht-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Erb- und Pflichtteilsrecht ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-erbrecht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-erbrecht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Erb- und Pflichtteilsrecht: ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Erb- und Pflichtteilsrecht
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Erb- und Pflichtteilsrecht, in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Pflichtteilsabfindung, Erbauseinandersetzung, Hoferbenstreit.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Erb- und Pflichtteilsrecht typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus §§ 1922 ff. BGB, FamFG, ErbStG, BeurkG verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Erb- und Pflichtteilsrecht
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> §§ 1922 ff. BGB und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von §§ 1922 ff. BGB und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Erb- und Pflichtteilsrecht oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Erb- und Pflichtteilsrecht:
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-familienrecht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-familienrecht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Familien-, Kindschafts- und Versorgungsausgleichsrecht: Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Familien-, Kindschafts- und Versorgungsausgleichsrecht
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Familien-, Kindschafts- und Versorgungsausgleichsrecht (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Familien-, Kindschafts- und Versorgungsausgleichsrecht:
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: Scheidung, Unterhalt, ZGW, VA, Sorge/Umgang, Gewaltschutz, EheVertrag
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Scheidungsantrag, Unterhaltsklage, Sorgerechtsantrag, VA-Beschwerde). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Familien-, Kindschafts- und Versorgungsausgleichsrecht:
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Familien-, Kindschafts- und Versorgungsausgleichsrecht.
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- §§ 1297 ff. BGB, FamFG, VersAusglG, UVG, GewSchG, IntFamRVG (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Familien-, Kindschafts- und Versorgungsausgleichsrecht). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Familien-, Kindschafts- und Versorgungsausgleichsrecht: Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-familienrecht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-familienrecht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Scheidungsantrag, Unterhaltsklage, Sorgerechtsantrag, VA-Beschwerde: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Familien-, Kindschafts- und Versorgungsausgleichsrecht
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Familien-, Kindschafts- und Versorgungsausgleichsrecht erstellt werden, typischerweise: Scheidungsantrag, Unterhaltsklage, Sorgerechtsantrag, VA-Beschwerde.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in §§ 1297 ff. BGB, FamFG, VersAusglG, UVG, GewSchG, IntFamRVG eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Familien-, Kindschafts- und Versorgungsausgleichsrecht typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Familien-, Kindschafts- und Versorgungsausgleichsrecht
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Familien-, Kindschafts- und Versorgungsausgleichsrecht.
+- §§ 1297 ff. BGB, FamFG, VersAusglG, UVG, GewSchG, IntFamRVG sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Familien-, Kindschafts- und Versorgungsausgleichsrecht
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus §§ 1297 ff. BGB, FamFG, VersAusglG, UVG, GewSchG, IntFamRVG und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Familien-, Kindschafts- und Versorgungsausgleichsrecht (Scheidungsantrag, Unterhaltsklage, Sorgerechtsantrag, VA-Beschwerde):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Familien-, Kindschafts- und Versorgungsausgleichsrecht-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Familien-, Kindschafts- und Versorgungsausgleichsrecht ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-familienrecht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-familienrecht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Familien-, Kindschafts- und Versorgungsausgleichsrecht: ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Familien-, Kindschafts- und Versorgungsausgleichsrecht
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Familien-, Kindschafts- und Versorgungsausgleichsrecht, in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Trennungs- und Scheidungsfolgenvereinbarung, Umgangs-Mediation.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Familien-, Kindschafts- und Versorgungsausgleichsrecht typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus §§ 1297 ff. BGB, FamFG, VersAusglG, UVG, GewSchG, IntFamRVG verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Familien-, Kindschafts- und Versorgungsausgleichsrecht
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> §§ 1297 ff. BGB und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von §§ 1297 ff. BGB und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Familien-, Kindschafts- und Versorgungsausgleichsrecht oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Familien-, Kindschafts- und Versorgungsausgleichsrecht:
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-gewerblicher-rechtsschutz/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-gewerblicher-rechtsschutz/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Marken-, Patent-, Design- und Wettbewerbsrecht: Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Marken-, Patent-, Design- und Wettbewerbsrecht
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Marken-, Patent-, Design- und Wettbewerbsrecht (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Marken-, Patent-, Design- und Wettbewerbsrecht:
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: Marken, Designs, Patente, UWG-Abmahnung, Lizenz, Domain
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Abmahnung, Antrag eV, Unterlassungsklage, Loeschungsklage Marke). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Marken-, Patent-, Design- und Wettbewerbsrecht:
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Marken-, Patent-, Design- und Wettbewerbsrecht.
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- MarkenG, UWG, PatG, GeschmMG, DesignG, UrhG, GeschGehG, GMV/UMV (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Marken-, Patent-, Design- und Wettbewerbsrecht). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Marken-, Patent-, Design- und Wettbewerbsrecht: Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-gewerblicher-rechtsschutz/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-gewerblicher-rechtsschutz/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Abmahnung, Antrag eV, Unterlassungsklage, Loeschungsklage Marke: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Marken-, Patent-, Design- und Wettbewerbsrecht
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Marken-, Patent-, Design- und Wettbewerbsrecht erstellt werden, typischerweise: Abmahnung, Antrag eV, Unterlassungsklage, Loeschungsklage Marke.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in MarkenG, UWG, PatG, GeschmMG, DesignG, UrhG, GeschGehG, GMV/UMV eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Marken-, Patent-, Design- und Wettbewerbsrecht typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Marken-, Patent-, Design- und Wettbewerbsrecht
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Marken-, Patent-, Design- und Wettbewerbsrecht.
+- MarkenG, UWG, PatG, GeschmMG, DesignG, UrhG, GeschGehG, GMV/UMV sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Marken-, Patent-, Design- und Wettbewerbsrecht
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus MarkenG, UWG, PatG, GeschmMG, DesignG, UrhG, GeschGehG, GMV/UMV und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Marken-, Patent-, Design- und Wettbewerbsrecht (Abmahnung, Antrag eV, Unterlassungsklage, Loeschungsklage Marke):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Marken-, Patent-, Design- und Wettbewerbsrecht-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Marken-, Patent-, Design- und Wettbewerbsrecht ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-gewerblicher-rechtsschutz/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-gewerblicher-rechtsschutz/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Marken-, Patent-, Design- und Wettbewerbsrecht: ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Marken-, Patent-, Design- und Wettbewerbsrecht
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Marken-, Patent-, Design- und Wettbewerbsrecht, in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Abschlusserklaerung, Lizenzvereinbarung, Koexistenzvereinbarung.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Marken-, Patent-, Design- und Wettbewerbsrecht typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus MarkenG, UWG, PatG, GeschmMG, DesignG, UrhG, GeschGehG, GMV/UMV verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Marken-, Patent-, Design- und Wettbewerbsrecht
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> MarkenG und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von MarkenG und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Marken-, Patent-, Design- und Wettbewerbsrecht oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Marken-, Patent-, Design- und Wettbewerbsrecht:
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-handels-gesellschaftsrecht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-handels-gesellschaftsrecht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Handels- und Gesellschaftsrecht: Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Handels- und Gesellschaftsrecht
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Handels- und Gesellschaftsrecht (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Handels- und Gesellschaftsrecht:
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: Gruendung, Anteilsuebertragung, Gesellschafterstreit, GF-Haftung, M&A
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Anfechtungs-/Nichtigkeitsklage GV-Beschluss, Auskunftsklage, Squeeze-out). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Handels- und Gesellschaftsrecht:
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Handels- und Gesellschaftsrecht.
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- HGB, GmbHG, AktG, UmwG, GenG, GwG (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Handels- und Gesellschaftsrecht). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Handels- und Gesellschaftsrecht: Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-handels-gesellschaftsrecht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-handels-gesellschaftsrecht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Anfechtungs-/Nichtigkeitsklage GV-Beschluss, Auskunftsklage, Squeeze-out: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Handels- und Gesellschaftsrecht
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Handels- und Gesellschaftsrecht erstellt werden, typischerweise: Anfechtungs-/Nichtigkeitsklage GV-Beschluss, Auskunftsklage, Squeeze-out.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in HGB, GmbHG, AktG, UmwG, GenG, GwG eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Handels- und Gesellschaftsrecht typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Handels- und Gesellschaftsrecht
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Handels- und Gesellschaftsrecht.
+- HGB, GmbHG, AktG, UmwG, GenG, GwG sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Handels- und Gesellschaftsrecht
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus HGB, GmbHG, AktG, UmwG, GenG, GwG und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Handels- und Gesellschaftsrecht (Anfechtungs-/Nichtigkeitsklage GV-Beschluss, Auskunftsklage, Squeeze-out):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Handels- und Gesellschaftsrecht-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Handels- und Gesellschaftsrecht ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-handels-gesellschaftsrecht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-handels-gesellschaftsrecht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Handels- und Gesellschaftsrecht: ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Handels- und Gesellschaftsrecht
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Handels- und Gesellschaftsrecht, in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Gesellschafterstreit, Anteilsabfindung, Geschaeftsfuehrer-Aufhebung.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Handels- und Gesellschaftsrecht typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus HGB, GmbHG, AktG, UmwG, GenG, GwG verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Handels- und Gesellschaftsrecht
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> HGB und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von HGB und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Handels- und Gesellschaftsrecht oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Handels- und Gesellschaftsrecht:
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-insolvenz-sanierungsrecht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-insolvenz-sanierungsrecht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Insolvenz- und Restrukturierungsrecht: Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Insolvenz- und Restrukturierungsrecht
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Insolvenz- und Restrukturierungsrecht (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Insolvenz- und Restrukturierungsrecht:
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: Eigenverwaltung, Insolvenzantrag, StaRUG, Anfechtung, Sanierungsplanung
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Insolvenzantrag, Anfechtungsklage, StaRUG-Restrukturierungsantrag). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Insolvenz- und Restrukturierungsrecht:
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Insolvenz- und Restrukturierungsrecht.
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- InsO, StaRUG, AnfG, EuInsVO, COVInsAG-Nachwirkungen (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Insolvenz- und Restrukturierungsrecht). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Insolvenz- und Restrukturierungsrecht: Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-insolvenz-sanierungsrecht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-insolvenz-sanierungsrecht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Insolvenzantrag, Anfechtungsklage, StaRUG-Restrukturierungsantrag: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Insolvenz- und Restrukturierungsrecht
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Insolvenz- und Restrukturierungsrecht erstellt werden, typischerweise: Insolvenzantrag, Anfechtungsklage, StaRUG-Restrukturierungsantrag.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in InsO, StaRUG, AnfG, EuInsVO, COVInsAG-Nachwirkungen eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Insolvenz- und Restrukturierungsrecht typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Insolvenz- und Restrukturierungsrecht
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Insolvenz- und Restrukturierungsrecht.
+- InsO, StaRUG, AnfG, EuInsVO, COVInsAG-Nachwirkungen sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Insolvenz- und Restrukturierungsrecht
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus InsO, StaRUG, AnfG, EuInsVO, COVInsAG-Nachwirkungen und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Insolvenz- und Restrukturierungsrecht (Insolvenzantrag, Anfechtungsklage, StaRUG-Restrukturierungsantrag):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Insolvenz- und Restrukturierungsrecht-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Insolvenz- und Restrukturierungsrecht ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-insolvenz-sanierungsrecht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-insolvenz-sanierungsrecht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Insolvenz- und Restrukturierungsrecht: ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Insolvenz- und Restrukturierungsrecht
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Insolvenz- und Restrukturierungsrecht, in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Sanierungsvergleich, Anfechtungs-Vergleich, Restrukturierungsplan.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Insolvenz- und Restrukturierungsrecht typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus InsO, StaRUG, AnfG, EuInsVO, COVInsAG-Nachwirkungen verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Insolvenz- und Restrukturierungsrecht
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> InsO und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von InsO und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Insolvenz- und Restrukturierungsrecht oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Insolvenz- und Restrukturierungsrecht:
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-internationales-wirtschaftsrecht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-internationales-wirtschaftsrecht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Internationales Wirtschafts- und Schiedsrecht: Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Internationales Wirtschafts- und Schiedsrecht
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Internationales Wirtschafts- und Schiedsrecht (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Internationales Wirtschafts- und Schiedsrecht:
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: CISG, EuGVVO/Brussels Ia, Rom I/II, Schiedsklauseln, INCOTERMS
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Klage mit CISG-/EuGVVO-Bezug, Schiedsklage, Vollstreckung Auslandsurteil). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Internationales Wirtschafts- und Schiedsrecht:
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Internationales Wirtschafts- und Schiedsrecht.
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- CISG, Rom-I-VO, Rom-II-VO, EuGVVO, NYC58, ICC-/DIS-Schiedsordnung (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Internationales Wirtschafts- und Schiedsrecht). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Internationales Wirtschafts- und Schiedsrecht: Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-internationales-wirtschaftsrecht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-internationales-wirtschaftsrecht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Klage mit CISG-/EuGVVO-Bezug, Schiedsklage, Vollstreckung Auslandsurteil: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Internationales Wirtschafts- und Schiedsrecht
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Internationales Wirtschafts- und Schiedsrecht erstellt werden, typischerweise: Klage mit CISG-/EuGVVO-Bezug, Schiedsklage, Vollstreckung Auslandsurteil.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in CISG, Rom-I-VO, Rom-II-VO, EuGVVO, NYC58, ICC-/DIS-Schiedsordnung eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Internationales Wirtschafts- und Schiedsrecht typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Internationales Wirtschafts- und Schiedsrecht
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Internationales Wirtschafts- und Schiedsrecht.
+- CISG, Rom-I-VO, Rom-II-VO, EuGVVO, NYC58, ICC-/DIS-Schiedsordnung sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Internationales Wirtschafts- und Schiedsrecht
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus CISG, Rom-I-VO, Rom-II-VO, EuGVVO, NYC58, ICC-/DIS-Schiedsordnung und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Internationales Wirtschafts- und Schiedsrecht (Klage mit CISG-/EuGVVO-Bezug, Schiedsklage, Vollstreckung Auslandsurteil):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Internationales Wirtschafts- und Schiedsrecht-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Internationales Wirtschafts- und Schiedsrecht ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-internationales-wirtschaftsrecht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-internationales-wirtschaftsrecht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Internationales Wirtschafts- und Schiedsrecht: ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Internationales Wirtschafts- und Schiedsrecht
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Internationales Wirtschafts- und Schiedsrecht, in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Cross-Border-Settlement, Mediation Schiedsverfahren.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Internationales Wirtschafts- und Schiedsrecht typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus CISG, Rom-I-VO, Rom-II-VO, EuGVVO, NYC58, ICC-/DIS-Schiedsordnung verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Internationales Wirtschafts- und Schiedsrecht
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> CISG und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von CISG und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Internationales Wirtschafts- und Schiedsrecht oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Internationales Wirtschafts- und Schiedsrecht:
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-it-recht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-it-recht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer IT-, Datenschutz- und Telemedienrecht: Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im IT-, Datenschutz- und Telemedienrecht
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich IT-, Datenschutz- und Telemedienrecht (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer IT-, Datenschutz- und Telemedienrecht:
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: DSGVO, IT-Vertrag, Cloud, KI-VO, NIS-2, TDDDG, Datenpanne
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Unterlassungsklage Datenschutz, Klage IT-Vertrag, DSGVO-Bussgeldwiderspruch). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich IT-, Datenschutz- und Telemedienrecht:
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft IT-, Datenschutz- und Telemedienrecht.
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- DSGVO, BDSG, TDDDG, KI-VO, NIS-2-RL, BGB-Werk-/Mietvertrag (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich IT-, Datenschutz- und Telemedienrecht). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich IT-, Datenschutz- und Telemedienrecht: Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-it-recht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-it-recht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Unterlassungsklage Datenschutz, Klage IT-Vertrag, DSGVO-Bussgeldwiderspruch: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im IT-, Datenschutz- und Telemedienrecht
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich IT-, Datenschutz- und Telemedienrecht erstellt werden, typischerweise: Unterlassungsklage Datenschutz, Klage IT-Vertrag, DSGVO-Bussgeldwiderspruch.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in DSGVO, BDSG, TDDDG, KI-VO, NIS-2-RL, BGB-Werk-/Mietvertrag eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei IT-, Datenschutz- und Telemedienrecht typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im IT-, Datenschutz- und Telemedienrecht
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer IT-, Datenschutz- und Telemedienrecht.
+- DSGVO, BDSG, TDDDG, KI-VO, NIS-2-RL, BGB-Werk-/Mietvertrag sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im IT-, Datenschutz- und Telemedienrecht
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus DSGVO, BDSG, TDDDG, KI-VO, NIS-2-RL, BGB-Werk-/Mietvertrag und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in IT-, Datenschutz- und Telemedienrecht (Unterlassungsklage Datenschutz, Klage IT-Vertrag, DSGVO-Bussgeldwiderspruch):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei IT-, Datenschutz- und Telemedienrecht-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in IT-, Datenschutz- und Telemedienrecht ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-it-recht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-it-recht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer IT-, Datenschutz- und Telemedienrecht: ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im IT-, Datenschutz- und Telemedienrecht
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich IT-, Datenschutz- und Telemedienrecht, in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: IT-Projektstreit (agil/festpreis), DSGVO-Abmahnung, Lizenzkonflikt.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In IT-, Datenschutz- und Telemedienrecht typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus DSGVO, BDSG, TDDDG, KI-VO, NIS-2-RL, BGB-Werk-/Mietvertrag verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im IT-, Datenschutz- und Telemedienrecht
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> DSGVO und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von DSGVO und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich IT-, Datenschutz- und Telemedienrecht oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in IT-, Datenschutz- und Telemedienrecht:
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-medizinrecht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-medizinrecht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Arzthaftungs-, Berufs- und Vertragsarztrecht: Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Arzthaftungs-, Berufs- und Vertragsarztrecht
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Arzthaftungs-, Berufs- und Vertragsarztrecht (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Arzthaftungs-, Berufs- und Vertragsarztrecht:
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: Behandlungsfehler, Aufklaerung, Sozialrecht/SGB V, Praxisuebernahme, MBO-AE
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Arzthaftungsklage, Klage Sozialgericht (KV-/MDK-Streit), Berufsrechtsbeschwerde). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Arzthaftungs-, Berufs- und Vertragsarztrecht:
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Arzthaftungs-, Berufs- und Vertragsarztrecht.
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- §§ 630a ff. BGB, MBO-AE, SGB V, MPDG, GOAE, BAEO (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Arzthaftungs-, Berufs- und Vertragsarztrecht). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Arzthaftungs-, Berufs- und Vertragsarztrecht: Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-medizinrecht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-medizinrecht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Arzthaftungsklage, Klage Sozialgericht (KV-/MDK-Streit), Berufsrechtsbeschwerde: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Arzthaftungs-, Berufs- und Vertragsarztrecht
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Arzthaftungs-, Berufs- und Vertragsarztrecht erstellt werden, typischerweise: Arzthaftungsklage, Klage Sozialgericht (KV-/MDK-Streit), Berufsrechtsbeschwerde.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in §§ 630a ff. BGB, MBO-AE, SGB V, MPDG, GOAE, BAEO eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Arzthaftungs-, Berufs- und Vertragsarztrecht typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Arzthaftungs-, Berufs- und Vertragsarztrecht
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Arzthaftungs-, Berufs- und Vertragsarztrecht.
+- §§ 630a ff. BGB, MBO-AE, SGB V, MPDG, GOAE, BAEO sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Arzthaftungs-, Berufs- und Vertragsarztrecht
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus §§ 630a ff. BGB, MBO-AE, SGB V, MPDG, GOAE, BAEO und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Arzthaftungs-, Berufs- und Vertragsarztrecht (Arzthaftungsklage, Klage Sozialgericht (KV-/MDK-Streit), Berufsrechtsbeschwerde):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Arzthaftungs-, Berufs- und Vertragsarztrecht-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Arzthaftungs-, Berufs- und Vertragsarztrecht ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-medizinrecht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-medizinrecht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Arzthaftungs-, Berufs- und Vertragsarztrecht: ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Arzthaftungs-, Berufs- und Vertragsarztrecht
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Arzthaftungs-, Berufs- und Vertragsarztrecht, in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Aussergerichtlicher Vergleich Behandlungsfehler, KV-Streit.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Arzthaftungs-, Berufs- und Vertragsarztrecht typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus §§ 630a ff. BGB, MBO-AE, SGB V, MPDG, GOAE, BAEO verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Arzthaftungs-, Berufs- und Vertragsarztrecht
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> §§ 630a ff. BGB und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von §§ 630a ff. BGB und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Arzthaftungs-, Berufs- und Vertragsarztrecht oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Arzthaftungs-, Berufs- und Vertragsarztrecht:
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-miet-wohnungseigentumsrecht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-miet-wohnungseigentumsrecht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Wohnraum-, Gewerberaum- und WEG-Recht: Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Wohnraum-, Gewerberaum- und WEG-Recht
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Wohnraum-, Gewerberaum- und WEG-Recht (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Wohnraum-, Gewerberaum- und WEG-Recht:
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: Mietmangel, Eigenbedarf, Betriebskosten, WEG-Beschluss, Modernisierung
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Raeumungsklage, Mietminderungsklage, WEG-Anfechtungsklage). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Wohnraum-, Gewerberaum- und WEG-Recht:
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Wohnraum-, Gewerberaum- und WEG-Recht.
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- §§ 535 ff. BGB, WEG, BetrKV, II. BV, MietenWoG (Land) (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Wohnraum-, Gewerberaum- und WEG-Recht). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Wohnraum-, Gewerberaum- und WEG-Recht: Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-miet-wohnungseigentumsrecht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-miet-wohnungseigentumsrecht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Raeumungsklage, Mietminderungsklage, WEG-Anfechtungsklage: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Wohnraum-, Gewerberaum- und WEG-Recht
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Wohnraum-, Gewerberaum- und WEG-Recht erstellt werden, typischerweise: Raeumungsklage, Mietminderungsklage, WEG-Anfechtungsklage.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in §§ 535 ff. BGB, WEG, BetrKV, II. BV, MietenWoG (Land) eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Wohnraum-, Gewerberaum- und WEG-Recht typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Wohnraum-, Gewerberaum- und WEG-Recht
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Wohnraum-, Gewerberaum- und WEG-Recht.
+- §§ 535 ff. BGB, WEG, BetrKV, II. BV, MietenWoG (Land) sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Wohnraum-, Gewerberaum- und WEG-Recht
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus §§ 535 ff. BGB, WEG, BetrKV, II. BV, MietenWoG (Land) und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Wohnraum-, Gewerberaum- und WEG-Recht (Raeumungsklage, Mietminderungsklage, WEG-Anfechtungsklage):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Wohnraum-, Gewerberaum- und WEG-Recht-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Wohnraum-, Gewerberaum- und WEG-Recht ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-miet-wohnungseigentumsrecht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-miet-wohnungseigentumsrecht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Wohnraum-, Gewerberaum- und WEG-Recht: ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Wohnraum-, Gewerberaum- und WEG-Recht
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Wohnraum-, Gewerberaum- und WEG-Recht, in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Mietaufhebung, Modernisierung, WEG-Mediation Beiratsstreit.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Wohnraum-, Gewerberaum- und WEG-Recht typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus §§ 535 ff. BGB, WEG, BetrKV, II. BV, MietenWoG (Land) verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Wohnraum-, Gewerberaum- und WEG-Recht
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> §§ 535 ff. BGB und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von §§ 535 ff. BGB und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Wohnraum-, Gewerberaum- und WEG-Recht oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Wohnraum-, Gewerberaum- und WEG-Recht:
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-migrationsrecht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-migrationsrecht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Auslaender-, Asyl- und Staatsangehoerigkeitsrecht: Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Auslaender-, Asyl- und Staatsangehoerigkeitsrecht
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Auslaender-, Asyl- und Staatsangehoerigkeitsrecht (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Auslaender-, Asyl- und Staatsangehoerigkeitsrecht:
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: Aufenthaltstitel, Asyl, Abschiebung, Einbuergerung, FamNachzug, FreizuegigG/EU
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Klage VG (Asyl/AufenthG), Eilantrag § 80 Abs. 5 VwGO, Einbuergerungsklage). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Auslaender-, Asyl- und Staatsangehoerigkeitsrecht:
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Auslaender-, Asyl- und Staatsangehoerigkeitsrecht.
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- AufenthG, AsylG, StAG, FreizuegigG/EU, BeschV, EU-RL 2008/115/EG (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Auslaender-, Asyl- und Staatsangehoerigkeitsrecht). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Auslaender-, Asyl- und Staatsangehoerigkeitsrecht: Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-migrationsrecht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-migrationsrecht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Klage VG (Asyl/AufenthG), Eilantrag § 80 Abs. 5 VwGO, Einbuergerungsklage: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Auslaender-, Asyl- und Staatsangehoerigkeitsrecht
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Auslaender-, Asyl- und Staatsangehoerigkeitsrecht erstellt werden, typischerweise: Klage VG (Asyl/AufenthG), Eilantrag § 80 Abs. 5 VwGO, Einbuergerungsklage.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in AufenthG, AsylG, StAG, FreizuegigG/EU, BeschV, EU-RL 2008/115/EG eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Auslaender-, Asyl- und Staatsangehoerigkeitsrecht typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Auslaender-, Asyl- und Staatsangehoerigkeitsrecht
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Auslaender-, Asyl- und Staatsangehoerigkeitsrecht.
+- AufenthG, AsylG, StAG, FreizuegigG/EU, BeschV, EU-RL 2008/115/EG sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Auslaender-, Asyl- und Staatsangehoerigkeitsrecht
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus AufenthG, AsylG, StAG, FreizuegigG/EU, BeschV, EU-RL 2008/115/EG und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Auslaender-, Asyl- und Staatsangehoerigkeitsrecht (Klage VG (Asyl/AufenthG), Eilantrag § 80 Abs. 5 VwGO, Einbuergerungsklage):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Auslaender-, Asyl- und Staatsangehoerigkeitsrecht-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Auslaender-, Asyl- und Staatsangehoerigkeitsrecht ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-migrationsrecht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-migrationsrecht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Auslaender-, Asyl- und Staatsangehoerigkeitsrecht: ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Auslaender-, Asyl- und Staatsangehoerigkeitsrecht
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Auslaender-, Asyl- und Staatsangehoerigkeitsrecht, in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Aufenthaltsverhandlung Auslaenderbehoerde, Familienzusammenfuehrung.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Auslaender-, Asyl- und Staatsangehoerigkeitsrecht typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus AufenthG, AsylG, StAG, FreizuegigG/EU, BeschV, EU-RL 2008/115/EG verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Auslaender-, Asyl- und Staatsangehoerigkeitsrecht
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> AufenthG und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von AufenthG und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Auslaender-, Asyl- und Staatsangehoerigkeitsrecht oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Auslaender-, Asyl- und Staatsangehoerigkeitsrecht:
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-sozialrecht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-sozialrecht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Sozialrecht (SGB I-XIV): Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Sozialrecht (SGB I-XIV)
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Sozialrecht (SGB I-XIV) (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Sozialrecht (SGB I-XIV):
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: Buergergeld, Rente, GdB/SchwbR, Pflegegrad, Hilfsmittel, ALG, Reha
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Widerspruch + SG-Klage, Eilantrag § 86b SGG, Ueberpruefungsantrag § 44 SGB X). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Sozialrecht (SGB I-XIV):
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Sozialrecht (SGB I-XIV).
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- SGB I-XIV, SGG, AsylbLG, BVG, SchwbVwV (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Sozialrecht (SGB I-XIV)). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Sozialrecht (SGB I-XIV): Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-sozialrecht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-sozialrecht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Widerspruch + SG-Klage, Eilantrag § 86b SGG, Ueberpruefungsantrag § 44 SGB X: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Sozialrecht (SGB I-XIV)
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Sozialrecht (SGB I-XIV) erstellt werden, typischerweise: Widerspruch + SG-Klage, Eilantrag § 86b SGG, Ueberpruefungsantrag § 44 SGB X.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in SGB I-XIV, SGG, AsylbLG, BVG, SchwbVwV eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Sozialrecht (SGB I-XIV) typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Sozialrecht (SGB I-XIV)
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Sozialrecht (SGB I-XIV).
+- SGB I-XIV, SGG, AsylbLG, BVG, SchwbVwV sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Sozialrecht (SGB I-XIV)
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus SGB I-XIV, SGG, AsylbLG, BVG, SchwbVwV und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Sozialrecht (SGB I-XIV) (Widerspruch + SG-Klage, Eilantrag § 86b SGG, Ueberpruefungsantrag § 44 SGB X):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Sozialrecht (SGB I-XIV)-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Sozialrecht (SGB I-XIV) ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-sozialrecht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-sozialrecht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Sozialrecht (SGB I-XIV): ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Sozialrecht (SGB I-XIV)
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Sozialrecht (SGB I-XIV), in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Vergleich Renten-/Pflegestufe/Hilfsmittel/Buergergeld.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Sozialrecht (SGB I-XIV) typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus SGB I-XIV, SGG, AsylbLG, BVG, SchwbVwV verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Sozialrecht (SGB I-XIV)
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> SGB I-XIV und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von SGB I-XIV und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Sozialrecht (SGB I-XIV) oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Sozialrecht (SGB I-XIV):
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-sportrecht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-sportrecht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Sport- und Sponsoringrecht: Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Sport- und Sponsoringrecht
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Sport- und Sponsoringrecht (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Sport- und Sponsoringrecht:
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: Vertragsspieler, Transfer, Doping, Sponsoring, Verbandsstrafe, Image-Rights
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Klage ordentliches Gericht/Sportgericht, CAS-/DIS-Schiedsantrag, Antidoping). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Sport- und Sponsoringrecht:
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Sport- und Sponsoringrecht.
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- BGB, HGB, WADA-Code, NADA-Code, Verbands-Statuten, DIS-/CAS-Schiedsordnung (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Sport- und Sponsoringrecht). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Sport- und Sponsoringrecht: Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-sportrecht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-sportrecht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Klage ordentliches Gericht/Sportgericht, CAS-/DIS-Schiedsantrag, Antidoping: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Sport- und Sponsoringrecht
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Sport- und Sponsoringrecht erstellt werden, typischerweise: Klage ordentliches Gericht/Sportgericht, CAS-/DIS-Schiedsantrag, Antidoping.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in BGB, HGB, WADA-Code, NADA-Code, Verbands-Statuten, DIS-/CAS-Schiedsordnung eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Sport- und Sponsoringrecht typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Sport- und Sponsoringrecht
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Sport- und Sponsoringrecht.
+- BGB, HGB, WADA-Code, NADA-Code, Verbands-Statuten, DIS-/CAS-Schiedsordnung sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Sport- und Sponsoringrecht
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus BGB, HGB, WADA-Code, NADA-Code, Verbands-Statuten, DIS-/CAS-Schiedsordnung und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Sport- und Sponsoringrecht (Klage ordentliches Gericht/Sportgericht, CAS-/DIS-Schiedsantrag, Antidoping):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Sport- und Sponsoringrecht-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Sport- und Sponsoringrecht ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-sportrecht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-sportrecht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Sport- und Sponsoringrecht: ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Sport- und Sponsoringrecht
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Sport- und Sponsoringrecht, in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Transferstreit, Sponsoring-Aufhebung, Verbandsstrafe-Vergleich.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Sport- und Sponsoringrecht typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus BGB, HGB, WADA-Code, NADA-Code, Verbands-Statuten, DIS-/CAS-Schiedsordnung verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Sport- und Sponsoringrecht
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> BGB und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von BGB und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Sport- und Sponsoringrecht oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Sport- und Sponsoringrecht:
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-strafrecht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-strafrecht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Allgemeines und Wirtschaftsstrafrecht: Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Allgemeines und Wirtschaftsstrafrecht
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Allgemeines und Wirtschaftsstrafrecht (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Allgemeines und Wirtschaftsstrafrecht:
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: Beschuldigtenvernehmung, Akteneinsicht, U-Haft, Verteidigungslinie, OWi
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Einspruch gegen Strafbefehl, Revisionsbegruendung, Klageerzwingung). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Allgemeines und Wirtschaftsstrafrecht:
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Allgemeines und Wirtschaftsstrafrecht.
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- StGB, StPO, BtMG, AO (§§ 369 ff.), OWiG, JGG (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Allgemeines und Wirtschaftsstrafrecht). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Allgemeines und Wirtschaftsstrafrecht: Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-strafrecht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-strafrecht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Einspruch gegen Strafbefehl, Revisionsbegruendung, Klageerzwingung: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Allgemeines und Wirtschaftsstrafrecht
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Allgemeines und Wirtschaftsstrafrecht erstellt werden, typischerweise: Einspruch gegen Strafbefehl, Revisionsbegruendung, Klageerzwingung.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in StGB, StPO, BtMG, AO (§§ 369 ff.), OWiG, JGG eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Allgemeines und Wirtschaftsstrafrecht typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Allgemeines und Wirtschaftsstrafrecht
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Allgemeines und Wirtschaftsstrafrecht.
+- StGB, StPO, BtMG, AO (§§ 369 ff.), OWiG, JGG sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Allgemeines und Wirtschaftsstrafrecht
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus StGB, StPO, BtMG, AO (§§ 369 ff.), OWiG, JGG und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Allgemeines und Wirtschaftsstrafrecht (Einspruch gegen Strafbefehl, Revisionsbegruendung, Klageerzwingung):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Allgemeines und Wirtschaftsstrafrecht-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Allgemeines und Wirtschaftsstrafrecht ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-strafrecht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-strafrecht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Allgemeines und Wirtschaftsstrafrecht: ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Allgemeines und Wirtschaftsstrafrecht
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Allgemeines und Wirtschaftsstrafrecht, in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Verstaendigung § 257c StPO, Einstellung § 153a, Adhaesionsverfahren.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Allgemeines und Wirtschaftsstrafrecht typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus StGB, StPO, BtMG, AO (§§ 369 ff.), OWiG, JGG verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Allgemeines und Wirtschaftsstrafrecht
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> StGB und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von StGB und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Allgemeines und Wirtschaftsstrafrecht oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Allgemeines und Wirtschaftsstrafrecht:
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-transport-speditionsrecht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-transport-speditionsrecht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Transport-, Speditions- und Logistikrecht: Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Transport-, Speditions- und Logistikrecht
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Transport-, Speditions- und Logistikrecht (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Transport-, Speditions- und Logistikrecht:
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: Frachtvertrag, CMR, Spediteur, Versicherung, Multimodal, Zoll
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Frachtklage, Klage CMR-Schaden, Klage HGB-Spediteur-Haftung). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Transport-, Speditions- und Logistikrecht:
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Transport-, Speditions- und Logistikrecht.
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- §§ 407 ff. HGB, CMR, MC, ADSp, RVS-Konvention (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Transport-, Speditions- und Logistikrecht). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Transport-, Speditions- und Logistikrecht: Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-transport-speditionsrecht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-transport-speditionsrecht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Frachtklage, Klage CMR-Schaden, Klage HGB-Spediteur-Haftung: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Transport-, Speditions- und Logistikrecht
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Transport-, Speditions- und Logistikrecht erstellt werden, typischerweise: Frachtklage, Klage CMR-Schaden, Klage HGB-Spediteur-Haftung.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in §§ 407 ff. HGB, CMR, MC, ADSp, RVS-Konvention eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Transport-, Speditions- und Logistikrecht typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Transport-, Speditions- und Logistikrecht
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Transport-, Speditions- und Logistikrecht.
+- §§ 407 ff. HGB, CMR, MC, ADSp, RVS-Konvention sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Transport-, Speditions- und Logistikrecht
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus §§ 407 ff. HGB, CMR, MC, ADSp, RVS-Konvention und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Transport-, Speditions- und Logistikrecht (Frachtklage, Klage CMR-Schaden, Klage HGB-Spediteur-Haftung):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Transport-, Speditions- und Logistikrecht-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Transport-, Speditions- und Logistikrecht ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-transport-speditionsrecht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-transport-speditionsrecht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Transport-, Speditions- und Logistikrecht: ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Transport-, Speditions- und Logistikrecht
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Transport-, Speditions- und Logistikrecht, in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Frachtschaden/Versicherung, Demurrage, Multimodal-Schaden.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Transport-, Speditions- und Logistikrecht typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus §§ 407 ff. HGB, CMR, MC, ADSp, RVS-Konvention verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Transport-, Speditions- und Logistikrecht
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> §§ 407 ff. HGB und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von §§ 407 ff. HGB und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Transport-, Speditions- und Logistikrecht oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Transport-, Speditions- und Logistikrecht:
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-urheber-medienrecht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-urheber-medienrecht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Urheber-, Presse- und Medienrecht: Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Urheber-, Presse- und Medienrecht
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Urheber-, Presse- und Medienrecht (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Urheber-, Presse- und Medienrecht:
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: Urheberrecht, KUG, Bildrechte, Filesharing, Verlag, GG-Pressefreiheit
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Unterlassungsklage Persoenlichkeitsrecht, Klage Urheberrechtsverletzung). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Urheber-, Presse- und Medienrecht:
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Urheber-, Presse- und Medienrecht.
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- UrhG, KUG, GG Art. 5, RStV/MStV, TDDDG, BGB (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Urheber-, Presse- und Medienrecht). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Urheber-, Presse- und Medienrecht: Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-urheber-medienrecht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-urheber-medienrecht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Unterlassungsklage Persoenlichkeitsrecht, Klage Urheberrechtsverletzung: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Urheber-, Presse- und Medienrecht
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Urheber-, Presse- und Medienrecht erstellt werden, typischerweise: Unterlassungsklage Persoenlichkeitsrecht, Klage Urheberrechtsverletzung.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in UrhG, KUG, GG Art. 5, RStV/MStV, TDDDG, BGB eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Urheber-, Presse- und Medienrecht typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Urheber-, Presse- und Medienrecht
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Urheber-, Presse- und Medienrecht.
+- UrhG, KUG, GG Art. 5, RStV/MStV, TDDDG, BGB sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Urheber-, Presse- und Medienrecht
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus UrhG, KUG, GG Art. 5, RStV/MStV, TDDDG, BGB und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Urheber-, Presse- und Medienrecht (Unterlassungsklage Persoenlichkeitsrecht, Klage Urheberrechtsverletzung):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Urheber-, Presse- und Medienrecht-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Urheber-, Presse- und Medienrecht ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-urheber-medienrecht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-urheber-medienrecht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Urheber-, Presse- und Medienrecht: ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Urheber-, Presse- und Medienrecht
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Urheber-, Presse- und Medienrecht, in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Gegendarstellung, Lizenzvergleich, Filesharing-Abmahnung.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Urheber-, Presse- und Medienrecht typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus UrhG, KUG, GG Art. 5, RStV/MStV, TDDDG, BGB verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Urheber-, Presse- und Medienrecht
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> UrhG und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von UrhG und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Urheber-, Presse- und Medienrecht oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Urheber-, Presse- und Medienrecht:
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-vergaberecht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-vergaberecht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Vergaberecht (Oberschwellen- und Unterschwellenvergabe): Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Vergaberecht (Oberschwellen- und Unterschwellenvergabe)
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Vergaberecht (Oberschwellen- und Unterschwellenvergabe) (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Vergaberecht (Oberschwellen- und Unterschwellenvergabe):
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: Ruege, Nachpruefung, Wertung, Ausschluss, Eignung, Mittelstandsschutz
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Nachpruefungsantrag VK, Sofortige Beschwerde OLG, Schadensersatzklage § 181 GWB). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Vergaberecht (Oberschwellen- und Unterschwellenvergabe):
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Vergaberecht (Oberschwellen- und Unterschwellenvergabe).
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- GWB Teil 4, VgV, UVgO, VOB/A, SektVO, KonzVgV (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Vergaberecht (Oberschwellen- und Unterschwellenvergabe)). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Vergaberecht (Oberschwellen- und Unterschwellenvergabe): Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-vergaberecht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-vergaberecht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Nachpruefungsantrag VK, Sofortige Beschwerde OLG, Schadensersatzklage § 181 GWB: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Vergaberecht (Oberschwellen- und Unterschwellenvergabe)
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Vergaberecht (Oberschwellen- und Unterschwellenvergabe) erstellt werden, typischerweise: Nachpruefungsantrag VK, Sofortige Beschwerde OLG, Schadensersatzklage § 181 GWB.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in GWB Teil 4, VgV, UVgO, VOB/A, SektVO, KonzVgV eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Vergaberecht (Oberschwellen- und Unterschwellenvergabe) typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Vergaberecht (Oberschwellen- und Unterschwellenvergabe)
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Vergaberecht (Oberschwellen- und Unterschwellenvergabe).
+- GWB Teil 4, VgV, UVgO, VOB/A, SektVO, KonzVgV sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Vergaberecht (Oberschwellen- und Unterschwellenvergabe)
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus GWB Teil 4, VgV, UVgO, VOB/A, SektVO, KonzVgV und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Vergaberecht (Oberschwellen- und Unterschwellenvergabe) (Nachpruefungsantrag VK, Sofortige Beschwerde OLG, Schadensersatzklage § 181 GWB):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Vergaberecht (Oberschwellen- und Unterschwellenvergabe)-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Vergaberecht (Oberschwellen- und Unterschwellenvergabe) ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-vergaberecht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-vergaberecht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Vergaberecht (Oberschwellen- und Unterschwellenvergabe): ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Vergaberecht (Oberschwellen- und Unterschwellenvergabe)
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Vergaberecht (Oberschwellen- und Unterschwellenvergabe), in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Ruegestadium-Loesung, einvernehmliche Aufhebung, Mehraufwand.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Vergaberecht (Oberschwellen- und Unterschwellenvergabe) typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus GWB Teil 4, VgV, UVgO, VOB/A, SektVO, KonzVgV verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Vergaberecht (Oberschwellen- und Unterschwellenvergabe)
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> GWB Teil 4 und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von GWB Teil 4 und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Vergaberecht (Oberschwellen- und Unterschwellenvergabe) oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Vergaberecht (Oberschwellen- und Unterschwellenvergabe):
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-verkehrsrecht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-verkehrsrecht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht): Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht)
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht) (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht):
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: Unfallregulierung, OWi, Punktekonto, MPU, Fahrerlaubnis, KFZ-Versicherung
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Klage Verkehrsunfall, Einspruch OWi-Bussgeldbescheid, Klage KFZ-Versicherung). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht):
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht).
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- StVG, StVO, StVZO, FeV, PflVG, BKatV, OWiG (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht)). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht): Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-verkehrsrecht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-verkehrsrecht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Klage Verkehrsunfall, Einspruch OWi-Bussgeldbescheid, Klage KFZ-Versicherung: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht)
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht) erstellt werden, typischerweise: Klage Verkehrsunfall, Einspruch OWi-Bussgeldbescheid, Klage KFZ-Versicherung.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in StVG, StVO, StVZO, FeV, PflVG, BKatV, OWiG eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht) typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht)
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht).
+- StVG, StVO, StVZO, FeV, PflVG, BKatV, OWiG sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht)
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus StVG, StVO, StVZO, FeV, PflVG, BKatV, OWiG und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht) (Klage Verkehrsunfall, Einspruch OWi-Bussgeldbescheid, Klage KFZ-Versicherung):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht)-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht) ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-verkehrsrecht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-verkehrsrecht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht): ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht)
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht), in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Schadenregulierung Haftpflicht, OWi-Einstellung, Fahrerlaubnis.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht) typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus StVG, StVO, StVZO, FeV, PflVG, BKatV, OWiG verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht)
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> StVG und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von StVG und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht) oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Verkehrsrecht (Unfall-, OWi- und Verkehrsstrafrecht):
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-versicherungsrecht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-versicherungsrecht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Versicherungsvertragsrecht (Personen- und Sachversicherung): Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Versicherungsvertragsrecht (Personen- und Sachversicherung)
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Versicherungsvertragsrecht (Personen- und Sachversicherung) (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Versicherungsvertragsrecht (Personen- und Sachversicherung):
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: Berufsunfaehigkeit, Unfallversicherung, Sachversicherung, RSV, Haftpflicht
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Deckungsklage, Klage BU/UB, Klage Sachversicherung, RSV-Deckungsklage). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Versicherungsvertragsrecht (Personen- und Sachversicherung):
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Versicherungsvertragsrecht (Personen- und Sachversicherung).
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- VVG, AVB, BU-/UV-Bedingungen, ARB, PflVG (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Versicherungsvertragsrecht (Personen- und Sachversicherung)). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Versicherungsvertragsrecht (Personen- und Sachversicherung): Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-versicherungsrecht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-versicherungsrecht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Deckungsklage, Klage BU/UB, Klage Sachversicherung, RSV-Deckungsklage: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Versicherungsvertragsrecht (Personen- und Sachversicherung)
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Versicherungsvertragsrecht (Personen- und Sachversicherung) erstellt werden, typischerweise: Deckungsklage, Klage BU/UB, Klage Sachversicherung, RSV-Deckungsklage.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in VVG, AVB, BU-/UV-Bedingungen, ARB, PflVG eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Versicherungsvertragsrecht (Personen- und Sachversicherung) typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Versicherungsvertragsrecht (Personen- und Sachversicherung)
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Versicherungsvertragsrecht (Personen- und Sachversicherung).
+- VVG, AVB, BU-/UV-Bedingungen, ARB, PflVG sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Versicherungsvertragsrecht (Personen- und Sachversicherung)
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus VVG, AVB, BU-/UV-Bedingungen, ARB, PflVG und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Versicherungsvertragsrecht (Personen- und Sachversicherung) (Deckungsklage, Klage BU/UB, Klage Sachversicherung, RSV-Deckungsklage):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Versicherungsvertragsrecht (Personen- und Sachversicherung)-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Versicherungsvertragsrecht (Personen- und Sachversicherung) ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-versicherungsrecht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-versicherungsrecht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Versicherungsvertragsrecht (Personen- und Sachversicherung): ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Versicherungsvertragsrecht (Personen- und Sachversicherung)
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Versicherungsvertragsrecht (Personen- und Sachversicherung), in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Vergleich BU-Rentenhoehe, Sachschaden-Regulierung.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Versicherungsvertragsrecht (Personen- und Sachversicherung) typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus VVG, AVB, BU-/UV-Bedingungen, ARB, PflVG verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Versicherungsvertragsrecht (Personen- und Sachversicherung)
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> VVG und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von VVG und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Versicherungsvertragsrecht (Personen- und Sachversicherung) oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Versicherungsvertragsrecht (Personen- und Sachversicherung):
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/fachanwalt-verwaltungsrecht/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/fachanwalt-verwaltungsrecht/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Allgemeines Verwaltungs- und Bauplanungsrecht: Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Allgemeines Verwaltungs- und Bauplanungsrecht
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Allgemeines Verwaltungs- und Bauplanungsrecht (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Allgemeines Verwaltungs- und Bauplanungsrecht:
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: VA, Widerspruch, Klage VG, Bauplanung, Gewerberecht, Beamtenrecht
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Widerspruch, Anfechtungsklage VG, Verpflichtungsklage, Eilantrag § 80 Abs. 5 VwGO). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Allgemeines Verwaltungs- und Bauplanungsrecht:
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Allgemeines Verwaltungs- und Bauplanungsrecht.
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- VwVfG, VwGO, BauGB, BauNVO, GewO, BBG/BeamtStG (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Allgemeines Verwaltungs- und Bauplanungsrecht). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Allgemeines Verwaltungs- und Bauplanungsrecht: Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/fachanwalt-verwaltungsrecht/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/fachanwalt-verwaltungsrecht/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Widerspruch, Anfechtungsklage VG, Verpflichtungsklage, Eilantrag § 80 Abs. 5 VwGO: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Allgemeines Verwaltungs- und Bauplanungsrecht
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Allgemeines Verwaltungs- und Bauplanungsrecht erstellt werden, typischerweise: Widerspruch, Anfechtungsklage VG, Verpflichtungsklage, Eilantrag § 80 Abs. 5 VwGO.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in VwVfG, VwGO, BauGB, BauNVO, GewO, BBG/BeamtStG eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Allgemeines Verwaltungs- und Bauplanungsrecht typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Allgemeines Verwaltungs- und Bauplanungsrecht
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Allgemeines Verwaltungs- und Bauplanungsrecht.
+- VwVfG, VwGO, BauGB, BauNVO, GewO, BBG/BeamtStG sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Allgemeines Verwaltungs- und Bauplanungsrecht
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus VwVfG, VwGO, BauGB, BauNVO, GewO, BBG/BeamtStG und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Allgemeines Verwaltungs- und Bauplanungsrecht (Widerspruch, Anfechtungsklage VG, Verpflichtungsklage, Eilantrag § 80 Abs. 5 VwGO):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Allgemeines Verwaltungs- und Bauplanungsrecht-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Allgemeines Verwaltungs- und Bauplanungsrecht ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/fachanwalt-verwaltungsrecht/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/fachanwalt-verwaltungsrecht/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Allgemeines Verwaltungs- und Bauplanungsrecht: ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Allgemeines Verwaltungs- und Bauplanungsrecht
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Allgemeines Verwaltungs- und Bauplanungsrecht, in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Abhilfe, Tausch-/Anpassungslosung, Mediation Behoerde-Buerger.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Allgemeines Verwaltungs- und Bauplanungsrecht typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus VwVfG, VwGO, BauGB, BauNVO, GewO, BBG/BeamtStG verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Allgemeines Verwaltungs- und Bauplanungsrecht
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> VwVfG und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von VwVfG und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Allgemeines Verwaltungs- und Bauplanungsrecht oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Allgemeines Verwaltungs- und Bauplanungsrecht:
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.

--- a/steuerrecht-anwalt-und-berater/skills/erstgespraech-mandatsannahme/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/erstgespraech-mandatsannahme/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: erstgespraech-mandatsannahme
+description: Strukturierter Erstgespraechsleitfaden fuer Steuerrecht (Beratung und Prozess): Erfassung der Konstellation, Konflikt- und GwG-Check, Vollmacht, Streitwert/Gebuehrenvereinbarung, Fristen-Erstprognose und Handlungsweichen.
+---
+
+# Erstgespraech und Mandatsannahme im Steuerrecht (Beratung und Prozess)
+
+## Wann dieser Skill greift
+
+- Neue Anfrage aus dem Bereich Steuerrecht (Beratung und Prozess) (Telefon, Mail, Empfehlung, Walk-in).
+- Mandantin oder Mandant beschreibt Sachverhalt unstrukturiert; viele Anlagen ohne System.
+- Vor jeder weiteren fachlichen Bearbeitung: erst Annahme klaeren, Konflikt- und GwG-Pruefung, Vollmacht, Streitwert/Vereinbarung, Fristen.
+
+## Phasen des Erstgespraechs
+
+### 1. Aufnahme der Konstellation (10-15 Min.)
+
+Standard-Fragenraster fuer Steuerrecht (Beratung und Prozess):
+
+- Beteiligte (Vor-/Nachname, Geburtsdatum, Anschrift, Rolle: Klaegerin/Beklagter, Antragsteller, Beschuldigter)
+- Konflikt-Kern in einem Satz ("Was ist Ihr Ziel?")
+- Konkrete fachliche Stossrichtung: Bescheid, Einspruch, AdV, Aussenpruefung, BFH-Revision, Selbstanzeige
+- Bisherige Korrespondenz (Bescheide, Schreiben der Gegenseite, anwaltliche Vertretung der Gegenseite?)
+- **Fristenscreening sofort:** anstehende Klage-/Widerspruchs-/Einspruchsfristen aus den vorgelegten Schreiben (z.B. Einspruch, Klage FG, Revision BFH, Stundungs-/Erlassantrag). Frist-Alarm an die Vorbereitung weitergeben.
+
+### 2. Konflikt-Pruefung und GwG-Check (5 Min.)
+
+- Konflikt-Check ueber Mandantsystem: Gegnerin, Streitgegenstand, frueherer Mandant?
+- GwG-Identifizierung: amtlicher Lichtbildausweis (Ausweisscan), bei juristischer Person Handelsregister-/Transparenzregister-Auszug, ggf. wirtschaftlich Berechtigte/n.
+- Risikobewertung (niedrig/mittel/hoch) abhaengig von Mandatscharakter, Bargeld, Auslandsbezug.
+- Doku im Mandatsbogen (Pflicht nach §§ 10 ff. GwG i.V.m. § 2 Abs. 1 Nr. 10 GwG fuer RA-Mandate).
+
+### 3. Vollmacht und Schweigepflichtentbindung
+
+- Allgemeine Prozess-/Aussenvollmacht (BORA, ZPO, FamFG, je nach Fachgebiet).
+- Spezielle Vollmachten: ggf. Akteneinsicht Strafakte, KV-Abrechnungsdaten, Sozialdaten (Schweigepflichtentbindung gegenueber Krankenkasse, Arzt, Behoerde).
+- Bei Eheleuten/GbR/GmbH: einzelvollmachtgebende Person und Vertretungsmacht klaeren.
+
+### 4. Streitwert und Gebuehrenvereinbarung
+
+Standard-Streitwerte im Bereich Steuerrecht (Beratung und Prozess):
+
+- Skizze: Streitwert grob abschaetzen (z.B. Hauptforderung, ggf. + Zinsen, Nebenforderungen).
+- RVG-Pauschalrechnung (Berechnungstool im Plugin) oder Stundenhonorarvereinbarung.
+- Beratungshilfe-/Prozesskostenhilfe-Antrag pruefen, wenn wirtschaftlich angezeigt.
+- Vorschussanforderung nach § 9 RVG.
+
+### 5. Strategie-Erstskizze
+
+Drei Weichen am Ende des Erstgespraechs:
+
+- **Mandat annehmen:** vollstaendig (Pruefung + Schriftsatz) oder begrenzt (nur Pruefung/Gutachten).
+- **Verweisen:** wenn Spezialgebiet ausserhalb der Fachanwaltschaft, oertlich unzustaendig oder Konflikt.
+- **Ablehnen:** offensichtlich aussichtslos, GwG-Hit, Bauchgefuehl-Vorsicht.
+
+## Pflicht-Output am Ende
+
+1. **Mandatsbogen** mit Beteiligten, Konflikt-Check, GwG-Status, Streitwert.
+2. **Frist-Liste** (Sofortfristen, Verjaehrung, Ausschlussfristen, Beweisanforderungs-Fristen).
+3. **Anlagenverzeichnis** des uebergebenen Datenraums (Stand erstes Sortieren).
+4. **Naechster-Schritt-Plan:** binnen 24/48/72 h, Owner, Output.
+5. **Honorarvereinbarung** unterschrieben oder Vorbehalt notiert.
+
+## Relevante Rechtsgrundlagen und Standards
+
+- BORA, BRAO, FAO fuer Fachanwaltschaft Steuerrecht (Beratung und Prozess).
+- GwG, GwGMeldV, Identifizierungsleitfaden BRAK.
+- AO, FGO, EStG, KStG, UStG, GewStG, ErbStG, BewG (fuer fachliche Erstpruefung).
+- DSGVO und BDSG fuer den Umgang mit Mandantendaten (Art. 6 DSGVO als Rechtsgrundlage, Art. 9 ggf. Gesundheitsdaten).
+
+## Typische Fehler im Erstgespraech
+
+- Frist uebersehen, weil Mandantin sie nicht selber genannt hat (immer aus jedem Schreiben Frist herausziehen).
+- Konflikt-Check nur nach Personennamen, nicht nach Sachzusammenhang (gleiche Liegenschaft, gleicher Sachverhalt).
+- Vollmachtsumfang unklar -> spaeter Streit mit Mandantin ueber Befugnisse.
+- Honorarvereinbarung muendlich -> Beweisnot bei Streitwert-/Honorar-Streit.
+- GwG: kein Lichtbildausweis erfasst, kein Aktenvermerk ueber Risikobewertung.
+
+## Praxis-Checkliste
+
+- [ ] Personalien und Rolle aller Beteiligten erfasst
+- [ ] Konflikt-Check durchgefuehrt
+- [ ] GwG: Identifizierung + Risikobewertung notiert
+- [ ] Allgemeine Vollmacht unterschrieben
+- [ ] Speziale Vollmacht / Entbindungserklaerung (wo noetig) unterschrieben
+- [ ] Streitwert geschaetzt
+- [ ] Honorarvereinbarung unterschrieben oder ausdruecklich auf RVG verwiesen
+- [ ] Fristenliste angelegt und in Kalender eingetragen
+- [ ] Mandatsbogen vollstaendig
+- [ ] Naechster-Schritt-Plan dem Mandanten kommuniziert (E-Mail-Zusammenfassung)
+
+
+## Konkrete Praxis-Konstellationen
+
+### Konstellation A: Eilbeduerftigkeit
+
+Mandantin kommt am Donnerstag, Frist laeuft am Montag (Klage- oder Widerspruchsfrist im Bereich Steuerrecht (Beratung und Prozess)). Handlungs-Sequenz:
+
+1. Sofort-Vollmacht und Sofort-Akteneinsicht (per beA, ELSTER, Behoerdenportal).
+2. Antrag auf Wiedereinsetzung (§ 233 ZPO, § 60 VwGO, § 110 AO) als Reserve dokumentieren.
+3. Spaeteste-Stunde-Versand-Plan: beA bevorzugt, mit qualifizierter Signatur und Empfangsbekenntnis.
+4. Honorarvereinbarung NICHT auf Eilzuschlag verzichten - aber transparent kommunizieren.
+
+### Konstellation B: Komplexer Sachverhalt, Datenraum unsortiert
+
+Mandant uebergibt 200+ Dateien (PDF-Scans, E-Mails, Excel-Listen). Vor jeder fachlichen Bewertung:
+
+1. Datenraum-Index in Excel: Datum, Absender, Empfaenger, Aktenzeichen, kurze Inhaltszeile.
+2. Chronologischer Verlauf als Zeitstrahl - Spielraum fuer Verjaehrungs- und Ausschlussfristen identifizieren.
+3. Loecher im Datenraum gezielt anfordern (Mandantenfragen-Katalog).
+
+### Konstellation C: Interessenkonflikt-Naehe
+
+Frueheres Mandat mit derselben Gegnerin oder gleichem Sachzusammenhang. Pruefung:
+
+1. § 43a Abs. 4 BRAO und § 3 BORA - Sachzusammenhang, nicht nur Personenidentitaet.
+2. Einwilligung beider Mandanten in Textform (mit konkreter Beschreibung).
+3. Bei Zweifel: Mandat ablehnen und an Kanzleikollegium ueberweisen.
+
+## Mandanten-Erwartungsmanagement
+
+- Realistische Erfolgs- und Kostenprognose (nicht "Wir gewinnen sicher").
+- Verfahrensdauer im Bereich Steuerrecht (Beratung und Prozess): Erfahrungswerte nach Instanz.
+- Vergleichschance vs. streitiges Urteil als Option offen halten.
+- Schriftliche Zusammenfassung des Erstgespraechs binnen 48 h.
+
+## Honorarvereinbarung - Best Practices
+
+- RVG-Basis als Default, Stundenhonorar nur mit gesondertem Hinweis nach § 3a RVG.
+- Erfolgshonorar nur in den engen Grenzen § 4a RVG.
+- Vorschuss in Hoehe der voraussichtlichen 1. Instanz.
+- Klarstellung: Auslagen-Pauschale, USt, Reisekosten, Sachverstaendigenkosten gesondert.
+- Bei PKH/Beratungshilfe-Mandant: schriftliche Belehrung, dass eigene Beitraege moeglich sind.
+
+## Mandatsbogen-Muster (Mindestinhalt)
+
+- Mandant (Name, Geburtsdatum, Anschrift, Telefon, E-Mail)
+- Gegner (Name, Anschrift, ggf. anwaltliche Vertretung)
+- Kurzbeschreibung Sachverhalt (5-10 Saetze)
+- Ziel des Mandats (eine Zeile)
+- Strittige Fragen (bullet)
+- Geprueft: Konflikt - GwG - Vollmacht
+- Streitwert (Schaetzung)
+- Honorarvereinbarung (RVG/Stunde/Pauschale)
+- Frist-Liste
+- Aktenanlage Datum
+- Naechster-Schritt
+
+## Cross-Refs
+
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer den Fall, dass aussergerichtliche Loesung angestrebt wird.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Schriftsatzaufbau, wenn Klage/Widerspruch eingereicht wird.
+- Kanzlei-Allgemein-Plugin `kanzlei-allgemein` fuer Konflikt-, GwG- und PEP-Pruefroutinen.

--- a/steuerrecht-anwalt-und-berater/skills/schriftsatzkern-substantiierung/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/schriftsatzkern-substantiierung/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: schriftsatzkern-substantiierung
+description: Substantiierter Schriftsatzkern fuer Einspruch, Klage FG, Revision BFH, Stundungs-/Erlassantrag: Tatsachenvortrag-Geruest, Anspruchsgrundlagen-Kette, Beweisangebote, Hilfsantraege, Replik-/Duplik-Vorausschau.
+---
+
+# Schriftsatzkern und Substantiierung im Steuerrecht (Beratung und Prozess)
+
+## Wann dieser Skill greift
+
+- Es soll ein vollwertiger Schriftsatz im Bereich Steuerrecht (Beratung und Prozess) erstellt werden, typischerweise: Einspruch, Klage FG, Revision BFH, Stundungs-/Erlassantrag.
+- Die Mandatsannahme und ggf. Vergleichsverhandlung sind abgeschlossen oder gescheitert.
+- Klage-, Widerspruchs-, Einspruchs-, Rechtsmittel-Frist ist bekannt und im Kalender eingetragen.
+
+## Aufbauschema
+
+### A. Rubrum
+
+- Parteien (Bezeichnung wie im Vorprozess oder Bescheid, exakte Schreibweise!).
+- Zustellungsanschrift Bevollmaechtigte.
+- Gericht/Behoerde (Zustaendigkeit pruefen und im Schriftsatz darstellen, wenn streitig).
+- Aktenzeichen (Bezugs-Az., neues Az. nach Eingang).
+- Streitwert/Gegenstandswert.
+
+### B. Antraege
+
+Klassischer Antrag-Block; je nach Verfahrenstyp:
+
+- Leistungsantrag (zu zahlen, zu unterlassen, zu beseitigen, herauszugeben).
+- Feststellungsantrag (Feststellungsinteresse darlegen).
+- Gestaltungsantrag (Aufhebung, Anfechtung, Scheidung).
+- Hilfsantraege staffeln (von eng nach weit oder von hoch nach niedrig).
+
+### C. Tatsachenvortrag
+
+Der Substantiierungs-Kern; pro Anspruchsgrundlage in AO, FGO, EStG, KStG, UStG, GewStG, ErbStG, BewG eine eigene Tatsachen-Sequenz:
+
+1. **Sachverhalts-Chronologie** mit konkreten Daten (Tag, Uhrzeit, Ort, Personen).
+2. **Mandantenseitige Tatsachenbehauptungen** mit Beweisangeboten.
+3. **Gegnerisches Verhalten** mit Belegen (Schreiben, Aussage, Verhalten).
+4. **Schaden/Folgen** bezifferbar (Hauptforderung, Nebenforderung, Zinsen, Folgekosten).
+
+### D. Rechtliche Wuerdigung
+
+Anspruchsaufbau klassisch:
+
+1. **Anspruchsgrundlage** nennen (z.B. § X iVm § Y).
+2. **Tatbestandsmerkmale** durchgehen; jedes Merkmal wird gegen den Tatsachenvortrag gespiegelt.
+3. **Einwendungen** der Gegenseite vorwegnehmen und entkraeften.
+4. **Rechtsprechungs-Verweise:** BAG/BGH/BVerfG/EuGH/BFH je nach Fachgebiet; bei Steuerrecht (Beratung und Prozess) typischerweise die letzte hoechstrichterliche Linie zitieren.
+5. **Subsumtion-Ergebnis** klar formulieren.
+
+### E. Beweisangebote
+
+Pflichtbestandteil, ohne den Substantiierung nicht ausreicht:
+
+- Urkundenbeweis: konkrete Anlage Kxx benennen, Inhalt nicht nur "Vertrag" sondern "Vertrag vom TT.MM.JJJJ, dort § X Abs. Y, Anlage K1".
+- Zeugenbeweis: Name, ladungsfaehige Anschrift, Beweisthema in einem Satz.
+- Sachverstaendigenbeweis: ggf. Privatgutachten mit anfuegen, gerichtliches Gutachten beantragen.
+- Parteivernehmung als letzte Stufe, mit Antrag § 448 ZPO und Indiziengeruest.
+- Inaugenscheinnahme: bei Sache vor Ort (Mietraum, Baustelle, Fahrzeug, Hardware).
+
+### F. Anlagenverzeichnis
+
+- K1, K2 ... durchnummeriert (Antragstellerin/Klaegerin).
+- Bei Beklagten B1, B2 ...
+- Jede Anlage mit Datum, Absender, Empfaenger, Inhaltsbeschreibung in einem Satz.
+- Pflicht-Erwaehnung im Tatsachenvortrag.
+
+## Substantiierungs-Fallen im Steuerrecht (Beratung und Prozess)
+
+- **Pauschaltatsachen** ohne konkrete Daten ("seit Jahren", "regelmaessig", "in mehreren Faellen") werden vom Gericht uebergangen.
+- **Beweisangebot zur falschen Tatsache:** Beweisthema deckt nur Teilaussage ab.
+- **Selbst-widersprueche** zwischen Schriftsatz und Anlage ("Im Vertrag steht doch was anderes").
+- **Verspaeteter Vortrag** § 296 ZPO/§ 87b VwGO: Rueglich-Fristen beachten, Verschulden vermeiden.
+- **Anspruchskonkurrenz** zwischen mehreren Grundlagen: nicht eine wegfallen lassen.
+
+## Pruefkette vor Versand
+
+1. Antragsformulierung tenoriert (urteilstauglich, vollstreckbar)?
+2. Jede Tatbestandsmerkmal-Subsumtion mit eigener Tatsache + Beweis hinterlegt?
+3. Frist eingehalten (Eingangsstempel/elektronische Uebermittlung)?
+4. Zustaendigkeit positiv festgestellt?
+5. Streitwert plausibel, ggf. mit Anlage Streitwert-Berechnung?
+6. Anlagenverzeichnis vollstaendig und nummerisch konsistent?
+7. beA-/EGVP-/EBO-Konformitaet (PDF/A, ERVV-Signatur)?
+8. Vier-Augen-Pruefung durch Sozius oder Senior-Anwaeltin?
+
+## Rechtsprechungs-Werkzeugkasten
+
+- BVerfG, BGH, BAG, BFH, BVerwG, EuGH und die jeweils massgeblichen Fachsenate fuer Steuerrecht (Beratung und Prozess).
+- AO, FGO, EStG, KStG, UStG, GewStG, ErbStG, BewG sowie Verordnungen/Richtlinien dazu.
+- Aktuelle Reform- und Gesetzgebungslage einbeziehen.
+
+## Pflicht-Output
+
+1. **Schriftsatz** mit Rubrum, Antraegen, Tatsachenvortrag, Rechtsausfuehrung, Beweisangeboten, Anlagenverzeichnis.
+2. **Anlagen-Konvolut** numerisch geordnet, jede Anlage einzeln benannt.
+3. **Frist-Doku** mit Eingangsbestaetigung (beA-Eingangsnachricht, EB).
+4. **Streitwertskizze** (eigenes Memo, falls > 1 Anspruch).
+5. **Mandanten-Erinnerung** mit Naechster-Schritt-Aufgaben (Zeuginnen vorbereiten, Sachverstaendiger?).
+
+
+## Beispiel-Anspruchsgrundlagen im Steuerrecht (Beratung und Prozess)
+
+Drei haeufig gebrauchte Anspruchsgrundlagen aus AO, FGO, EStG, KStG, UStG, GewStG, ErbStG, BewG und ihre Substantiierungs-Anforderungen:
+
+### Grundlage 1
+
+- Tatbestandsmerkmal 1: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 2: konkrete Tatsache + Beweis.
+- Tatbestandsmerkmal 3: konkrete Tatsache + Beweis.
+- Rechtsfolge: konkreter Antrag.
+
+### Grundlage 2
+
+Analog - jede Tatsache braucht ein Beweisangebot.
+
+### Grundlage 3 (Auffanggrundlage / Sekundaeranspruch)
+
+Hilfsweise vortragen, klar als Hilfsantrag/Hilfsvortrag kennzeichnen.
+
+## Antrags-Muster nach Verfahrenstyp
+
+Typische Antraege in Steuerrecht (Beratung und Prozess) (Einspruch, Klage FG, Revision BFH, Stundungs-/Erlassantrag):
+
+- Hauptantrag (Leistung/Feststellung/Gestaltung).
+- Hilfsantrag (z.B. fuer den Fall, dass Hauptforderung verjaehrt ist).
+- Annex-Antraege (Zinsen, Nebenforderungen, Kosten).
+- Streitwert-Antrag (falls Streitwert streitig).
+
+## Beweisaufnahme - was das Gericht sehen will
+
+### Urkundenbeweis
+
+- Anlage K1: Bezeichnung, Datum, kurze Inhaltsbeschreibung.
+- Im Tatsachenvortrag: "Diese Behauptung beruht auf dem als Anlage K1 vorgelegten Schreiben der Beklagten vom TT.MM.JJJJ, dort Seite Y, Absatz Z."
+
+### Zeugenbeweis
+
+- Form: "Beweis: Aussage der Zeugin Name, ladungsfaehige Anschrift, zum Beweisthema (konkret in einem Satz)."
+- Mehrere Zeuginnen zum gleichen Thema: Indiziengeruest staerken.
+- Keine Beweisermittlung ueber Zeugnis - das Beweisthema muss konkret sein.
+
+### Sachverstaendigenbeweis
+
+- Bei Steuerrecht (Beratung und Prozess)-typischen Streitfaellen oft notwendig (Bauwerk, IT-System, Anlagebewertung, medizinische Frage).
+- Privatgutachten als Anlage K vorlegen + zugleich gerichtliches Gutachten beantragen.
+- Verfahrensoekonomie: Sachverstaendigen-Kosten frueh mit Mandantin besprechen.
+
+### Parteivernehmung (§ 448 ZPO)
+
+- Letzte Stufe, nur wenn andere Beweismittel ausgeschoepft.
+- Indiziengeruest vortragen, das eine gewisse Wahrscheinlichkeit der Behauptung tragt.
+
+## Replik-/Duplik-Vorausschau
+
+Schon im Klageschriftsatz die wahrscheinlichen Einwaende der Gegenseite vorwegnehmen:
+
+- Verjaehrung -> Hemmungstatbestand vortragen.
+- Erfuellung/Aufrechnung -> rechtzeitige Tatsachenbasis schaffen.
+- Formmangel -> Heilung/Schutz-Argument bereit halten.
+- Treuwidrigkeit -> Indiziengeruest gegen Treuwidrigkeits-Vorwurf.
+
+## Elektronische Einreichung (beA, EGVP, EBO, ELSTER)
+
+- PDF/A-2 oder PDF/A-3, mit eingebetteten Schriften.
+- Strukturdatensatz nach ERVV pflicht-konform (Sender, Empfaenger, Az., Versanddatum).
+- Qualifizierte elektronische Signatur (qeS) der einreichenden RA-Person oder einfacher elektronischer Versand ueber beA (sicherer Uebermittlungsweg).
+- Eingangsbestaetigung aufbewahren - Datum der Einreichung ist Fristwahrungs-Beweis.
+- 1.10.2026 / 1.10.2027 - ZVollstrDigitG-Aenderungen im Vollstreckungsbereich; in Steuerrecht (Beratung und Prozess) ggf. spezifische ERV-Pflichten beachten.
+
+## Schriftsatz-Stil
+
+- Aktiv, kurze Saetze, klare Subsumtion.
+- Keine Floskeln ("Die Klage ist zulaessig und begruendet" als Ueberschrift, aber dann substantiieren).
+- Mandanten- und Beweismittel-Zitate woertlich, in Anfuehrungszeichen, mit Anlage-Verweis.
+- Keine Gefuehlsausbrueche - sachlich auch bei provokanter Gegenseite.
+
+## Vier-Augen-Check
+
+Vor Versand:
+
+- [ ] Antrag tenorierungsfaehig
+- [ ] Frist gewahrt mit Reserve
+- [ ] Jede Tatsache hat Beweis
+- [ ] Anlagen vollstaendig und nummeriert
+- [ ] Rechtsprechungs-Zitat aktuell
+- [ ] Streitwert plausibel
+- [ ] beA/EGVP-konform
+- [ ] Senior-/Sozius-Freigabe
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Tatsachen-Grundlage und Streitwertskizze.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer parallelen Vergleichsversuch (Gueteverhandlung, Mediation).

--- a/steuerrecht-anwalt-und-berater/skills/vergleichsverhandlung-strategie/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/vergleichsverhandlung-strategie/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vergleichsverhandlung-strategie
+description: Vergleichsverhandlungs-Strategie fuer Steuerrecht (Beratung und Prozess): ZOPA, BATNA, Verhandlungsfenster, Druckmittel, Settlement-Skript, Vergleichsentwurf und prozessuale Absicherung (Protokoll-/Anwaltsvergleich).
+---
+
+# Vergleichsverhandlung und Einigung im Steuerrecht (Beratung und Prozess)
+
+## Wann dieser Skill greift
+
+- Sachverhalte aus dem Bereich Steuerrecht (Beratung und Prozess), in denen eine aussergerichtliche oder prozessbegleitende Einigung sinnvoll erscheint.
+- Typische Konstellationen: Tatsaechliche Verstaendigung, Aussetzung der Vollziehung, Billigkeitsvergleich.
+- Sowohl in der aussergerichtlichen Phase (vor Klage) als auch im laufenden Prozess (Gueteverhandlung, Hauptverhandlung).
+
+## Vorbereitung der Verhandlung
+
+### 1. BATNA und ZOPA bestimmen
+
+- **BATNA** (Best Alternative to Negotiated Agreement): Was passiert, wenn wir uns nicht einigen? Kosten- und Zeit-Prognose Prozess, Erfolgsaussichten-Quote, Vollstreckungsrisiko.
+- **WATNA** (Worst Alternative): schlimmster denkbarer Verlauf bei Klage/Klageabweisung.
+- **Reservation Price** auf eigener Seite: untere Grenze der Akzeptanz.
+- **ZOPA** (Zone of Possible Agreement): geschaetzte Schnittmenge zwischen eigener Reservation und der vermuteten Reservation der Gegenseite.
+
+### 2. Interessen vs. Positionen
+
+Klassisches Harvard-Konzept: nicht nur Positionen ("Ich will 100.000 Euro") sondern Interessen ("Ich brauche bis Jahresende Liquiditaet"). In Steuerrecht (Beratung und Prozess) typische Interessen-Cluster:
+
+- Liquiditaet (Sofort-Zahlung vs. Ratenzahlung)
+- Reputation (Gegnerin will keinen Prozess mit Pressewirkung)
+- Zukunfts-Beziehung (Mieter und Vermieter, Arbeitgeberin und ehem. Arbeitnehmer, Geschaeftspartner)
+- Steuerliche Optimierung (Vergleich vs. Klage: ertragsteuerliche Behandlung, USt-Frage)
+- Vertraulichkeit (NDA im Vergleich)
+
+### 3. Druckmittel und Hebel
+
+- Frist (Klage-/Verjaehrungsfrist als Druckmittel der Gegenseite kennen und eigene Frist gezielt einsetzen).
+- Eskalationsstufen ankuendigen ohne sie zu uebertreiben.
+- Hinweis auf Beweismittel, ohne diese vollstaendig offen zu legen.
+- Reputationsdruck (Presse, Branche, Berufsregeln) sehr massvoll, nur wenn ethisch vertretbar.
+
+## Ablauf der Verhandlung
+
+### Eroeffnung
+
+- Anker setzen: erste Zahl/Position deutlich hoeher als Reservation, aber begruendbar.
+- Begruendung mit konkreten Positionen aus AO, FGO, EStG, KStG, UStG, GewStG, ErbStG, BewG verknuepfen.
+
+### Konzessionsphase
+
+- In kleinen, begruendeten Schritten nachgeben.
+- Jede Konzession an Gegenleistung knuepfen ("Wenn Sie X, dann koennen wir Y").
+- Konzessionsmuster nicht linear (sonst extrapolierbar) sondern abnehmend.
+
+### Endspiel
+
+- Abschluss aktiv herbeifuehren ("Sind wir bei 47.500 dann durch?").
+- Schweige-Pausen aushalten.
+- Nachverhandlungs-Versuche der Gegenseite ("ein letztes Detail noch") freundlich, aber bestimmt zurueckweisen, wenn Substanz steht.
+
+## Vergleichsentwurf - Pflichtbestandteile
+
+### Bei aussergerichtlichem Vergleich
+
+1. **Praeambel** mit kurzem Sachstand und Streitthema.
+2. **Hauptregelung** (Zahlung, Leistung, Unterlassung, Rueckabwicklung).
+3. **Faelligkeit** und Verzinsung.
+4. **Sicherheiten** (Buergschaft, Hinterlegung, Sicherungsabtretung).
+5. **Erfuellung gegen Erledigung:** keine Aufrechnung, Ratenausfall = Sofortfaelligkeit.
+6. **Abgeltungs-/Vorbehaltsklausel:** "Mit diesem Vergleich sind alle wechselseitigen Anspruche aus dem zugrundeliegenden Sachverhalt abgegolten."
+7. **Verschwiegenheit** (wenn von einer Partei gewuenscht).
+8. **Steuerliche Behandlung** ggf. ausdruecklich, sonst Hinweis auf Steuerberatung.
+9. **Salvatorische Klausel und Schriftform.**
+10. **Vollstreckungstitel-Ersatz:** notarielle Beurkundung, Anwaltsvergleich nach § 796a ZPO, oder Schiedsvergleich.
+
+### Bei Prozessvergleich
+
+- Protokollvergleich nach § 794 Abs. 1 Nr. 1 ZPO (Vollstreckungstitel kraft Protokollierung).
+- Widerrufsvorbehalt mit klarer Frist.
+- Kostenregelung: ueblich Kostenaufhebung, ggf. Quote.
+- Beteiligung der Streithelfer/Nebenintervenienten beachten.
+
+## Risiken und Stolpersteine im Steuerrecht (Beratung und Prozess)
+
+- Steuerliche Fehlbehandlung: Vergleichszahlung als Schadensersatz vs. Lohn vs. USt-pflichtige Leistung -> AO und ESt-/USt-Regeln pruefen.
+- Vollmacht: Mandantin muss zustimmen, anwaltliche Vergleichsbefugnis muss in Vollmacht expliziert sein.
+- Vollstreckbarkeit: aussergerichtlicher Vergleich ohne notarielle Form/Anwaltsvergleich ist kein Vollstreckungstitel.
+- Verzicht zu weit gefasst: pauschale Abgeltungsklausel kann eigene Ansprueche unbeabsichtigt mit erfassen.
+- Mandanten-Erwartung: Vergleich ist oft Kompromiss - Erwartungsmanagement vor Verhandlung.
+
+## Pflicht-Output
+
+1. **Verhandlungs-Memo** mit BATNA/WATNA, ZOPA-Schaetzung, Strategie.
+2. **Vergleichsentwurf** (anwaltsvertraglich oder Protokollvergleich-Skript).
+3. **Mandantenfreigabe** vor Unterzeichnung schriftlich.
+4. **Steuer- und Vollstreckungs-Memo** zum Vergleich.
+5. **Abschluss-Schreiben** an Gegenseite mit Kopien und Erfuellungsplan.
+
+
+## Verhandlungs-Skripte
+
+### Skript 1: Eroeffnung mit Ankerwert
+
+> "Wir haben die Sache durchgerechnet. Auf Basis von AO und der aktuellen Rechtsprechung kommen wir auf eine Hauptforderung von X Euro plus Y Euro Nebenforderungen. Wir sind bereit, ueber eine Pauschalsumme zu sprechen, die die Sache abschliesst."
+
+### Skript 2: Begruendete Konzession
+
+> "Wir koennen Z Euro nachgeben, wenn Sie im Gegenzug die Klausel A streichen und einer Vertraulichkeitsvereinbarung zustimmen. Andernfalls bleiben wir bei der urspruenglichen Position."
+
+### Skript 3: Abschluss-Frage
+
+> "Wenn wir uns auf 47.500 Euro einigen und das Geld bis zum 30. dieses Monats fliesst, ist die Sache fuer Sie dann erledigt?"
+
+### Skript 4: Walk-Away-Signal
+
+> "Wir haben hier eine klare Linie. Wenn Sie nicht ueber die 35.000 Euro hinauskommen, werden wir Klage einreichen und sehen, wie das Gericht entscheidet."
+
+## Stoerfeuer und Antwort-Bausteine
+
+- **"Wir haben rechtsschutzversichert, uns ist der Prozess egal":** "Die Versicherung pruft Erfolgsaussichten. Wir koennen Ihnen gerne unser BVerfG-/BGH-Zitat zur Klage-Quote in diesen Faellen schicken."
+- **"Wir warten erstmal das Urteil im Verfahren XY ab":** "Verjaehrung laeuft uns weg. Wir lassen den Schiedsspruch im Hintergrund mitlaufen."
+- **"Ihre Mandantin hat sich rechtsmissbraeuchlich verhalten":** "Bitte praezisieren Sie - dann nehmen wir das ggf. in den Vergleich auf."
+
+## Steuerliche Behandlung des Vergleichs
+
+Im Bereich Steuerrecht (Beratung und Prozess) oft uebersehen:
+
+- Vergleichszahlung als Schadensersatz (in der Regel keine USt, EStG je nach Art).
+- Vergleich ueber Lohn-/Gehaltsanspruch -> Lohnsteuer- und SV-Abzug pruefen.
+- Vergleichszahlung als Anwaltshonorar -> ggf. USt.
+- Erbrechtliche Abfindung -> ggf. ErbStG.
+- Hinweis im Vergleich: "Die steuerliche Behandlung ist nicht Gegenstand dieser Vereinbarung und obliegt der eigenen Steuerberatung der Parteien."
+
+## Mediation als Alternative
+
+- Wenn Beziehung erhalten bleiben soll (Familie, Geschaeftspartner, Mieter und Vermieter).
+- Mediator unparteiisch, kein Entscheidungstraeger - braucht Vertraulichkeitsvereinbarung.
+- Mediations-Vergleich kann durch Notar oder Anwaltsvergleich vollstreckbar gemacht werden.
+- Foerderung MediationsG; in einigen Bundeslaendern Kostenuebernahme bei Familiensachen.
+
+## Vollstreckbarkeit
+
+- **Anwaltsvergleich nach § 796a ZPO:** anwaltlich beurkundeter Vergleich, mit Vollstreckungsklausel des Gerichts = Vollstreckungstitel.
+- **Notarieller Vergleich:** als Schuldanerkenntnis mit Vollstreckungsunterwerfung.
+- **Prozessvergleich:** § 794 Abs. 1 Nr. 1 ZPO, sofort vollstreckbar.
+- **Schiedsvergleich:** Vollstreckbarerklaerung nach §§ 1054, 1060 ZPO.
+
+## Vergleichs-Reichweite und Abgeltungsklausel
+
+Klassische Stolperfalle in Steuerrecht (Beratung und Prozess):
+
+- **Eng:** "Mit Zahlung sind alle Anspruche aus diesem Verfahren erledigt."
+- **Mittel:** "Mit Zahlung sind alle Anspruche aus dem zugrundeliegenden Sachverhalt erledigt."
+- **Weit:** "Mit Zahlung sind saemtliche bekannten und unbekannten Anspruche zwischen den Parteien erledigt." -> Vorsicht: Schadensersatz fuer noch nicht erkannte Schaeden ggf. weg.
+
+## Cross-Refs
+
+- `erstgespraech-mandatsannahme` (im selben Plugin) fuer die Erstaufnahme und Streitwertgrundlage.
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Fall, dass Vergleichsverhandlungen scheitern und Klage erforderlich wird.


### PR DESCRIPTION
Fuegt drei generische, in jeder Fachanwaltschaft breit nutzbare Skills hinzu - **fachspezifisch im jeweiligen Kontext**:

1. **erstgespraech-mandatsannahme** - strukturierter Erstgespraechs-Workflow: Konflikt- und GwG-Check, Vollmacht, Streitwert, Honorarvereinbarung, Fristen, Mandatsbogen.
2. **vergleichsverhandlung-strategie** - BATNA/WATNA/ZOPA, Verhandlungsskripte, steuerliche Behandlung, Vollstreckbarkeit (Anwaltsvergleich § 796a ZPO, Notarvergleich, Prozessvergleich).
3. **schriftsatzkern-substantiierung** - Aufbauschema, Beweisangebot-Standards, Replik-Vorausschau, beA/ERV-Anforderungen, Vier-Augen-Check.

**24 Plugins x 3 Skills = 72 neue SKILL.md.**

Jeder Skill ist auf das Plugin zugeschnitten: typische Themen, Schriftsatz-Typ, Vergleichskonstellationen und Kernparagrafen aus dem jeweiligen Fachgebiet sind eingebettet (z.B. KSchG/TzBfG bei Arbeitsrecht, AO/FGO/EStG bei Steuerrecht, SGB I-XIV bei Sozialrecht).

**Stil:** Generisch + breit nutzbar (wie vom User gewuenscht). Mittlere Tiefe (~160-200 Zeilen pro Skill). Frontmatter-Konvention: ASCII-only beim Steuer-Plugin, sonst beliebig.

**Validator:** kein \d,\d in description, alle descriptions <= 1024 Zeichen. Lokaler Vorabcheck: 0 Fehler bei allen 72 Dateien.

**Hinweis:** Diese Skills sind die generische Basis. Spezifischere Spezial-Skills werden separat von Claude ergaenzt.