### PR TITLE
feat(ki-vo): Hochrisiko und Nicht-Hochrisiko Roadmaps + fix(geschgehg): § 23 Abs. 2

### DIFF
--- a/fachanwalt-gewerblicher-rechtsschutz/skills/fachanwalt-gewrechts-geschgehg-kollisionen-nda-hinschg-urhg/SKILL.md
+++ b/fachanwalt-gewerblicher-rechtsschutz/skills/fachanwalt-gewrechts-geschgehg-kollisionen-nda-hinschg-urhg/SKILL.md
@@ -26,7 +26,7 @@ description: Geschaeftsgeheimnisgesetz (GeschGehG) in der Praxis - Schutzvorauss
 - **§§ 6-8 GeschGehG** - zivilrechtliche Ansprueche (Unterlassung, Beseitigung, Vernichtung, Auskunft, Schadensersatz).
 - **§§ 9-14 GeschGehG** - prozessuale Sondervorschriften: Geheimhaltungsanordnung, beschraenkter Personenkreis, Geheimnisklage.
 - **§ 15-22 GeschGehG** - sachliche Zustaendigkeit Landgerichte, Konzentration, Strafvorschriften.
-- **§ 23 GeschGehG** - Strafbarkeit Geheimnisverrat: Grundtatbestand Abs. 1 Geldstrafe oder Freiheitsstrafe bis zu drei Jahren; Abs. 2 (Verwertung/Offenlegung trotz Erlangungsverbot) Geldstrafe oder Freiheitsstrafe bis zu zwei Jahren; Abs. 4 (qualifizierte Faelle/Auslandsbezug/Wirtschaftsspionage) Freiheitsstrafe bis zu fuenf Jahren.
+- **§ 23 GeschGehG** - Strafbarkeit Geheimnisverrat: Abs. 1 (Erlangung) Geldstrafe oder Freiheitsstrafe bis zu drei Jahren; Abs. 2 (Nutzung/Offenlegung) ebenfalls Geldstrafe oder Freiheitsstrafe bis zu drei Jahren; Abs. 3 (Konstellationen z.B. nach Beendigung Arbeitsverhaeltnis) Geldstrafe oder Freiheitsstrafe bis zu zwei Jahren; Abs. 4 (qualifizierte Faelle/Auslandsbezug/Wirtschaftsspionage) Freiheitsstrafe bis zu fuenf Jahren.
 - **HinSchG vom 31.5.2023** (BGBl. I Nr. 140) - Hinweisgeberschutz, Schutz vor Repressalien.
 - **§ 6 HinSchG** - Verhaeltnis zu anderen Vorschriften: GeschGehG-Schweigegebot tritt bei berechtigtem Hinweis nach §§ 32 ff. HinSchG zurueck.
 - **§ 2 HinSchG** - sachlicher Anwendungsbereich, Verstoesse gegen Strafrecht, OWi-Recht, EU-Recht, Wettbewerbs-/Kartell-/Finanz-/Datenschutz-/Lebensmittel-/Produktrecht u.a.

--- a/ki-vo-ai-act-pruefer/.claude-plugin/plugin.json
+++ b/ki-vo-ai-act-pruefer/.claude-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
-  "name": "ki-vo-ai-act-pruefer",
-  "version": "9.0.0",
-  "description": "Vollstaendiger Mechanik-Workflow zur Verordnung (EU) 2024/1689 (KI-VO): KI-System-Definition, Rollen, Risikoklassen, Hochrisiko-Pflichten, GPAI-Modelle, Sanktionen. Kein Rechtsrat.",
-  "license": "Apache-2.0 OR MIT",
-  "author": {
-    "name": "Klotzkette"
-  },
-  "homepage": "https://github.com/Klotzkette/claude-fuer-deutsches-recht"
+    "name": "ki-vo-ai-act-pruefer",
+    "version": "9.0.0",
+    "description": "Mechanik-Workflow zur KI-VO (EU 2024/1689): KI-System-Definition, Rollen, Risikoklassen, verbotene Praktiken, Hochrisiko-Diagnose und 12-Schritte-Roadmap bis CE, Konformitaetsbewertung, EU-DB, Marktbeobachtung. Auch Negativ-Diagnose ueber Rueckausnahme Art. 6 Abs. 3, GPAI, Sanktionen.",
+    "license": "Apache-2.0 OR MIT",
+    "author": {
+        "name": "Klotzkette"
+    },
+    "homepage": "https://github.com/Klotzkette/claude-fuer-deutsches-recht"
 }

--- a/ki-vo-ai-act-pruefer/README.md
+++ b/ki-vo-ai-act-pruefer/README.md
@@ -43,15 +43,27 @@ Der KI-VO-Prüfer ist ein interaktives Mechanik-Plugin für die vollständige Pr
 7. Liegt ein GPAI-Modell vor? (Art. 3 Nr. 63 KI-VO)
 8. Welche Pflichten treffen mich?
 9. Konformitätsbewertung und Registrierung?
+10. Welche **End-to-End-Roadmap** brauche ich danach?
+
+Drei mögliche Diagnose-Ergebnisse, drei Workflows:
+
+- **Hochrisiko bestätigt** → `hochrisiko-bestaetigt-end-to-end-roadmap` führt durch zwölf Schritte von Risikomanagement (Art. 9) bis CE-Kennzeichnung, EU-DB-Registrierung und Marktbeobachtung.
+- **Hochrisiko verneint über Rückausnahme** (Art. 6 Abs. 3 KI-VO) → `nicht-hochrisiko-bestaetigt-end-to-end-roadmap` dokumentiert Negativ-Diagnose und Restpflichten.
+- **Anhang I/III nicht zutreffend** → ebenfalls `nicht-hochrisiko-bestaetigt-end-to-end-roadmap` mit Pflichten zu Art. 5 (Verbot), Art. 50 (Transparenz), Art. 4 (KI-Kompetenz), GPAI.
 
 ---
 
-## Skills (42 Stück)
+## Skills (44 Stück)
 
 ### Einstieg
 
 - **`entscheidungsbaum-ki-vo-gesamt-workflow`** — Master-Workflow: Start hier für vollständige Prüfung
 - **`triage-ki-vo-vorpruefung`** — Erfassung des Sachverhalts
+
+### End-to-End-Roadmaps nach Diagnose
+
+- **`hochrisiko-bestaetigt-end-to-end-roadmap`** — zwölf Schritte vom Risikomanagement bis zu CE-Kennzeichnung, EU-DB-Registrierung und Marktbeobachtung; mit Aufwandsschätzung, Akteur-Übersicht (notifizierte Stelle, Marktaufsicht, AI Office, Sektor-Regulatoren) und Markteintritts-Checkliste.
+- **`nicht-hochrisiko-bestaetigt-end-to-end-roadmap`** — drei Wege zur Negativ-Diagnose (Anhang nicht zutreffend / Rückausnahme Art. 6 Abs. 3 / kein KI-System), Restpflichten Art. 4, Art. 5, Art. 50, GPAI, sektoral, Dokumentationspflicht und Re-Evaluation-Trigger.
 
 ### A. KI-System-Definition
 

--- a/ki-vo-ai-act-pruefer/skills/entscheidungsbaum-ki-vo-gesamt-workflow/SKILL.md
+++ b/ki-vo-ai-act-pruefer/skills/entscheidungsbaum-ki-vo-gesamt-workflow/SKILL.md
@@ -115,7 +115,7 @@ Vor Beginn des Entscheidungsbaums: kurze Situationserfassung.
 | Antwort | Nächster Schritt |
 |---|---|
 | **JA** — Anhang-III-Bereich zutreffend | → Frage 7 (Rückausnahme?) |
-| **NEIN** — Kein Anhang-III-Bereich | → Frage 8 (begrenztes Risiko?) |
+| **NEIN** — Kein Anhang-III-Bereich | → Frage 8 (begrenztes Risiko?) und parallel `nicht-hochrisiko-bestaetigt-end-to-end-roadmap` zur Dokumentation |
 
 ---
 
@@ -127,8 +127,8 @@ Vor Beginn des Entscheidungsbaums: kurze Situationserfassung.
 
 | Antwort | Nächster Schritt |
 |---|---|
-| **JA** — Rückausnahme greift | → Kein Hochrisiko. Weiter zu Frage 8 (begrenztes Risiko?). Dokumentationspflicht beachten. |
-| **NEIN** — Rückausnahme greift nicht | → **Hochrisiko bestätigt.** Weiter zu Fragen 9-10 und Pflichtenkatalog: Anbieter → Art. 9-15, 43-49; Betreiber → Art. 26, 27 KI-VO |
+| **JA** — Rückausnahme greift | → **Kein Hochrisiko.** → `nicht-hochrisiko-bestaetigt-end-to-end-roadmap` (drei mögliche Wege und Restpflichten). Dokumentationspflicht Art. 6 Abs. 4 KI-VO beachten. Weiter zu Frage 8. |
+| **NEIN** — Rückausnahme greift nicht | → **Hochrisiko bestätigt.** → `hochrisiko-bestaetigt-end-to-end-roadmap` (zwölf-Schritte-Roadmap von Risikomanagement bis CE und EU-DB-Registrierung). Parallel: Frage 9-10 und Pflichten Anbieter Art. 9-15, 43-49; Betreiber Art. 26, 27 KI-VO |
 
 ---
 

--- a/ki-vo-ai-act-pruefer/skills/hochrisiko-bestaetigt-end-to-end-roadmap/SKILL.md
+++ b/ki-vo-ai-act-pruefer/skills/hochrisiko-bestaetigt-end-to-end-roadmap/SKILL.md
@@ -1,0 +1,341 @@
+---
+name: hochrisiko-bestaetigt-end-to-end-roadmap
+description: "Hochrisiko-KI bestaetigt: vollstaendige End-to-End-Roadmap fuer Anbieter und Betreiber. Zwoelf Schritte von Risikomanagement bis CE-Kennzeichnung EU-Datenbank-Registrierung und Marktbeobachtung. Aufwand Akteure Fristen Kosten realistisch eingeordnet. So schlimm ist es halt auch nicht."
+---
+
+# Hochrisiko-KI bestätigt — die End-to-End-Roadmap
+
+## Zweck
+
+Sie haben festgestellt: das System ist Hochrisiko nach Art. 6 Abs. 1 oder Abs. 2 i.V.m. Anhang I/III KI-VO. Die Rückausnahme nach Art. 6 Abs. 3 KI-VO greift nicht. **Was jetzt?**
+
+Dieser Skill liefert den vollständigen Mandanten-Workflow von "Hochrisiko-Diagnose" bis "Marktreife mit CE-Kennzeichnung". Ziel ist Entdramatisierung: jeder Schritt ist mechanisch abarbeitbar.
+
+---
+
+## PFLICHT-DISCLAIMER
+
+**Keine Rechtsberatung. Mechanischer Workflow.** Die konkrete Umsetzung erfordert produkt-/branchen-spezifische Detailprüfung durch Fachpersonal (interne Compliance, externe Beratung, Konformitätsbewertungsstelle).
+
+---
+
+## Vorbedingung — wer macht was?
+
+| Akteur | Hauptpflichten | Roadmap relevant? |
+|---|---|---|
+| **Anbieter** (Art. 3 Nr. 3) | Art. 9-15, 16-21, 43-49 KI-VO | Alle 12 Schritte |
+| **Betreiber** (Art. 3 Nr. 4) | Art. 26-27 KI-VO | Schritt 11-12 + Folgenabschätzung |
+| **Einführer** (Art. 3 Nr. 6) | Art. 23 KI-VO | Schritt 7-9 (Verifikation) |
+| **Händler** (Art. 3 Nr. 7) | Art. 24 KI-VO | Schritt 10 (Verifikation vor Vertrieb) |
+| **Bevollmächtigter** (Art. 3 Nr. 5) | Art. 22 KI-VO | Schritt 1-12 stellvertretend |
+
+→ Rollenzuordnung vorher klären über `rolle-anbieter-pruefen-art-3-nr-3` bzw. `rolle-betreiber-pruefen-art-3-nr-4`.
+
+---
+
+## Die zwölf Schritte für Anbieter
+
+### Schritt 1 — Risikomanagementsystem aufsetzen (Art. 9 KI-VO)
+
+**Was:** kontinuierlicher iterativer Prozess über den gesamten Lebenszyklus.
+
+**Mindestelemente:**
+- Identifikation und Analyse bekannter und vernünftig vorhersehbarer Risiken
+- Abschätzung möglicher Risiken bei bestimmungsgemäßer Verwendung und bei vernünftigerweise vorhersehbarer Fehlanwendung
+- Bewertung anderer Risiken aus Post-Market-Daten
+- geeignete und gezielte Risikomanagementmaßnahmen
+
+**Output:** dokumentiertes RMS, Eingang in technische Dokumentation Anhang IV.
+
+→ Detail-Skill: `hochrisiko-risikomanagementsystem-art-9`
+
+---
+
+### Schritt 2 — Daten-Governance und Trainingsdaten-Qualität (Art. 10 KI-VO)
+
+**Was:** Trainings-, Validierungs- und Testdaten müssen Qualitätskriterien erfüllen.
+
+**Mindestelemente:**
+- Datenerhebungsverfahren dokumentiert
+- relevante Datenaufbereitung (Annotation, Labelling, Bereinigung, Aktualisierung, Anreicherung, Aggregation)
+- Untersuchung auf mögliche Verzerrungen, die zu Diskriminierung führen
+- Datensätze relevant, hinreichend repräsentativ, fehlerfrei, vollständig
+- Berücksichtigung geographischer, kontextueller, verhaltensbezogener und funktionaler Besonderheiten
+
+**Output:** Daten-Governance-Dokumentation, Bias-Bewertung.
+
+→ Detail-Skill: `hochrisiko-datenqualitaet-und-data-governance-art-10`
+
+---
+
+### Schritt 3 — Technische Dokumentation erstellen (Art. 11, Anhang IV KI-VO)
+
+**Was:** vor Inverkehrbringen vollständig erstellt, aktuell gehalten.
+
+**Inhalte (Anhang IV) — neun Hauptblöcke:**
+1. Allgemeine Beschreibung des KI-Systems
+2. Detaillierte Beschreibung der Elemente und Entwicklung
+3. Detaillierte Informationen zur Überwachung, Funktionsweise und Kontrolle
+4. Beschreibung der Eignung der Leistungskennzahlen
+5. Detaillierte Beschreibung des Risikomanagementsystems
+6. Beschreibung relevanter Änderungen
+7. Liste der harmonisierten Normen
+8. EU-Konformitätserklärung-Kopie
+9. Detaillierte Beschreibung des Systems zur Bewertung der Leistung nach Inverkehrbringen
+
+**Output:** Anhang-IV-Doku, mindestens zehn Jahre aufbewahren.
+
+→ Detail-Skill: `hochrisiko-technische-dokumentation-art-11-und-anhang-iv`
+
+---
+
+### Schritt 4 — Aufzeichnungspflichten / Logging einrichten (Art. 12 KI-VO)
+
+**Was:** automatische Aufzeichnung von Ereignissen während des Betriebs.
+
+**Mindest-Loggings:**
+- Zeitpunkt der Verwendung
+- Referenzdatenbank, gegen die Input-Daten geprüft
+- Input-Daten, die zu einem Treffer führten
+- Identifizierung beteiligter natürlicher Personen bei Ergebnisverifikation
+
+**Aufbewahrung:** angemessene Dauer, mindestens sechs Monate, sofern Unionsrecht oder nationales Recht nicht längere Dauer vorschreibt.
+
+→ Detail-Skill: `hochrisiko-aufzeichnungspflichten-logging-art-12`
+
+---
+
+### Schritt 5 — Transparenz und Informationen für Betreiber (Art. 13 KI-VO)
+
+**Was:** Gebrauchsanweisung mit präzisen, vollständigen, korrekten Informationen.
+
+**Pflichtinhalte:**
+- Identität und Kontaktdaten des Anbieters
+- Merkmale, Fähigkeiten und Leistungsgrenzen
+- ggf. bekannte oder vernünftig vorhersehbare Umstände, die zu Risiken führen können
+- ggf. technische Fähigkeiten und Kennwerte
+- Leistung in Bezug auf spezifische Personen oder Personengruppen
+- Anforderungen an Eingabedaten
+- ggf. Informationen zur Datenverarbeitung durch das System
+
+→ Detail-Skill: `hochrisiko-transparenz-und-informationen-fuer-betreiber-art-13`
+
+---
+
+### Schritt 6 — Menschliche Aufsicht ermöglichen (Art. 14 KI-VO)
+
+**Was:** Hochrisiko-KI muss so konzipiert sein, dass natürliche Personen wirksam beaufsichtigen können.
+
+**Befähigungen, die der Mensch haben muss:**
+- die Fähigkeiten und Grenzen des Systems vollständig verstehen
+- die Tendenz zum Automatisierungsbias kennen und einkalkulieren
+- die Ausgaben des Systems korrekt interpretieren
+- die Verwendung des Systems ablehnen, dessen Verwendung übergehen, rückgängig machen
+- in den Betrieb eingreifen oder den Betrieb durch Stopp-Taste unterbrechen
+
+**Bei biometrischer Fernidentifizierung:** Vier-Augen-Prinzip nach Art. 14 Abs. 5 KI-VO.
+
+→ Detail-Skill: `hochrisiko-menschliche-aufsicht-art-14`
+
+---
+
+### Schritt 7 — Genauigkeit, Robustheit, Cybersicherheit (Art. 15 KI-VO)
+
+**Was:** angemessene Genauigkeit, Robustheit und Cybersicherheit über den gesamten Lebenszyklus.
+
+**Pflichten:**
+- Genauigkeitsgrade und einschlägige Genauigkeitsmetriken in Gebrauchsanweisung
+- Robustheit gegen Fehler, Störungen, Inkonsistenzen
+- Resilienz gegen Versuche unberechtigter Dritter, Verwendung zu ändern (z.B. durch Ausnutzung von Schwachstellen)
+- bei lernfähigen Systemen: Schutz gegen verzerrte Ausgaben (Feedback Loops) durch geeignete Maßnahmen
+- Anfälligkeit gegen "Data Poisoning", "Model Poisoning", "Model Evasion", "Adversarial Examples", "Confidentiality Attacks" adressieren
+
+→ Detail-Skill: `hochrisiko-genauigkeit-robustheit-cybersicherheit-art-15`
+
+---
+
+### Schritt 8 — Qualitätsmanagementsystem (Art. 17 KI-VO)
+
+**Was:** dokumentiertes QMS mit schriftlichen Vorschriften, Verfahren und Anweisungen.
+
+**Mindestelemente (Art. 17 Abs. 1 KI-VO):**
+- Strategie für die Einhaltung der Regulierung einschließlich Konformitätsbewertungsverfahren
+- Verfahren für Design, Designkontrolle und Designverifikation
+- Verfahren für Entwicklung, Qualitätskontrolle und Qualitätssicherung
+- Untersuchung, Test- und Validierungsverfahren vor, während und nach Entwicklung
+- anwendbare technische Spezifikationen einschließlich Normen
+- Systeme und Verfahren für Datenverwaltung
+- Risikomanagementsystem nach Art. 9
+- Aufstellung und Umsetzung Post-Market-Monitoring-System nach Art. 72
+- Meldeverfahren für schwerwiegende Vorfälle nach Art. 73
+- Kommunikation mit zuständigen Behörden, notifizierten Stellen, Kunden
+- Aufzeichnungssysteme und -verfahren
+- Ressourcenmanagement einschließlich Versorgungssicherheit
+- Rechenschaftsrahmen mit klaren Verantwortlichkeiten
+
+---
+
+### Schritt 9 — Konformitätsbewertungsverfahren wählen (Art. 43 KI-VO)
+
+**Was:** Vor Inverkehrbringen / Inbetriebnahme nachweisen, dass alle Anforderungen aus Art. 8-15 KI-VO erfüllt sind.
+
+**Verfahrenswahl je nach Systemart:**
+
+| Konstellation | Verfahren | Notifizierte Stelle? |
+|---|---|---|
+| Anhang-III-Hochrisiko (außer biometrisch) | Anhang VI — interne Kontrolle | nein |
+| Anhang-III-Bereich 1 (biometrische Identifizierung) ohne anwendbare Norm | Anhang VII — Bewertung durch notifizierte Stelle | ja |
+| Anhang-III-Bereich 1 mit anwendbarer Norm vollständig befolgt | Anhang VI — interne Kontrolle | nein, aber Norm verbindlich |
+| Anhang-I-Hochrisiko (Sicherheitsbauteil) | Verfahren des einschlägigen Sektor-Rechtsakts (z.B. Medizinprodukte: MDR-Verfahren mit KI-VO-Integration) | nach Sektor-Recht |
+
+**Output:** EU-Konformitätserklärung nach Anhang V.
+
+→ Detail-Skills: `hochrisiko-konformitaetsbewertung-art-43-bis-49`, `output-konformitaetserklaerung-eu-anhang-v`, `code-of-practice-und-harmonisierte-normen`
+
+---
+
+### Schritt 10 — CE-Kennzeichnung anbringen (Art. 48 KI-VO)
+
+**Was:** sichtbar, leserlich, dauerhaft.
+
+**Erforderlich:**
+- digitale CE-Kennzeichnung möglich, wenn nicht über physisches Produkt zugänglich
+- Identifikationsnummer der notifizierten Stelle hinzufügen, wenn an Konformitätsbewertung beteiligt
+- in Gebrauchsanweisung und Begleitdokumentation
+
+---
+
+### Schritt 11 — EU-Datenbank-Registrierung (Art. 49, 71 KI-VO)
+
+**Was:** **vor** Inverkehrbringen / Inbetriebnahme in EU-Datenbank registrieren.
+
+**Daten:**
+- Identität, Kontaktdaten Anbieter (ggf. Bevollmächtigter)
+- Handelsname und etwaige weitere eindeutige Kennung des KI-Systems
+- Anhang-III-Bereich
+- Status der Konformitätsbewertung
+- Kopie der EU-Konformitätserklärung
+- elektronische Gebrauchsanweisung (außer Strafverfolgung/Migration)
+- URL für zusätzliche Informationen
+
+**Betreiber öffentlicher Stellen:** ebenfalls vor Einsatz registrierungspflichtig (Art. 49 Abs. 3 KI-VO).
+
+→ Detail-Skill: `eu-datenbank-registrierung-art-49-und-71`
+
+---
+
+### Schritt 12 — Marktbeobachtung und Vorfallsmeldung (Art. 72-79 KI-VO)
+
+**Was:** Post-Market-Monitoring-System aktiv betreiben.
+
+**Pflichten:**
+- aktive systematische Sammlung relevanter Daten zur Leistung über Lebenszyklus
+- Bewertung kontinuierlicher Einhaltung der Anforderungen aus Art. 8-15
+- Plan für Post-Market-Monitoring (Anhang VIII)
+- Meldung schwerwiegender Vorfälle binnen fünfzehn Tagen an Marktaufsichtsbehörde (Art. 73)
+- bei Tod: binnen zehn Tagen; bei groß angelegtem Verstoß: binnen zwei Tagen
+- Kooperation mit Marktaufsichtsbehörden
+- Korrekturmaßnahmen bei Nichtkonformität (Rückruf, Rücknahme, Nachbesserung)
+
+→ Detail-Skill: `marktueberwachung-meldung-vorfaelle-art-72-bis-79`
+
+---
+
+## Ergänzungs-Workflow für Betreiber
+
+Wer das System **einsetzt** (Art. 3 Nr. 4 KI-VO), durchläuft einen kürzeren Workflow:
+
+### Betreiber-Schritt 1 — Einsatzbedingungen prüfen (Art. 26 KI-VO)
+
+- Verwendung gemäß Gebrauchsanweisung
+- Sicherstellung menschlicher Aufsicht (geschulte, befugte Personen)
+- Eingabedaten relevant und hinreichend repräsentativ
+- Betriebsüberwachung mit Information des Anbieters bei Auffälligkeiten
+- Logging nach Art. 12 für eigene Aufzeichnungen
+- Information natürlicher Personen, die Hochrisiko-KI ausgesetzt sind
+- bei Beschäftigten: Information vor Inbetriebnahme
+
+### Betreiber-Schritt 2 — Folgenabschätzung Grundrechte (Art. 27 KI-VO)
+
+Pflicht für **öffentliche Stellen** und einige private Betreiber (z.B. Banken bei Kreditwürdigkeit, Versicherer bei Lebens-/Krankenversicherung):
+
+- Beschreibung Prozesse, in denen Hochrisiko-KI eingesetzt wird
+- Beschreibung Einsatzzeitraum und -häufigkeit
+- Kategorien betroffener Personen
+- Risiken für Grundrechte
+- Beschreibung Aufsichtsmaßnahmen
+- Maßnahmen bei Risikoeintritt
+
+→ Detail-Skill: `output-betreiber-checkliste-und-folgenabschaetzung`
+
+---
+
+## Realistische Aufwands-Einordnung
+
+| Schritt | typischer Zeitaufwand kleine/mittlere Anbieter | typischer Zeitaufwand bei vorhandenem ISO-9001/27001/14971 |
+|---|---|---|
+| RMS aufsetzen | 4-8 Wochen | 2-4 Wochen |
+| Daten-Governance | 6-12 Wochen | 3-6 Wochen |
+| Technische Dokumentation | 8-16 Wochen | 4-8 Wochen |
+| Logging | 2-4 Wochen | 1-2 Wochen |
+| Transparenz/Gebrauchsanweisung | 2-4 Wochen | 1-2 Wochen |
+| Menschliche Aufsicht | 2-4 Wochen | 1-2 Wochen |
+| Genauigkeit/Robustheit | 6-12 Wochen | 3-6 Wochen |
+| QMS | 8-16 Wochen | bereits vorhanden, nur ergänzen |
+| Konformitätsbewertung | 4-8 Wochen interne / 12-26 Wochen notifizierte Stelle | wie links |
+| CE und EU-DB | 1-2 Wochen | 1 Woche |
+| Marktbeobachtung-Setup | 4-8 Wochen | 2-4 Wochen |
+
+**Hinweis:** Übergangsfristen beachten — Hochrisiko Anhang III: ab 2.8.2026 anwendbar; Hochrisiko Anhang I (Sicherheitsbauteile): ab 2.8.2027 anwendbar. → `zeitlicher-geltungsbereich-uebergangsfristen`.
+
+---
+
+## Beteiligte Akteure / Wo melde ich was?
+
+| Akteur | Rolle | Wann kontaktieren? |
+|---|---|---|
+| **Notifizierte Stelle** | externe Konformitätsbewertung | bei Anhang VII, biometrischer Fernidentifizierung, sektorspezifischen Vorgaben |
+| **Nationale Marktaufsichtsbehörde** | Aufsicht, Vorfallsmeldung | bei schwerwiegenden Vorfällen (Art. 73), Anfragen, Inspektionen |
+| **Notifizierungsbehörde** | Aufsicht über notifizierte Stellen | indirekt relevant |
+| **EU-KI-Büro** (AI Office, Kommission GD CONNECT) | GPAI-Modelle, Code of Practice | wenn auch GPAI-Anbieter |
+| **EU-KI-Datenbank** | Registrierung Hochrisiko-Systeme | vor Inverkehrbringen |
+| **EDPB / nationale DSchB** | DSGVO-Schnittstelle | bei personenbezogenen Daten |
+| **Sektor-Regulatoren** (BaFin, BNetzA, BfArM, ...) | sektorale Aufsicht | je nach Anwendungsbereich |
+
+---
+
+## Mini-Checkliste vor Markteintritt
+
+- [ ] Risikomanagementsystem dokumentiert und auf aktuellem Stand
+- [ ] Daten-Governance abgeschlossen, Bias-Bewertung vorhanden
+- [ ] Technische Dokumentation Anhang IV vollständig
+- [ ] Logging aktiv, Speicherdauer eingestellt
+- [ ] Gebrauchsanweisung vollständig nach Art. 13
+- [ ] Menschliche Aufsicht implementiert und beschrieben
+- [ ] Genauigkeitsmetriken dokumentiert, Robustheitstests durchgeführt
+- [ ] Cybersicherheitskonzept vorhanden
+- [ ] QMS aufgesetzt und dokumentiert
+- [ ] Konformitätsbewertungsverfahren durchlaufen
+- [ ] EU-Konformitätserklärung Anhang V erstellt
+- [ ] CE-Kennzeichnung angebracht
+- [ ] EU-Datenbank-Registrierung erfolgt
+- [ ] Post-Market-Monitoring-Plan aktiv
+- [ ] Vorfalls-Meldesystem etabliert
+- [ ] interne Verantwortlichkeiten zugewiesen
+- [ ] Mitarbeiter geschult (KI-Kompetenz Art. 4 KI-VO)
+
+→ Output-Skill: `output-pruefdokument-ki-vo-mit-warnhinweisen`
+
+---
+
+## Querverweise
+
+- `entscheidungsbaum-ki-vo-gesamt-workflow` — Master-Workflow vorgelagert
+- `nicht-hochrisiko-bestaetigt-end-to-end-roadmap` — alternative Pfade
+- `rueckausnahme-art-6-abs-3` — falls Diagnose noch unsicher
+- `sanktionen-art-99-bis-101` — was passiert, wenn nichts unternommen wird
+- `mandatsabbruch-empfehlung-komplexe-faelle` — wenn intern nicht stemmbar
+
+---
+
+Hinweis: Keine Rechtsberatung. Mechanische Roadmap. Konkrete Umsetzung erfordert produkt-/branchen-spezifische Detailprüfung.

--- a/ki-vo-ai-act-pruefer/skills/nicht-hochrisiko-bestaetigt-end-to-end-roadmap/SKILL.md
+++ b/ki-vo-ai-act-pruefer/skills/nicht-hochrisiko-bestaetigt-end-to-end-roadmap/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: nicht-hochrisiko-bestaetigt-end-to-end-roadmap
+description: "Kein Hochrisiko bestaetigt: drei moegliche Pfade Anhang I/III nicht zutreffend Rueckausnahme Art. 6 Abs. 3 KI-VO greift oder verbotene Praktik geprueft und ausgeschlossen. Was bleibt an Pflichten Transparenz Art. 50 GPAI Sanktionen KI-Kompetenz Art. 4. Dokumentation der Negativ-Diagnose."
+---
+
+# Kein Hochrisiko bestätigt — die End-to-End-Roadmap
+
+## Zweck
+
+Sie haben die Prüfung durchlaufen und das Ergebnis ist: **kein Hochrisiko**. Das ist auch ein Ergebnis — und es will dokumentiert sein. Dieser Skill führt durch die drei Wege, auf denen man dort hin kommt, und zeigt, welche Restpflichten dennoch zu beachten sind.
+
+---
+
+## PFLICHT-DISCLAIMER
+
+**Keine Rechtsberatung. Mechanischer Workflow.** Die Negativ-Diagnose ist nur so belastbar wie die zugrunde liegenden Tatsachenfeststellungen.
+
+---
+
+## Die drei Wege zum "Kein Hochrisiko"
+
+### Weg A — Nie ein Anhang-I- oder Anhang-III-Bereich
+
+**Diagnose:** das System ist kein Sicherheitsbauteil eines in Anhang I genannten Produkts (Art. 6 Abs. 1 KI-VO) UND fällt nicht in einen der acht Anhang-III-Bereiche (Art. 6 Abs. 2 KI-VO).
+
+**Anhang-III-Bereiche zur Erinnerung:**
+1. biometrische Systeme (Identifizierung, Kategorisierung, Emotionserkennung)
+2. kritische Infrastruktur (Verkehr, Wasser, Gas, Wärme, Strom, kritische digitale Infrastruktur)
+3. allgemeine und berufliche Bildung (Zugang, Bewertung, Verhalten)
+4. Beschäftigung, Personalmanagement, Selbständigkeit (Personalentscheidungen, Aufgabenzuteilung, Leistungsüberwachung)
+5. Zugang zu wesentlichen privaten und öffentlichen Diensten (Sozialleistungen, Bonität, Risikobewertung Lebens-/Krankenversicherung, Notruf-Triage)
+6. Strafverfolgung (Risikobewertung, Lügendetektor, Beweisbewertung, Profiling, Vorhersagen)
+7. Migration, Asyl, Grenzkontrolle
+8. Justiz, demokratische Prozesse
+
+**Was tun?**
+- → Skill: `hochrisiko-zuordnung-art-6-und-anhang-i-iii` (Negativ-Prüfung dokumentieren)
+- → Skill: `hochrisiko-art-6-abs-2-anhang-iii` für jeden der acht Bereiche begründen, warum er nicht greift
+- → Skill: `hochrisiko-art-6-abs-1-sicherheitsbauteil` für Anhang-I-Negativ-Begründung
+
+**Ergebnis:** Keine Konformitätsbewertung, keine CE-Kennzeichnung, keine EU-DB-Registrierung als Hochrisiko-System.
+
+---
+
+### Weg B — Rückausnahme nach Art. 6 Abs. 3 KI-VO greift
+
+**Diagnose:** das System fällt zwar in einen Anhang-III-Bereich, erfüllt aber eine der vier Rückausnahmen UND **kein Profiling natürlicher Personen** liegt vor.
+
+**Die vier Rückausnahmen (Art. 6 Abs. 3 KI-VO):**
+
+| Nr. | Tatbestand | typische Beispiele |
+|---|---|---|
+| (a) | rein vorbereitende Aufgabe einer Bewertung | Dokumentensortierung, Formatprüfung |
+| (b) | enge prozedurale Aufgabe | Datenextraktion aus strukturiertem Formular |
+| (c) | Verbesserung des Ergebnisses einer zuvor abgeschlossenen menschlichen Tätigkeit | Stilkorrektur, Übersetzungsverbesserung |
+| (d) | Erkennung von Entscheidungsmustern, ohne menschliche Bewertung zu ersetzen | Anomalie-Markierung zur menschlichen Nachkontrolle |
+
+**Wichtige Schranke:** Rückausnahme **niemals** anwendbar, wenn das System **Profiling natürlicher Personen** durchführt (Art. 6 Abs. 3 letzter Satz KI-VO).
+
+**Was tun?**
+- → Skill: `rueckausnahme-art-6-abs-3` (Tatbestand prüfen und dokumentieren)
+- Begründung schriftlich festhalten, warum eine der vier Ausnahmen greift
+- Profiling-Negativ-Prüfung dokumentieren
+- **Dokumentationspflicht:** Anbieter, der sich auf Rückausnahme beruft, muss die Bewertung vor Inverkehrbringen dokumentieren und auf Anforderung der nationalen Marktaufsichtsbehörde vorlegen (Art. 6 Abs. 4 KI-VO).
+
+**Achtung:** Das Risiko der Fehleinordnung trägt der Anbieter. Bei Streit mit Marktaufsicht: Beweislast für Vorliegen der Rückausnahme.
+
+---
+
+### Weg C — KI-System liegt schon nicht vor / kein territorialer Anwendungsbereich
+
+**Diagnose:** das System ist konventionelle Software (Art. 3 Nr. 1 KI-VO nicht erfüllt) ODER der territoriale Anwendungsbereich (Art. 2 KI-VO) ist nicht eröffnet ODER ein sachlicher Ausschluss greift (Art. 2 Abs. 3-12 KI-VO).
+
+**Sachliche Ausschlüsse (Auswahl):**
+- militärische, Verteidigungs- und nationale Sicherheitszwecke (Art. 2 Abs. 3)
+- ausschließlich für wissenschaftliche Forschung (Art. 2 Abs. 6)
+- Freie und Open-Source-KI (eingeschränkt, Art. 2 Abs. 12)
+- rein persönliche Nutzung außerhalb beruflicher Tätigkeit (Art. 2 Abs. 10)
+
+**Was tun?**
+- → Skill: `liegt-ki-system-vor-art-3-nr-1` für Negativ-Begründung
+- → Skill: `territorialer-anwendungsbereich-art-2`
+- → Skill: `sachlicher-ausschluss-art-2-abs-3-bis-12`
+- → Skill: `abgrenzung-konventionelle-software-vs-ki-system` bei Grenzfällen
+
+**Ergebnis:** KI-VO-Anwendungsbereich nicht eröffnet. Andere Rechtsrahmen prüfen (DSGVO, Produkthaftung, Sektor-Recht).
+
+---
+
+## Restpflichten — auch ohne Hochrisiko
+
+**Auch wenn Hochrisiko verneint ist, bleiben Pflichten bestehen:**
+
+### 1. Verbot prüfen (Art. 5 KI-VO)
+
+Egal welche Risikoklasse: Verbotene Praktiken nach Art. 5 KI-VO sind **immer** verboten, unabhängig vom Hochrisiko-Status. → Skill: `verbotene-praktiken-art-5`.
+
+| Verbot | Tatbestand |
+|---|---|
+| (a) | unterschwellige Beeinflussung |
+| (b) | Ausnutzung Verletzlichkeit |
+| (c) | Social Scoring durch Behörden |
+| (d) | Vorhersage Straftaten allein auf Profiling |
+| (e) | ungezielte Bildersammlung für Gesichtsdatenbanken |
+| (f) | Emotionserkennung am Arbeitsplatz / in Bildung |
+| (g) | biometrische Kategorisierung sensibler Merkmale |
+| (h) | Echtzeit-biometrische Fernidentifizierung im öffentlichen Raum (mit engen Ausnahmen) |
+
+**Geltung seit:** 2.2.2025.
+
+### 2. Begrenztes Risiko / Transparenzpflichten (Art. 50 KI-VO)
+
+Auch ohne Hochrisiko: wenn das System unter Art. 50 fällt — Transparenz!
+
+| Konstellation | Pflicht |
+|---|---|
+| direkter Kontakt mit natürlichen Personen | Hinweis, dass mit KI interagiert wird (außer offenkundig) |
+| Erzeugung synthetischer Audio-, Bild-, Video-, Text-Inhalte | maschinenlesbare Markierung als KI-generiert |
+| Emotionserkennungs- oder biometrisches Kategorisierungssystem (soweit nicht verboten/Hochrisiko) | Information betroffener natürlicher Personen |
+| Deepfakes | Kenntlichmachung als KI-generiert/manipuliert |
+| KI-generierter Text zu Themen öffentlichen Interesses | Kenntlichmachung als KI-generiert (außer redaktionelle Verantwortung) |
+
+→ Skill: `begrenztes-risiko-art-50-transparenzpflichten`.
+
+### 3. GPAI-Pflichten (Art. 51-55 KI-VO)
+
+Wenn auch ein **GPAI-Modell** vorliegt: separate Pflichten unabhängig vom System-Risiko.
+
+→ Skill: `gpai-modelle-art-51-bis-55`, `gpai-vorliegen-art-3-nr-63`.
+
+### 4. KI-Kompetenz (Art. 4 KI-VO)
+
+**Pflicht für alle Anbieter und Betreiber**, unabhängig von Risikoklasse: ausreichendes Maß an KI-Kompetenz beim Personal, das mit Betrieb und Nutzung der KI-Systeme befasst ist.
+
+**Geltung seit:** 2.2.2025.
+
+### 5. Sektorale Vorgaben
+
+KI-VO ergänzt — ersetzt nicht — andere Rechtsrahmen:
+- DSGVO (Datenschutz)
+- Produkthaftung
+- DSA / DMA
+- sektorale Aufsicht (BaFin, BNetzA, BfArM, ...)
+- Urheberrecht (insb. § 44b UrhG für Training)
+- Arbeitsrecht (Betriebsrat, AGG)
+
+→ Skill: `verhaeltnis-zu-anderen-unionsrechtsakten`, `falsche-wiese-warnung-ki-vo`.
+
+---
+
+## Dokumentations-Checkliste der Negativ-Diagnose
+
+Auch ein "Kein Hochrisiko" will dokumentiert sein:
+
+- [ ] Sachverhalt aus Mandanten-Triage festgehalten
+- [ ] KI-System nach Art. 3 Nr. 1 (positiv oder negativ) festgestellt
+- [ ] territorialer Anwendungsbereich nach Art. 2 (positiv oder negativ) festgestellt
+- [ ] Rolle nach Art. 3 Nr. 3-7 zugeordnet
+- [ ] Verbotene Praktik nach Art. 5 ausgeschlossen
+- [ ] Anhang I (Sicherheitsbauteil) ausgeschlossen
+- [ ] alle acht Anhang-III-Bereiche einzeln ausgeschlossen ODER
+- [ ] Anhang-III-Bereich identifiziert + Rückausnahme Art. 6 Abs. 3 dokumentiert + Profiling-Negativ-Prüfung
+- [ ] Art. 50-Transparenzpflichten geprüft (positiv oder negativ)
+- [ ] GPAI-Modell-Frage geprüft (positiv oder negativ)
+- [ ] KI-Kompetenz Art. 4 organisiert
+- [ ] Querschnitt zu anderen Rechtsgebieten (DSGVO, sektoral) abgeklärt
+
+→ Output-Skill: `output-pruefdokument-ki-vo-mit-warnhinweisen`
+
+---
+
+## Wichtige Warnung — Statusverlust
+
+Negativ-Diagnose ist nicht "für immer". **Re-Evaluation bei:**
+
+- wesentlicher Änderung des Systems (Art. 43 Abs. 4 KI-VO)
+- Erweiterung der bestimmungsgemäßen Verwendung
+- neuer Use-Case in einem Anhang-III-Bereich
+- neue Daten / neuer Trainingslauf mit erweitertem Funktionsumfang
+- Änderung der Rechtslage (Durchführungsrechtsakte, Leitlinien Kommission, harmonisierte Normen)
+
+**Empfehlung:** jährliche Review der Negativ-Diagnose festschreiben.
+
+---
+
+## Querverweise
+
+- `entscheidungsbaum-ki-vo-gesamt-workflow` — Master-Workflow vorgelagert
+- `hochrisiko-bestaetigt-end-to-end-roadmap` — alternative Pfade
+- `risikoklassen-uebersicht-und-triage` — Klassenüberblick
+- `falsche-wiese-warnung-ki-vo` — was ist KI-VO nicht
+- `verbotene-praktiken-art-5` — gilt immer
+- `begrenztes-risiko-art-50-transparenzpflichten` — gilt oft auch ohne Hochrisiko
+- `gpai-vorliegen-art-3-nr-63` — Separate-Modellschiene
+- `sanktionen-art-99-bis-101` — was passiert bei Fehl-Diagnose
+
+---
+
+Hinweis: Keine Rechtsberatung. Mechanische Roadmap. Die Negativ-Diagnose ist nur so belastbar wie die zugrunde liegenden Tatsachenfeststellungen.


### PR DESCRIPTION
## ki-vo-ai-act-pruefer Ausbau

Bisher prueft das Plugin zwar die Hochrisiko-/Rueckausnahmen-Frage, aber der Mandant landet danach im Vakuum. Dieser PR macht beide Pfade vollstaendig sichtbar:

### Neuer Skill: hochrisiko-bestaetigt-end-to-end-roadmap

Zwoelf-Schritte-Workflow fuer Anbieter nach bestaetigter Hochrisiko-Diagnose:

1. Risikomanagementsystem Art. 9
2. Daten-Governance Art. 10
3. Technische Dokumentation Art. 11 + Anhang IV
4. Aufzeichnungspflichten/Logging Art. 12
5. Transparenz fuer Betreiber Art. 13
6. Menschliche Aufsicht Art. 14
7. Genauigkeit, Robustheit, Cybersicherheit Art. 15
8. Qualitaetsmanagementsystem Art. 17
9. Konformitaetsbewertungsverfahren Art. 43-49
10. CE-Kennzeichnung Art. 48
11. EU-Datenbank-Registrierung Art. 49, 71
12. Marktbeobachtung + Vorfallsmeldung Art. 72-79

Plus: Betreiber-Workflow Art. 26-27, realistische Aufwandsschaetzungen (mit/ohne vorhandenes ISO-QMS), Akteur-Tabelle (notifizierte Stelle, Marktaufsicht, AI Office, Sektor-Regulatoren), Markteintritts-Checkliste.

### Neuer Skill: nicht-hochrisiko-bestaetigt-end-to-end-roadmap

Drei Wege zur dokumentierten Negativ-Diagnose:

- Weg A: weder Anhang I noch Anhang III zutreffend
- Weg B: Rueckausnahme Art. 6 Abs. 3 KI-VO greift (vier Tatbestaende, Profiling-Schranke, Dokumentationspflicht Art. 6 Abs. 4)
- Weg C: kein KI-System / kein territorialer Anwendungsbereich / sachlicher Ausschluss Art. 2 Abs. 3-12

Restpflichten Art. 4 (KI-Kompetenz), Art. 5 (Verbot), Art. 50 (Transparenz), GPAI, sektoral. Re-Evaluation-Trigger.

### Sonstige Aenderungen

- Master-Workflow entscheidungsbaum-ki-vo-gesamt-workflow: Querverweise auf beide neuen Roadmaps an Fragen 6 und 7
- README: drei Diagnose-Pfade explizit, Skill-Zahl 42 -> 44, neue Einstiegs-Sektion
- plugin.json description: 285/300 Zeichen, Hochrisiko-Diagnose und Negativ-Diagnose ergaenzt

### Codex-Fix P1

- GeschGehG-Skill § 23 Abs. 2: Strafrahmen drei Jahre (vorher faelschlich zwei). Abs. 3 hat den Zwei-Jahres-Cap, nicht Abs. 2.