### PR TITLE
fix: tote Skill-Slug-Verweise + GeschGehG-Strafrahmen und HinSchG-Anwendungsbereich

### DIFF
--- a/fachanwalt-gewerblicher-rechtsschutz/skills/fachanwalt-gewrechts-geschgehg-kollisionen-nda-hinschg-urhg/SKILL.md
+++ b/fachanwalt-gewerblicher-rechtsschutz/skills/fachanwalt-gewrechts-geschgehg-kollisionen-nda-hinschg-urhg/SKILL.md
@@ -26,10 +26,11 @@ description: Geschaeftsgeheimnisgesetz (GeschGehG) in der Praxis - Schutzvorauss
 - **§§ 6-8 GeschGehG** - zivilrechtliche Ansprueche (Unterlassung, Beseitigung, Vernichtung, Auskunft, Schadensersatz).
 - **§§ 9-14 GeschGehG** - prozessuale Sondervorschriften: Geheimhaltungsanordnung, beschraenkter Personenkreis, Geheimnisklage.
 - **§ 15-22 GeschGehG** - sachliche Zustaendigkeit Landgerichte, Konzentration, Strafvorschriften.
-- **§ 23 GeschGehG** - Strafbarkeit Geheimnisverrat (1-5 Jahre, bei Wirtschaftsspionage bis 5 J.).
+- **§ 23 GeschGehG** - Strafbarkeit Geheimnisverrat: Grundtatbestand Abs. 1 Geldstrafe oder Freiheitsstrafe bis zu drei Jahren; Abs. 2 (Verwertung/Offenlegung trotz Erlangungsverbot) Geldstrafe oder Freiheitsstrafe bis zu zwei Jahren; Abs. 4 (qualifizierte Faelle/Auslandsbezug/Wirtschaftsspionage) Freiheitsstrafe bis zu fuenf Jahren.
 - **HinSchG vom 31.5.2023** (BGBl. I Nr. 140) - Hinweisgeberschutz, Schutz vor Repressalien.
 - **§ 6 HinSchG** - Verhaeltnis zu anderen Vorschriften: GeschGehG-Schweigegebot tritt bei berechtigtem Hinweis nach §§ 32 ff. HinSchG zurueck.
-- **§ 32 HinSchG** - Inhaltlicher Anwendungsbereich, Verstoesse gegen Strafrecht, OWi, Wettbewerbsrecht u.a.
+- **§ 2 HinSchG** - sachlicher Anwendungsbereich, Verstoesse gegen Strafrecht, OWi-Recht, EU-Recht, Wettbewerbs-/Kartell-/Finanz-/Datenschutz-/Lebensmittel-/Produktrecht u.a.
+- **§ 32 HinSchG** - Offenlegung (Public Disclosure) als Ultima Ratio: zulaessig erst bei ausbleibender Reaktion, unmittelbarer Gefahr oder drohender Vertuschung.
 - **§ 5 Nr. 2 GeschGehG i.V.m. § 32 HinSchG** - das Whistleblower-Privileg innerhalb der GeschGehG-Ausnahmesystematik.
 - **§ 203 StGB** - Verletzung von Privatgeheimnissen (Berufsgeheimnistraeger).
 - **§ 17 UWG (alt) / GeschGehG** - GeschGehG hat § 17-19 UWG abgeloest (Stichtag 26.4.2019).

--- a/fachanwalt-gewerblicher-rechtsschutz/skills/fachanwalt-gewrechts-ki-vo-50-genai/SKILL.md
+++ b/fachanwalt-gewerblicher-rechtsschutz/skills/fachanwalt-gewrechts-ki-vo-50-genai/SKILL.md
@@ -120,8 +120,8 @@ Spezial-Mandat im gewerblichen Rechtsschutz: Mandant nutzt generative KI für Ma
 
 - `fachanwalt-gewerblicher-rechtsschutz-orientierung` — Triage
 - `fachanwalt-gewerblicher-rechtsschutz-uwg-einstweilige-verfuegung` — bei Abmahnung
-- `fachanwalt-it-recht-ki-vo-hochrisiko-system-konformitaetsbewertung-art-16-29` — bei High-Risk-AI
-- `fachanwalt-urheber-medienrecht-text-data-mining-44b-urhg-ki-training-opt-out` — Training-Daten-Recht
+- `fachanwalt-it-recht-ki-vo-hochrisiko-konformitaetsbewertung` — bei High-Risk-AI
+- `fachanwalt-urheber-medienrecht-tdm-44b-urhg-ki-training-opt-out` — Training-Daten-Recht
 
 ## Quellen und Updates
 

--- a/fachanwalt-it-recht/skills/fachanwalt-it-recht-ki-vo-hochrisiko-konformitaetsbewertung/SKILL.md
+++ b/fachanwalt-it-recht/skills/fachanwalt-it-recht-ki-vo-hochrisiko-konformitaetsbewertung/SKILL.md
@@ -102,7 +102,7 @@ Spezial-Mandat: Mandant entwickelt/vertreibt KI-System, das nach **Anhang III KI
 ## Querverweise
 
 - `fachanwalt-it-recht-orientierung` — Triage
-- `fachanwalt-gewerblicher-rechtsschutz-ki-vo-art-50-generative-ai-transparenz` — bei generativer KI
+- `fachanwalt-gewrechts-ki-vo-50-genai` — bei generativer KI
 - `fachanwalt-it-recht-cyber-vorfall-sofortmassnahmen` — bei Sicherheitsvorfall
 - `aussenwirtschaft-zoll-sanktionen` — bei Dual-Use-KI
 

--- a/fachanwalt-transport-speditionsrecht/skills/fachanwalt-transport-autonome-lkw-konvois-haftung-1d-stvg/SKILL.md
+++ b/fachanwalt-transport-speditionsrecht/skills/fachanwalt-transport-autonome-lkw-konvois-haftung-1d-stvg/SKILL.md
@@ -118,7 +118,7 @@ Spezial-Mandat: LKW-Spedition setzt Platooning (autonome Konvois, mehrere LKW in
 
 - `fachanwalt-transport-speditionsrecht-orientierung` — Triage
 - `fachanwalt-transport-cmr-schadensregulierung` — CMR-Verfahren
-- `fachanwalt-verkehrsrecht-autonomes-fahren-1d-stvg-haftungskonzept` — PKW-Variante
+- `fachanwalt-verkehr-autonom-1d-stvg` — PKW-Variante
 - `fachanwalt-versicherungsrecht-orientierung` — Versicherer-Streit
 
 ## Quellen und Updates

--- a/fachanwalt-urheber-medienrecht/skills/fachanwalt-urheber-medienrecht-tdm-44b-urhg-ki-training-opt-out/SKILL.md
+++ b/fachanwalt-urheber-medienrecht/skills/fachanwalt-urheber-medienrecht-tdm-44b-urhg-ki-training-opt-out/SKILL.md
@@ -140,7 +140,7 @@ Generative AI training prohibited.
 
 - `fachanwalt-urheber-medienrecht-orientierung` — Triage
 - `fachanwalt-urheber-medienrecht-lizenzvertrag-verhandlung` — bei nachträglicher Lizenz
-- `fachanwalt-gewerblicher-rechtsschutz-ki-vo-art-50-generative-ai-transparenz` — Output-Kennzeichnung
+- `fachanwalt-gewrechts-ki-vo-50-genai` — Output-Kennzeichnung
 - `fachanwalt-it-recht-ki-vo-hochrisiko-konformitaetsbewertung` — bei KI-Anbieter
 
 ## Quellen und Updates


### PR DESCRIPTION
Behebt fuenf Codex-Befunde am Skill-Set rund um KI-VO/GeschGehG.

## P2 - tote Cross-Refs (4 Dateien)

- fachanwalt-gewrechts-ki-vo-50-genai: Verweise auf existierende Slugs fachanwalt-it-recht-ki-vo-hochrisiko-konformitaetsbewertung und fachanwalt-urheber-medienrecht-tdm-44b-urhg-ki-training-opt-out
- fachanwalt-it-recht-ki-vo-hochrisiko-konformitaetsbewertung: Verweis auf fachanwalt-gewrechts-ki-vo-50-genai (statt langer Alt-Slug)
- fachanwalt-transport-autonome-lkw-konvois-haftung-1d-stvg: Verweis auf fachanwalt-verkehr-autonom-1d-stvg
- fachanwalt-urheber-medienrecht-tdm-44b-urhg-ki-training-opt-out: Verweis auf fachanwalt-gewrechts-ki-vo-50-genai

## P1 - GeschGehG-Skill

- § 23 GeschGehG: korrekter Strafrahmen (Abs. 1 bis 3 J., Abs. 2 bis 2 J., Abs. 4 bis 5 J.) statt fehlerhaftem 1-5 J. Mindestrahmen
- § 2 HinSchG (sachlicher Anwendungsbereich) eingefuehrt; § 32 HinSchG auf Offenlegung/Public Disclosure als Ultima Ratio praezisiert