### PR TITLE
feat(fa-gewrechts): GeschGehG-Skill mit Kollisionen NDA/HinSchG/UrhG/Verschwiegenheit

### DIFF
--- a/fachanwalt-gewerblicher-rechtsschutz/skills/fachanwalt-gewrechts-geschgehg-kollisionen-nda-hinschg-urhg/SKILL.md
+++ b/fachanwalt-gewerblicher-rechtsschutz/skills/fachanwalt-gewrechts-geschgehg-kollisionen-nda-hinschg-urhg/SKILL.md
@@ -1,0 +1,330 @@
+---
+name: fachanwalt-gewrechts-geschgehg-kollisionen-nda-hinschg-urhg
+description: Geschaeftsgeheimnisgesetz (GeschGehG) in der Praxis - Schutzvoraussetzungen, angemessene Geheimhaltungsmassnahmen, Kollisionen mit HinSchG (Whistleblower-Privileg), NDA-Klauselgrenzen, UrhG-/Patent-/Know-how-Abgrenzung, anwaltliche Verschwiegenheit (BORA, § 203 StGB), DSGVO und reverse engineering.
+---
+
+# Geschaeftsgeheimnisgesetz - Kollisionen mit Urheberrecht, Know-how, HinSchG, NDA und Verschwiegenheit
+
+## Wann dieser Skill greift
+
+- Mandantin will Konstruktionsdaten, Quellcode, Kundenliste, Rezeptur, Algorithmus, Verfahrensweise schuetzen.
+- Streit ueber Abwanderung Mitarbeiter mit "Wissen im Kopf", Konkurrenzunternehmen-Gruendung, Verwertung von Know-how.
+- Whistleblower-Hinweis bringt ehemalige oder aktuelle Beschaeftigte in einen Loyalitaetskonflikt: GeschGehG schweigen oder HinSchG melden?
+- NDA-Entwurf oder NDA-Pruefung im M&A-, Lieferanten-, Forschungs-, Lizenz-, Joint-Venture-Kontext.
+- Auseinandersetzung Urheberrecht vs. Geheimnisschutz (Software, Datenbanken, Konstruktionsdaten).
+- Reverse Engineering, Benchmarking, Konkurrenz-Recherche; AGB und Lizenzbedingungen, die das ausschliessen wollen.
+- Anwaltliche Vertretung der Mandantin in einem Verfahren, in dem Geschaeftsgeheimnisse offen zu legen waeren - Spannung zu BORA-Verschwiegenheit.
+
+## Rechtsgrundlagen
+
+- **GeschGehG vom 18.4.2019** (BGBl. I S. 466), in Kraft seit 26.4.2019, Umsetzung der RL (EU) 2016/943 (Know-how-RL).
+- **§ 1 GeschGehG** - Anwendungsbereich, Verhaeltnis zu anderen Vorschriften (insb. Strafrecht, Arbeitsrecht, Wettbewerbsrecht).
+- **§ 2 Nr. 1 GeschGehG** - Legaldefinition Geschaeftsgeheimnis: (a) nicht allgemein bekannt/zugaenglich, (b) wirtschaftlicher Wert wegen Geheimnischarakter, (c) Gegenstand angemessener Geheimhaltungsmassnahmen, (d) berechtigtes Geheimhaltungsinteresse.
+- **§ 3 GeschGehG** - erlaubte Handlungen (eigenstaendige Entwicklung, reverse engineering, Arbeitnehmer-Mitbestimmung, Whistleblowing als Ausnahme erst ueber § 5).
+- **§ 4 GeschGehG** - verbotene Handlungen (unbefugte Erlangung, Nutzung, Offenlegung).
+- **§ 5 GeschGehG** - Ausnahmen: (1) Meinungs-/Informationsfreiheit, (2) Aufdeckung rechtswidriger Handlungen und beruflichen Fehlverhaltens (Whistleblower-Privileg), (3) Mitteilung an AN-Vertretung.
+- **§§ 6-8 GeschGehG** - zivilrechtliche Ansprueche (Unterlassung, Beseitigung, Vernichtung, Auskunft, Schadensersatz).
+- **§§ 9-14 GeschGehG** - prozessuale Sondervorschriften: Geheimhaltungsanordnung, beschraenkter Personenkreis, Geheimnisklage.
+- **§ 15-22 GeschGehG** - sachliche Zustaendigkeit Landgerichte, Konzentration, Strafvorschriften.
+- **§ 23 GeschGehG** - Strafbarkeit Geheimnisverrat (1-5 Jahre, bei Wirtschaftsspionage bis 5 J.).
+- **HinSchG vom 31.5.2023** (BGBl. I Nr. 140) - Hinweisgeberschutz, Schutz vor Repressalien.
+- **§ 6 HinSchG** - Verhaeltnis zu anderen Vorschriften: GeschGehG-Schweigegebot tritt bei berechtigtem Hinweis nach §§ 32 ff. HinSchG zurueck.
+- **§ 32 HinSchG** - Inhaltlicher Anwendungsbereich, Verstoesse gegen Strafrecht, OWi, Wettbewerbsrecht u.a.
+- **§ 5 Nr. 2 GeschGehG i.V.m. § 32 HinSchG** - das Whistleblower-Privileg innerhalb der GeschGehG-Ausnahmesystematik.
+- **§ 203 StGB** - Verletzung von Privatgeheimnissen (Berufsgeheimnistraeger).
+- **§ 17 UWG (alt) / GeschGehG** - GeschGehG hat § 17-19 UWG abgeloest (Stichtag 26.4.2019).
+- **BORA § 2** und **BRAO § 43a Abs. 2** - anwaltliche Verschwiegenheit (Mandantengeheimnis).
+- **UrhG §§ 2, 69a, 87a-87e** - Werk-, Software-, Datenbankschutz; Verhaeltnis zum GeschGehG (parallel moeglich, anderer Schutzgegenstand).
+- **PatG § 1**, **GebrMG § 1**, **DesignG** - gewerbliche Schutzrechte mit Anmeldung; vor Anmeldung: Geheimnisschutz.
+- **Art. 6 DSGVO**, **Art. 9 DSGVO**, **BDSG** - Datenschutz bei Mitarbeiter-Daten/Personendaten, kollidiert mit Compliance-Untersuchung in Whistleblower-Faellen.
+- **Art. 5 GG** - Meinungs- und Pressefreiheit als verfassungsrechtlicher Rahmen fuer § 5 Nr. 1 GeschGehG.
+
+## Pruefungsschema Geschaeftsgeheimnis-Status
+
+### Schritt 1: Definition nach § 2 Nr. 1 GeschGehG
+
+Vier-Stufen-Test:
+
+1. **Nicht allgemein bekannt** und **nicht ohne weiteres zugaenglich** - im konkreten Marktsegment, fuer einschlaegigen Fachmann. Bekanntheit im Internet, in Branchenliteratur, auf Fachmessen schliesst Status aus.
+2. **Wirtschaftlicher Wert** gerade wegen des Geheimnischarakters - praktisch immer +, wenn 1. + 3. erfuellt; pruefen bei reinem Negativwissen (was funktioniert nicht).
+3. **Angemessene Geheimhaltungsmassnahmen** - der kritische Test, an dem viele Faelle scheitern.
+4. **Berechtigtes Geheimhaltungsinteresse** - praktisch immer +, ausser bei illegalen Inhalten.
+
+### Schritt 2: Angemessenheit der Geheimhaltungsmassnahmen
+
+Drei-Ebenen-Modell aus der BGH/OLG-Rechtsprechung:
+
+#### Organisatorische Ebene
+
+- Information-Need-to-Know-Prinzip (Zugriff nur fuer Mitarbeiterinnen mit konkretem Bedarf).
+- Trennung sensibler Bereiche (R&D, Vorstand, Strategie).
+- Clean-Desk-Policy, Besucherregelung, Whiteboard-Loeschpflicht.
+- Onboarding und Offboarding mit Geheimnis-Belehrung und -Auditing (Rueckgabe Datentraeger, Sperrung Zugaenge am Letzten Arbeitstag).
+
+#### Vertragliche Ebene
+
+- NDA mit Lieferanten, Beratern, Forschungspartnern, Praktikanten, Bewerbern (vor Datenuebergabe!).
+- Geheimhaltungsklausel im Arbeitsvertrag (Differenzierung Geschaeftsgeheimnis vs. ueberwirkende AN-Loyalitaetspflicht).
+- Wettbewerbsverbot in Vorbereitung und nach Beendigung mit Karenzentschaedigung (§ 110 GewO, § 74 HGB).
+- Kundenliste-, Lieferantenliste-Schutzklausel.
+
+#### Technische Ebene
+
+- Zugriffsrechte differenziert (RBAC), Multi-Faktor-Auth, Logging.
+- Verschluesselung at-rest und in-transit (mind. AES-256, TLS 1.2+).
+- DLP (Data Loss Prevention) fuer USB-/Cloud-/Mail-Versand.
+- Endpoint-Hardening, Patchmanagement, Mobile Device Management.
+- Source-Code-Repositories mit Zugriffslog und Wasserzeichen.
+- Klassifizierungsschema (oeffentlich/intern/vertraulich/streng vertraulich) mit Kennzeichnung.
+
+#### Dokumentationspflicht
+
+- Schriftliche Geheimnisschutz-Richtlinie (GHS-Policy).
+- Klassifizierungs-Register sensibler Informationen.
+- Schulungsnachweise.
+- Audit-Logs.
+- Pruefroutine (jaehrlich) mit Protokoll.
+
+### Schritt 3: Anspruchsgrundlagen bei Verletzung
+
+- **§ 6 GeschGehG** - Unterlassungs- und Beseitigungsanspruch.
+- **§ 7 GeschGehG** - Vernichtung, Herausgabe, Rueckruf, definitive Marktentfernung.
+- **§ 8 GeschGehG** - Auskunfts- und Bewahrungsanspruch.
+- **§ 10 GeschGehG** - Schadensersatz (drei Methoden: konkreter Schaden, Verletzergewinn, fiktive Lizenzgebuehr).
+- **Hilfsweise** UWG-Anspruch (§§ 3, 4 Nr. 4, 8, 9 UWG bei gezielter Behinderung), BGB-Anspruch (§§ 823 II, 826), arbeitsrechtlicher Schadensersatz (§ 280 BGB, § 619a BGB), strafrechtliche Anzeige (§ 23 GeschGehG, § 17 UWG-alt nicht mehr).
+
+## Kollisionsfeld 1: GeschGehG vs. Urheberrecht
+
+Beide Schutzregime laufen parallel, schuetzen aber Verschiedenes:
+
+| Aspekt | GeschGehG | UrhG |
+|---|---|---|
+| Schutzgegenstand | Information mit wirtschaftlichem Wert | persoenliche geistige Schoepfung |
+| Voraussetzung | Geheimhaltung + Massnahmen | Werkcharakter, Schoepfungshoehe |
+| Entstehung | mit Geheimhaltung | mit Schoepfung (automatisch) |
+| Dauer | solange geheim | 70 Jahre nach Tod Urheber |
+| Lizenzierbar | ja, mit NDA | ja, ueber UrhG-Lizenzvertrag |
+| Bei Veroeffentlichung | Schutzverlust | weiterhin Urheberrecht |
+| Verfolgung | LG (§ 15 GeschGehG, sachlich konzentriert) | LG (UrhG-Kammer) |
+
+### Software-Sonderfall (§ 69a UrhG)
+
+Quellcode kann **gleichzeitig** Urheberrechtsschutz (§ 69a UrhG) **und** Geschaeftsgeheimnis-Status haben:
+
+- Vor Offenlegung: GeschGehG + UrhG.
+- Open-Source-Veroeffentlichung: GeschGehG-Status entfaellt, UrhG bleibt (mit Lizenz, z.B. GPL/MIT/Apache).
+- Bei Mischverwertung (proprietaer + Open Source): Compliance-Layer beachten.
+- Bei Decompilation nach § 69e UrhG: Grenze auch fuer reverse engineering nach § 3 GeschGehG.
+
+### Datenbankschutz (§§ 87a ff. UrhG)
+
+- Investitionsschutz sui generis (15 Jahre, verlaengerbar bei wesentlicher Aktualisierung).
+- Kundenliste, technische Datenbank koennen parallel Geschaeftsgeheimnis + Datenbankrecht.
+- Bei Veroeffentlichung verliert sie Geheimnisstatus, behaelt Datenbankrecht.
+
+## Kollisionsfeld 2: GeschGehG vs. Know-how (begriffliche Abgrenzung)
+
+"Know-how" ist kein Rechtsbegriff im engeren Sinne, sondern ein Sammelbegriff:
+
+- **Geschuetztes Know-how:** erfuellt die Voraussetzungen § 2 Nr. 1 GeschGehG -> GeschGehG-Schutz.
+- **Ungeschuetztes Know-how:** keine Geheimhaltungsmassnahmen -> kein GeschGehG-Schutz, ggf. nur AN-Treuepflicht oder UWG (gezielte Behinderung).
+- **Allgemeines Berufswissen / "Wissen im Kopf"** (skill, Erfahrung, Schulung) - **kein** Geschaeftsgeheimnis. Arbeitnehmerin darf es nach Beendigung des AV grundsaetzlich nutzen (BAG 2 AZR 547/05).
+
+Trennlinie nach BAG: Mitnahme von Daten oder Datentraegern = Geheimnisverletzung; Verwertung gelernter Faehigkeiten = erlaubt.
+
+## Kollisionsfeld 3: GeschGehG vs. HinSchG (Whistleblower-Privileg)
+
+Klassische Konfliktlage:
+
+- Beschaeftigte beobachtet rechtswidrige Praxis (Subventionsbetrug, Kartellverstoss, Umweltdelikt, Datenpanne, Verstoss gegen Sicherheitsstandards).
+- Information ist zugleich Geschaeftsgeheimnis (verschwiegene Methode, interne Bilanzposten, Kundendatenbank).
+- Whistleblower-Meldung an interne Meldestelle, externe Meldestelle (BfJ, BAFIN, BKartA) oder Oeffentlichkeit?
+
+### Pruefungsreihenfolge
+
+1. **§ 5 Nr. 2 GeschGehG** (alt-eigenstaendige Ausnahme): Geheimnisverletzung gerechtfertigt zur Aufdeckung rechtswidriger Handlungen / beruflichen Fehlverhaltens, wenn dies zum Schutz des allgemeinen oeffentlichen Interesses geeignet ist.
+2. **HinSchG-Anwendungsbereich** § 2 Abs. 1 (Verstoesse strafrechtlich, OWi-bewehrt, EU-Recht, kartell-, finanz-, datenschutz-, lebensmittel-, produktrechtlich u.a.).
+3. **Meldewege** § 7 HinSchG: interne ODER externe Meldestelle (gleichberechtigt, nicht hierarchisch).
+4. **Oeffentlichkeit** nach § 32 HinSchG nur als Ultima Ratio (Reaktion ausgeblieben, unmittelbare Gefahr, Vertuschung droht).
+5. **Schutzwirkung** § 36 HinSchG (Repressalienverbot, Beweislastumkehr zugunsten Hinweisgeber).
+
+### Was Hinweisgeber NICHT schuetzt
+
+- Vorsaetzlich falsche Meldung (§ 38 HinSchG - Schadensersatzpflicht).
+- Information, die ueber das fuer die Meldung Notwendige hinausgeht (Datenminimierung).
+- Meldung gegenueber Stellen ohne Zustaendigkeit (z.B. Presse statt BaFin bei reinem Bankverstoss).
+- Geschuetzte berufliche Geheimnisse Dritter (Anwaltsgeheimnis § 203 StGB).
+
+### Praxis-Empfehlung an Mandantin (Unternehmen)
+
+- Interne Meldestelle nach § 12 HinSchG einrichten und attraktiv machen (Vertrauen + Bearbeitungsqualitaet).
+- Internes Untersuchungsverfahren mit Datenschutz-Compliance (Art. 6 Abs. 1 lit. f DSGVO, ggf. DSFA).
+- Niemals Whistleblowing-Meldung als Geheimnisverrat verfolgen, solange § 5 Nr. 2 GeschGehG / HinSchG einschlaegig - das waere Repressalie und kann mit Bussgeldern nach § 40 HinSchG enden.
+
+### Praxis-Empfehlung an Mandanten (potenzielle Hinweisgeber)
+
+- Belege intern sichern (keine Schwarz-Kopien fremder Datenbanken, nur eigener Zugriff im normalen Arbeitsumfang).
+- Meldung schriftlich, sachlich, faktenbasiert.
+- Anwaltliche Beratung VOR der Meldung (Verfahrensaccount, Beweissicherung, Rechtsmittel).
+- Externe Meldestelle BfJ ist gleichwertig zur internen.
+
+## Kollisionsfeld 4: GeschGehG vs. NDA - Klauselgrenzen
+
+NDAs sind das Hauptinstrument zur "vertraglichen Ebene" der Geheimhaltungsmassnahmen. Aber sie haben Grenzen:
+
+### Zulaessige Klauseln
+
+- Definition des Geheimnisses (Bezeichnung, Klassifizierung, Markierungspflicht).
+- Pflicht zur Geheimhaltung mit klarer Dauer (typisch 3-10 Jahre nach Vertragsende; bei strategischen Geheimnissen unbegrenzt).
+- Pflicht zur Rueckgabe / Loeschung am Vertragsende.
+- Verbot der Weitergabe an Subunternehmer ohne schriftliche Zustimmung.
+- Vertragsstrafe (BGH-konform: bestimmter Betrag oder bestimmbarer Mechanismus, nicht "angemessen").
+- Gerichtsstand und anwendbares Recht.
+
+### Unwirksame oder problematische Klauseln
+
+- **Whistleblower-Ausschluss / Schweigegebot fuer rechtswidrige Sachverhalte** - unwirksam nach § 6 HinSchG, § 32 HinSchG, § 5 Nr. 2 GeschGehG.
+- **Aufweichungsverbot ueberwirkender Geheimhaltungspflichten ohne klare Begrenzung** - AGB-rechtlich (§ 307 BGB) problematisch.
+- **Geheimhaltung von Informationen, die bereits oeffentlich sind** - unwirksam (kein berechtigtes Interesse).
+- **Konkurrenzverbot mit Geheimhaltungsetikett** - oft Umgehung § 110 GewO / §§ 74 ff. HGB (Karenzentschaedigung).
+- **Strafe ohne Schadensobergrenze und ohne Schiedsmechanismus** - § 307 BGB-Problem in AGB.
+
+### Pflicht-Klauseln im 2026-Standard-NDA
+
+1. Praeambel mit Zweck und Vertragsparteien.
+2. Definition Vertrauliche Information (positiv UND negativ: Ausnahmen).
+3. Geheimhaltung und Nutzung nur zum Vertragszweck.
+4. Weitergabe nur an Need-to-Know-Empfaenger mit gleicher Pflicht.
+5. Dauer der Pflicht (mit klarer Frist).
+6. Rueckgabe/Loeschung.
+7. **HinSchG-Vorbehalt:** "Diese Vereinbarung beruehrt nicht die Rechte nach dem Hinweisgeberschutzgesetz; Meldungen ueber Rechtsverstoesse an interne, externe oder ggf. oeffentliche Meldestellen sind keine Verletzung dieser Vereinbarung."
+8. **GeschGehG-Ausnahmen-Klausel:** "Erlaubt bleiben die Faelle nach § 3 GeschGehG einschliesslich eigenstaendiger Entwicklung und reverse engineering, soweit gesetzlich zulaessig."
+9. Vertragsstrafe (bestimmter Betrag + ggf. Schadensersatz-Vorbehalt).
+10. Gerichtsstand und Recht.
+11. Salvatorische Klausel und Schriftform.
+
+## Kollisionsfeld 5: GeschGehG vs. anwaltliche Verschwiegenheit (BORA, § 203 StGB)
+
+Anwaltliche Verschwiegenheit ist staerker als GeschGehG, geht aber inhaltlich darueber hinaus:
+
+| Aspekt | Anwaltsgeheimnis | GeschGehG |
+|---|---|---|
+| Schutzgut | Vertrauensverhaeltnis | wirtschaftlicher Wert |
+| Rechtsquelle | § 43a Abs. 2 BRAO, § 2 BORA, § 203 StGB | GeschGehG |
+| Verletzung | strafbar (§ 203 StGB) + standesrechtlich + zivilrechtlich | zivilrechtlich + § 23 GeschGehG strafrechtlich |
+| Dauer | ueber Mandatsende hinaus, unbegrenzt | solange Geheimnischarakter besteht |
+| Ausnahme | mit Einwilligung Mandant; Berufsausuebung selbst | § 3, § 5 GeschGehG |
+
+### Konfliktfall: Anwaltin soll im eigenen Prozess Geschaeftsgeheimnisse offenlegen
+
+- Anwaltsgeheimnis hat Vorrang (BORA § 2).
+- Im Prozess: Geheimnisklage nach §§ 16-20 GeschGehG mit Geheimhaltungsanordnung beantragen.
+- Kammer kann Personenkreis beschraenken, Akten unter Verschluss nehmen, Hauptverhandlung ausschliessen (§ 172 GVG analog).
+- "Anwaltsschutzschild" bei beschlagnahmten Mandantenunterlagen (§§ 53, 97 StPO).
+
+### Konfliktfall: Mandantin teilt Geschaeftsgeheimnisse Dritter mit
+
+- Vorsicht bei der Aktenarbeit: keine unnoetige Weitergabe an Externe (Uebersetzer, Sachverstaendige, Praktikanten) ohne NDA.
+- Aktenfuehrung mit Zugriffs-Log fuer hochsensible Mandate.
+- Anwaltliche Schweigepflicht greift; aber wenn Anwaeltin selbst Geschaeftsgeheimnisse Dritter erlangt, kann sie selbst Adressatin von § 4 GeschGehG werden.
+
+## Reverse Engineering (§ 3 Abs. 1 Nr. 2 GeschGehG)
+
+Eigenstaendig zentral und oft missverstanden:
+
+- **Erlaubt:** Beobachtung, Untersuchung, Rueckbau, Test eines Produkts oder Gegenstands, das rechtmaessig in den Besitz gelangt ist (gekauft, geliehen, ueber Lizenz erlangt).
+- **Voraussetzung 1:** keine vertragliche Beschraenkung, die die Untersuchung ausschliesst (AGB-Klauseln moeglich, aber § 307 BGB-Pruefung).
+- **Voraussetzung 2:** keine Schutzrechtsverletzung (Patent, Urheberrecht).
+- **Voraussetzung 3:** keine unfaire Handlung nach UWG (gezielte Behinderung, Schwarzkopie).
+
+### Sondersituation Software
+
+- § 69e UrhG: Decompilation nur zur Herstellung von Interoperabilitaet erlaubt; Grenzen sehr eng.
+- AGB-Klausel "Reverse Engineering untersagt" - umstritten; BGH I ZR 173/12: bei Standardsoftware oft unwirksam.
+- Open-Source-Lizenzen erlauben reverse engineering grundsaetzlich.
+
+## Prozessuale Sondervorschriften (Geheimnisstreitverfahren §§ 9 ff. GeschGehG)
+
+### Geheimhaltungsanordnung § 16
+
+- Kammer kann Inhalt der Klageschrift und Anlagen als geheimhaltungsbeduerftig einstufen.
+- Personenkreis-Beschraenkung: nur Anwaltinnen, ein Mitarbeiter pro Partei, Sachverstaendige unter NDA.
+- Pflicht der Beteiligten zur Verschwiegenheit (bewehrt mit Ordnungsgeld).
+
+### Eingrenzung Hauptverhandlung § 19
+
+- Ausschluss der Oeffentlichkeit moeglich.
+- Vertrauliche Anhoerung mit beschraenktem Personenkreis.
+
+### Urteilstenor § 20
+
+- Veroeffentlichung des Urteils kann beschraenkt werden.
+- Anonymisierung der Geheimnis-Inhalte.
+
+### Praxis-Tipp
+
+- Antrag auf Geheimhaltungsanordnung bereits in der Klageschrift, mit konkreter Bezeichnung der zu schuetzenden Information und Begruendung des Geheimnischarakters.
+- Vor Klageeinreichung pruefen: reicht das Eilverfahren (eV) auf Unterlassung, ohne Geheimnis voll offen zu legen?
+
+## DSGVO-Schnittstellen
+
+- Kundenliste als Geschaeftsgeheimnis und zugleich personenbezogene Daten -> Doppelschutz.
+- Bei Whistleblowing: Datenverarbeitung nach Art. 6 Abs. 1 lit. f DSGVO, Datenschutz-Folgeabschaetzung nach Art. 35 DSGVO.
+- Beschaeftigtendatenschutz § 26 BDSG bei interner Untersuchung.
+- Internationale Datenuebertragung (M&A-DueD): Art. 44 ff. DSGVO + EU-US DPF (im Plugin internationales-wirtschaftsrecht behandelt).
+
+## Praxis-Konstellationen
+
+### Konstellation A: Mitarbeiterabwanderung
+
+- Mitarbeiterin kuendigt, gruendet Wettbewerber-Unternehmen oder wechselt zur Konkurrenz.
+- Mandantin (alter Arbeitgeber) befuerchtet Mitnahme Kundendaten, technisches Know-how.
+- Pruefung:
+  - Geheimnisschutz-Massnahmen vor Kuendigung dokumentiert?
+  - Datenabfluss ueber Endpoint-Logs/E-Mail-Logs nachweisbar?
+  - Nachvertragliches Wettbewerbsverbot existent + Karenzentschaedigung?
+  - Schnelle eV auf Unterlassung am LG (Konzentrationsgericht).
+  - Parallel: arbeitsrechtliche Schadensersatzklage, ggf. Strafanzeige § 23 GeschGehG.
+
+### Konstellation B: NDA-Pruefung im M&A
+
+- Mandantin will Daten an potenziellen Kaeufer geben.
+- NDA-Standardklauseln Kaeufer-Seite enthalten HinSchG-Aushebelung, ueberdehnte Loeschungspflichten, einseitige Vertragsstrafen.
+- Mandanten-Klausel-Set: HinSchG-Vorbehalt, GeschGehG-Reverse-Engineering-Erlaubnis nach § 3, beidseitige Vertragsstrafe, Schiedsklausel (DIS, ICC).
+
+### Konstellation C: Whistleblower-Verteidigung
+
+- Mandant ist Hinweisgeber; Arbeitgeber wirft Geheimnisverrat vor.
+- Verteidigungslinie:
+  1. § 5 Nr. 2 GeschGehG (Aufdeckung rechtswidriger Praxis).
+  2. HinSchG-Schutz § 32 + § 36 (Repressalienverbot, Beweislastumkehr).
+  3. Falls Klage: Geheimhaltungsanordnung beantragen, um nicht zusaetzlich materiell zu schaden.
+  4. Bei Kuendigung: KSchG-Klage parallel, Berufung auf § 36 HinSchG.
+
+### Konstellation D: Reverse Engineering Verteidigung
+
+- Mandantin wird verklagt, weil sie Konkurrenz-Produkt analysiert und ein eigenes auf den Markt gebracht hat.
+- Verteidigungslinie:
+  1. Produkt war frei am Markt erhaeltlich (rechtmaessiger Besitz).
+  2. Keine AGB-Beschraenkung in der Kette von Eigentumserwerbungen.
+  3. Eigenentwicklung mit zeitnaher Dokumentation (Labor-Tagebuch, Konstruktionsskizzen, Versionierung im Code).
+  4. Falls Patent: Pruefung Schutzrechtsverletzung (Aequivalenz, Doctrine of Equivalents).
+
+## Pflicht-Output bei Geheimnisschutz-Mandat
+
+1. **GeschGehG-Status-Memo:** Pruefung Status nach § 2 Nr. 1 (vier Stufen).
+2. **Massnahmenkatalog organisatorisch + vertraglich + technisch** mit Umsetzungsplan.
+3. **NDA-Vorlage** mit HinSchG-Vorbehalt und GeschGehG-konformen Ausnahmen.
+4. **Geheimnis-Klassifizierungs-Register** als XLSX mit Kategorie, Schutzdauer, Verantwortlichkeit.
+5. **Schulungs-Unterlage** fuer Belegschaft (rechtssichere Handlungsanweisungen).
+6. **Notfallplan bei Verletzung:** Mahnung, eV-Antrag, Strafanzeige § 23, Whistleblower-Check.
+
+## Cross-Refs
+
+- `fachanwalt-arbeitsrecht-hinschg-whistleblower-repressalie` fuer die HinSchG-Verteidigung im Arbeitsverhaeltnis.
+- `fachanwalt-it-recht-ki-vo-hochrisiko-konformitaetsbewertung` fuer technische Geheimhaltungsmassnahmen bei KI-Systemen.
+- `fachanwalt-urheber-medienrecht-tdm-44b-urhg-ki-training-opt-out` fuer KI-Training-Opt-out (eng mit reverse engineering verwandt).
+- `schriftsatzkern-substantiierung` (im selben Plugin) fuer den Aufbau einer Geheimnisklage mit Antrag auf Geheimhaltungsanordnung.
+- `vergleichsverhandlung-strategie` (im selben Plugin) fuer NDA-Lizenz-Vergleich.
+- Im Plugin `kanzlei-allgemein`: Verschwiegenheits- und Konfliktroutinen fuer die anwaltliche Seite.
+- Im Plugin `dsgvo` (falls vorhanden): Datenschutzfragen bei Geheimnisschutz-Massnahmen.


### PR DESCRIPTION
Neuer Skill im fachanwalt-gewerblicher-rechtsschutz-Plugin: **fachanwalt-gewrechts-geschgehg-kollisionen-nda-hinschg-urhg**.

Behandelt das Geschaeftsgeheimnisgesetz und die Kollisionen, die in der Praxis Probleme machen:

- **Schutzvoraussetzungen § 2 Nr. 1 GeschGehG** mit Drei-Ebenen-Modell der angemessenen Geheimhaltungsmassnahmen.
- **GeschGehG vs. UrhG** (Software § 69a, Datenbankrecht § 87a) - paralleler Schutz, andere Voraussetzungen.
- **GeschGehG vs. Know-how** - Abgrenzung Wissen im Kopf vs. mitgenommene Daten (BAG 2 AZR 547/05).
- **GeschGehG vs. HinSchG** - § 5 Nr. 2 GeschGehG mit § 32 HinSchG; was Whistleblower NICHT schuetzt.
- **NDA-Klauselgrenzen:** unwirksam sind Whistleblower-Aushebelung, ueberdehnte Verschwiegenheit ohne Frist, Schutz oeffentlicher Information.
- **GeschGehG vs. anwaltliche Verschwiegenheit** (BORA, § 203 StGB) - Anwaltsgeheimnis hat Vorrang.
- **Reverse Engineering § 3 Abs. 1 Nr. 2 GeschGehG** - Voraussetzungen und Software-Sonderfall § 69e UrhG.
- **Prozessuale Sondervorschriften §§ 9-20 GeschGehG** - Geheimhaltungsanordnung, Personenkreisbeschraenkung.
- **DSGVO-Schnittstellen.**
- Vier konkrete **Praxis-Konstellationen** (Mitarbeiterabwanderung, M&A-NDA-Pruefung, Whistleblower-Verteidigung, Reverse-Engineering-Verteidigung).

330 Zeilen, description 299 Zeichen, Validator-konform.