### PR TITLE
Codex P1+P2+P2 + neuer Forderungsanmeldung-Skill

### DIFF
--- a/insolvenzplan-starug-planwerkstatt/skills/ips-asset-deals-im-plan-grundstuecke-marken-kundendaten/SKILL.md
+++ b/insolvenzplan-starug-planwerkstatt/skills/ips-asset-deals-im-plan-grundstuecke-marken-kundendaten/SKILL.md
@@ -204,7 +204,7 @@ Mit rechtskräftiger Bestätigung des Insolvenzplans treten die im **gestaltende
 | Daten Minderjähriger | Art. 8 DSGVO: Einwilligung der Erziehungsberechtigten erforderlich |
 | Bank-/Zahlungsdaten | aufsichtsrechtliche Sonderregeln (BaFin), ggf. KWG/ZAG |
 | Patientendaten | § 203 StGB Schweigepflicht; OLG-Rspr. zur Praxisveräußerung (z.B. BGH IX ZR 80/14) |
-| Telekommunikationsdaten | § 3 TTDSG, § 9 TKG |
+| Telekommunikationsdaten | § 3 TDDDG, § 9 TKG |
 | Bestandskunden vs. Interessenten | Interessenten ohne abgeschlossenen Vertrag i.d.R. nur mit Einwilligung übertragbar |
 
 **Aufsichtsbehörden-Kommunikation:**
@@ -219,7 +219,9 @@ Mit rechtskräftiger Bestätigung des Insolvenzplans treten die im **gestaltende
 >
 > Damit das möglich ist, müssen wir Ihre Kundendaten (Name, Anschrift, E-Mail, Bestellhistorie, Vertragsdaten) an die [Erwerberin] übertragen. Bitte teilen Sie uns mit, ob Sie damit einverstanden sind.
 >
-> [☐] Ja, ich bin damit einverstanden, dass meine Daten an die [Erwerberin] übertragen werden. Als Dankeschön erhalte ich [Goodie X — z.B. 15-EUR-Willkommensgutschein].
+> Als Dankeschön für Ihre Rückmeldung erhalten Sie unabhängig von Ihrer Entscheidung [Goodie X — z.B. 15-EUR-Willkommensgutschein]. Der Gutschein ist nicht an Ihre Einwilligung gekoppelt (Art. 7 Abs. 4 DSGVO — Kopplungsverbot).
+>
+> [☐] Ja, ich bin damit einverstanden, dass meine Daten an die [Erwerberin] übertragen werden.
 >
 > [☐] Nein, ich möchte keine Übertragung. Meine Daten werden gelöscht, soweit keine gesetzlichen Aufbewahrungspflichten bestehen.
 >

--- a/insolvenzrecht/skills/forderungsanmeldung-glaeubiger-174-177-inso/SKILL.md
+++ b/insolvenzrecht/skills/forderungsanmeldung-glaeubiger-174-177-inso/SKILL.md
@@ -1,0 +1,350 @@
+---
+name: forderungsanmeldung-glaeubiger-174-177-inso
+description: "Glaeubiger meldet Forderung im Insolvenzverfahren an §§ 174-177 InsO: Fristen Form Anlagen Rang § 39 InsO Vorsatz § 174 Abs. 2 InsO nachtraegliche Anmeldung § 177 InsO Pruefungstermin § 176 Bestreiten § 178 Tabelle § 179 InsO. Mit Mustertexten und Fehlerkatalog."
+---
+
+# Forderungsanmeldung im Insolvenzverfahren — Gläubiger-Sicht (§§ 174-177 InsO)
+
+## Zweck
+
+Sobald das Insolvenzverfahren über das Vermögen des Schuldners eröffnet ist, müssen Insolvenzgläubiger ihre Forderungen beim Insolvenzverwalter zur Tabelle anmelden. Erst durch die Anmeldung wird die Forderung Teil der Verteilung. Dieser Skill führt Schritt für Schritt durch Form, Frist, Inhalt, Rangfragen, Besonderheiten (vorsätzliche unerlaubte Handlung, nachträgliche Anmeldung) und Reaktionsmöglichkeiten im Prüfungstermin.
+
+---
+
+## PFLICHT-DISCLAIMER
+
+**Keine Rechtsberatung. Mechanischer Workflow.** Konkrete Anmeldung ist im Einzelfall mit Fachanwalt für Insolvenzrecht abzustimmen.
+
+---
+
+## Teil A — Vor-Frage: Bin ich überhaupt Insolvenzgläubiger?
+
+Nicht jeder Anspruch gehört in die Tabelle. Erst klären, **welcher Forderungstyp** vorliegt:
+
+| Forderungstyp | Anmeldung zur Tabelle? | Rechtsgrundlage |
+|---|---|---|
+| **Insolvenzforderung** (Anspruch entstanden vor Eröffnung) | ja, §§ 174 ff. InsO | § 38 InsO |
+| **Nachrangige Insolvenzforderung** (Zinsen ab Eröffnung, Geldbußen, Schenkungsversprechen, Gesellschafterdarlehen) | ja, aber nur auf besondere Aufforderung des Gerichts | § 174 Abs. 3, § 39 InsO |
+| **Massegläubiger** (Anspruch aus der Verwaltung der Masse, vom Verwalter begründet) | **nein**, direkt vom Verwalter zu zahlen | §§ 53, 55 InsO |
+| **Aussonderungsberechtigter** (Eigentum am Gegenstand) | **nein**, Herausgabeanspruch direkt | § 47 InsO |
+| **Absonderungsberechtigter** (Sicherungsrecht an Massegegenstand) | nur Ausfall anmelden | §§ 49-52, 190-191 InsO |
+| **Aufrechnungsberechtigter** | keine Anmeldung erforderlich, Aufrechnung kraft Gesetzes | §§ 94-96 InsO |
+| **Unterhalts-/Familienforderungen** (laufender Unterhalt nach Eröffnung) | nein, kein Insolvenzanspruch | § 40 InsO |
+
+**Faustregel:** Anmeldung nur bei Insolvenzforderung (§ 38 InsO) und nachrangiger Insolvenzforderung (§ 39 InsO). Bei gemischter Forderung (z.B. Insolvenz- und Massebestandteil) getrennt geltend machen.
+
+→ Querverweis: `mandat-triage-insolvenzrecht`, `insolvenzrecht-kaltstart-interview`.
+
+---
+
+## Teil B — Anmeldefrist
+
+### B.1 Reguläre Anmeldefrist (§ 28 Abs. 1, § 174 Abs. 1 InsO)
+
+- Das **Insolvenzgericht** setzt im Eröffnungsbeschluss eine Frist zur Anmeldung.
+- Frist: regelmäßig zwischen **zwei Wochen und drei Monaten** ab Eröffnung.
+- Die Frist ist im Eröffnungsbeschluss konkret benannt und im Bundesanzeiger und auf `www.insolvenzbekanntmachungen.de` veröffentlicht.
+- Wirkung der Frist: keine **Ausschlussfrist** im engen Sinn, aber Anmeldungen danach lösen Mehrkosten aus (§ 177 InsO) und können vom Prüfungstermin ausgenommen werden.
+
+### B.2 Verspätete Anmeldung — § 177 InsO
+
+| Konstellation | Folge |
+|---|---|
+| Anmeldung nach Ablauf der Frist, vor Prüfungstermin | wird im Prüfungstermin geprüft, Mehrkosten Gläubiger |
+| Anmeldung nach Prüfungstermin | besonderer Prüfungstermin auf Antrag, Kosten gemäß § 177 Abs. 3 InsO |
+| Anmeldung nach Schlusstermin (§ 197 InsO) | grundsätzlich ausgeschlossen, nur noch über Nachtragsverteilung § 203 InsO |
+| Anmeldung nach Aufhebung des Verfahrens | nicht mehr möglich |
+
+**Faustregel:** Anmeldung so früh wie möglich, jedenfalls vor dem allgemeinen Prüfungstermin.
+
+### B.3 Fristbeginn und Fristberechnung
+
+- Fristbeginn: Tag nach Eröffnung (§ 187 BGB).
+- Fristberechnung nach §§ 187-193 BGB.
+- Auch elektronische Anmeldung möglich (§ 14 Abs. 4 InsO i.V.m. ERVV).
+
+---
+
+## Teil C — Form und Inhalt der Anmeldung
+
+### C.1 Formal — § 174 Abs. 1, 4 InsO
+
+- **schriftlich** oder elektronisch beim **Insolvenzverwalter** (nicht beim Gericht!)
+- in zweifacher Ausfertigung
+- Angabe des Aktenzeichens des Verfahrens
+- klare Forderungsbezeichnung
+
+### C.2 Pflichtangaben — § 174 Abs. 2 InsO
+
+| Angabe | Inhalt |
+|---|---|
+| Gläubiger | Name, Anschrift, Bankverbindung, Vertretung (falls Anwalt) |
+| Schuldner | Name, Anschrift, Insolvenz-Aktenzeichen |
+| Forderungssumme | Hauptforderung in Euro |
+| Forderungsgrund | Sachverhalt, der den Anspruch trägt — knapp aber identifizierbar |
+| Rechtsgrundlage | konkrete Anspruchsnormen (z.B. § 433 Abs. 2 BGB; § 280 Abs. 1 BGB; § 631 Abs. 1 BGB) |
+| Belege | Anlagen-Konvolut (Vertrag, Rechnung, Mahnungen, Vollstreckungstitel, Korrespondenz) |
+| Zinsen | nur bis zum Tag der Eröffnung (danach § 39 Abs. 1 Nr. 1 InsO nachrangig) |
+| Kosten | nur vor Eröffnung entstandene Kosten (Mahnkosten, Anwaltskosten, Gerichtskosten) |
+| Rang | wenn nachrangig: ausdrücklich § 39 InsO benennen |
+| Aussonderungs-/Absonderungsrechte | falls gleichzeitig bestehend, Hinweis zur Information |
+
+### C.3 Besondere Pflichtangabe — Vorsatz § 174 Abs. 2 InsO
+
+**Wichtig:** Wenn die Forderung aus einer **vorsätzlich begangenen unerlaubten Handlung** stammt (§ 823 ff. BGB i.V.m. § 826 BGB) oder aus einer vorsätzlich pflichtwidrig nicht gewährten gesetzlichen Unterhaltszahlung oder einer im Zusammenhang mit Steuerhinterziehung pflichtwidrig nicht gezahlten Steuer (§ 174 Abs. 2 InsO):
+
+- **ausdrücklich** unter Angabe des Tatbestands anmelden
+- Bedeutung: solche Forderungen sind von der **Restschuldbefreiung ausgeschlossen** (§ 302 Nr. 1 InsO) — Gläubiger kann nach Beendigung des Insolvenzverfahrens weiter vollstrecken
+- **wer ohne ausdrückliche Berufung auf den Vorsatz-Tatbestand anmeldet, verliert dieses Privileg** (Tabelle hat insoweit präjudizielle Wirkung — vgl. BGH IX ZR 178/03)
+
+Beispiele Vorsatz-Forderungen:
+- Schadensersatz aus Betrug (§ 263 StGB), Untreue (§ 266 StGB), Unterschlagung (§ 246 StGB)
+- vorsätzliche Körperverletzung (§ 223 StGB) mit Schmerzensgeld-Anspruch
+- Schadensersatz aus vorsätzlich falscher Bilanz (§ 331 HGB)
+- Schadensersatz aus Steuerhinterziehung des Geschäftsführers (§ 71 AO)
+- vorsätzlich nicht gezahlter Kindesunterhalt (§ 1601 BGB i.V.m. § 170 StGB)
+
+→ Querverweis: `vorsatzanfechtung-133-inso` (verwandte Norm).
+
+### C.4 Belege und Anlagen
+
+- in Kopie, geordnet, durchnummeriert
+- nicht im Original (Verlust-Risiko)
+- besonders wichtig: **rechtskräftige Titel** (Urteil, Vollstreckungsbescheid, Vergleich, notarielle Urkunde)
+- bei Mahnungen: Beweis des Zugangs sichern
+
+### C.5 Anmeldung mit Anwaltsvertretung
+
+- Verfahrensbevollmächtigter ist anzugeben
+- Vollmacht in Kopie beilegen
+- Zustellungen erfolgen an den Anwalt
+
+---
+
+## Teil D — Sondersituationen
+
+### D.1 Gesicherte Forderung mit Absonderungsrecht (§§ 49-52 InsO)
+
+Wer eine gesicherte Forderung hat (Pfand, Hypothek, Sicherungsübereignung), darf den **Ausfall** anmelden — also den Teil der Forderung, der nicht durch die Sicherheit gedeckt ist.
+
+**Vorgehen:**
+1. Anmeldung der vollen Forderung beim Verwalter mit Hinweis auf Sicherungsrecht
+2. Sicherheit verwerten (§§ 165-173 InsO)
+3. nach Verwertung Mitteilung an Verwalter, welcher Betrag durch Verwertung gedeckt ist
+4. **Ausfall** wird in der Tabelle festgestellt
+
+**Achtung:** Frist zur Mitteilung des Ausfalls in § 190 Abs. 2 InsO (drei Wochen nach Schlussverteilungsterminbestimmung).
+
+→ Querverweis (Plugin `insolvenzplan-starug-planwerkstatt`): `ips-sicherheiten-drittsicherheiten`.
+
+### D.2 Bedingte oder noch nicht fällige Forderung — § 191 InsO
+
+- bedingt: Anmeldung möglich, Berücksichtigung nur bei Eintritt
+- nicht fällig: Anmeldung in voller Höhe, Auswirkung auf Verteilung erst bei Fälligkeit
+- aufschiebend befristet: Anmeldung mit Hinweis auf Befristung
+
+### D.3 Wechselkursforderung / Auslandsforderung — § 45 InsO
+
+- Umrechnung in Euro **zum Stichtag der Eröffnung**
+- amtlicher Kurs der Europäischen Zentralbank
+- bei Forderung in Drittland-Währung: Beleg über Wechselkurs am Eröffnungstag
+
+### D.4 Solidargesamtgläubiger und Gesamtschuldner-Konstellationen — § 43 InsO
+
+- jeder Gläubiger meldet seine eigene Forderung an
+- bei Bürgschaft: Hauptgläubiger meldet, Bürge ggf. mit eigenem Regress-Anspruch nach Zahlung (§ 774 BGB)
+- bei Gesamtschuld auf Schuldnerseite: gegen jeden Gesamtschuldner gesondert anmelden, Doppel-Erlangung mindert (§ 422 BGB)
+
+### D.5 Arbeitnehmer-Forderungen
+
+- Arbeitnehmer mit Lohnansprüchen **vor** Eröffnung: Insolvenzgläubiger, aber **Insolvenzgeld** für die letzten drei Monate vor Eröffnung über die Bundesagentur für Arbeit (§ 165 SGB III)
+- Anmeldung nur, soweit Insolvenzgeld nicht greift oder darüber hinausgehend
+- → Querverweis: `insolvenzgeld-165-sgb-iii`.
+
+### D.6 Steuer- und Sozialversicherungsforderungen
+
+- Finanzamt und Sozialversicherungsträger melden eigenständig an
+- bei Geschäftsführer-Haftungsbescheiden: getrennt anmelden, ggf. mit Vorsatz-Hinweis (Steuerhinterziehung)
+
+### D.7 Forderungen aus Dauerschuldverhältnissen
+
+- Anteil bis Eröffnung: Insolvenzforderung
+- Anteil nach Eröffnung: Masseverbindlichkeit (§ 55 InsO), falls Verwalter wählt Erfüllung (§ 103 InsO), sonst Nichterfüllungsschaden als Insolvenzforderung (§ 103 Abs. 2 InsO)
+
+### D.8 Forderung gegen Gesellschafter aus Gesellschafterdarlehen
+
+- nachrangig (§ 39 Abs. 1 Nr. 5 InsO)
+- Anmeldung nur auf besondere Aufforderung des Gerichts
+- Achtung: bei Sanierungsdarlehen Privileg § 39 Abs. 4 InsO prüfen
+
+---
+
+## Teil E — Prüfungstermin (§§ 176-178 InsO)
+
+### E.1 Was passiert im Prüfungstermin
+
+- öffentliche Sitzung des Insolvenzgerichts
+- Verwalter prüft jede angemeldete Forderung nach Grund, Höhe und Rang
+- Schuldner kann jeder Forderung widersprechen
+- Insolvenzgläubiger können jeder Forderung widersprechen
+
+### E.2 Mögliche Ergebnisse
+
+| Status | Wirkung |
+|---|---|
+| **Festgestellt** (kein Widerspruch) | Forderung wirkt wie rechtskräftiges Urteil (§ 178 Abs. 3 InsO) |
+| **Bestritten Verwalter** | Gläubiger muss Klage erheben § 179 InsO |
+| **Bestritten Schuldner** | Forderung dennoch festgestellt, aber kein Vollstreckungstitel gegen Schuldner nach Verfahrensaufhebung (§ 201 InsO) |
+| **Bestritten Mit-Gläubiger** | Gläubiger muss Klage erheben § 179 InsO |
+| **Vorsatz-Charakter bestritten** | Klage auf Feststellung Vorsatz § 184 InsO |
+
+### E.3 Reaktion auf Bestreitung
+
+- Klage auf **Feststellung zur Tabelle** beim Prozessgericht (nicht Insolvenzgericht!)
+- Antragsfassung: "es wird festgestellt, dass die unter lfd. Nr. X zur Tabelle angemeldete Forderung in Höhe von ... Euro besteht"
+- Gerichtsstand: Sitz des Schuldners oder allgemeiner Gerichtsstand
+- Bei Vorsatz: separate Klage auf Feststellung des Vorsatz-Charakters § 184 InsO
+
+**Frist:** keine gesetzliche Klagefrist, aber Verzögerung führt zu Nicht-Berücksichtigung in Verteilung — daher zügig.
+
+→ Querverweis: `glaeubigerausschuss-mitwirkung` (falls Gläubiger im Ausschuss).
+
+---
+
+## Teil F — Nachträgliche Schritte
+
+### F.1 Nachtragsverteilung (§ 203 InsO)
+
+Wenn nach Schlusstermin (§ 197 InsO) noch Masse oder Forderungen auftauchen:
+- Antrag auf Nachtragsverteilung beim Gericht
+- nachträglich angemeldete Forderungen werden quotal befriedigt
+
+### F.2 Restschuldbefreiungsverfahren beachten
+
+- Schuldnerantrag auf Restschuldbefreiung läuft parallel
+- Vorsatz-Forderungen mit ausdrücklicher Anmeldung sind von Restschuldbefreiung ausgeschlossen (§ 302 Nr. 1 InsO)
+- Anfechtungsmöglichkeiten gegen Restschuldbefreiung (§§ 290, 296, 297 InsO) zeitlich beachten
+
+### F.3 Anfechtungsforderungen des Verwalters
+
+- separater Vorgang
+- führt bei Erfolg zu Massezufluss, der quotal verteilt wird
+- Gläubiger profitieren mittelbar
+
+→ Querverweis: `anfechtungsrechte-pruefen`, `vorsatzanfechtung-133-inso`.
+
+---
+
+## Teil G — Muster
+
+### G.1 Anmeldeschreiben (verkürzt)
+
+> **An den Insolvenzverwalter**
+> [Name und Adresse Verwalter]
+>
+> **Insolvenzverfahren über das Vermögen [Schuldner], AZ: [Aktenzeichen Insolvenzgericht]**
+>
+> **Forderungsanmeldung gemäß § 174 InsO**
+>
+> Sehr geehrte Damen und Herren,
+>
+> namens und in Vollmacht der [Gläubigerin], [Anschrift], melden wir zur Insolvenztabelle folgende Forderung an:
+>
+> **Hauptforderung:** [Betrag in Euro]
+> **Zinsen bis Eröffnung am [Datum]:** [Betrag] (auf Hauptforderung in Höhe von [Betrag] vom [Beginn] bis [Eröffnung] zu [Zinssatz] % p.a.)
+> **Vorgerichtliche Kosten:** [Betrag] (Mahnkosten, vorgerichtliche Anwaltskosten 1,3 RVG)
+> **Gerichtskosten Mahnverfahren:** [Betrag]
+> **Vollstreckungskosten:** [Betrag]
+>
+> **Gesamt:** [Summe]
+>
+> **Forderungsgrund:** [knappe Sachverhaltsdarstellung — z.B. "Kaufpreisanspruch aus Lieferung von Maschinenkomponenten gemäß Auftragsbestätigung Nr. 2025/0815 vom 14.3.2025, Rechnung Nr. 2025-0432 vom 28.3.2025, fällig zum 27.4.2025. Mahnung 15.5.2025; gerichtlicher Mahnbescheid vom 8.7.2025, AZ ...; Vollstreckungsbescheid vom 22.7.2025."]
+>
+> **Rechtsgrundlage:** § 433 Abs. 2 BGB; Zinsen § 286 Abs. 3 BGB i.V.m. § 288 Abs. 2 BGB; Kosten § 286 BGB.
+>
+> **Rang:** allgemeine Insolvenzforderung (§ 38 InsO).
+>
+> **Anlagenkonvolut** (Anlagen K1-K8): [Liste].
+>
+> **Bankverbindung für Verteilungen:** IBAN ..., BIC ...
+>
+> Mit freundlichen Grüßen
+> [Anwalt]
+
+### G.2 Anmeldeschreiben Vorsatz-Forderung (verkürzt)
+
+> [...]
+>
+> **Forderungsgrund:** Schadensersatzanspruch aus **vorsätzlich begangener unerlaubter Handlung** des Schuldners. Der Schuldner hat als Geschäftsführer der [...] GmbH im Zeitraum [...] vorsätzlich Gelder der Mandantin zweckwidrig auf ein eigenes Konto überwiesen (siehe rechtskräftiges Urteil LG ..., AZ ..., Anlage K1, sowie Strafurteil AG ..., AZ ..., Anlage K2 — Verurteilung wegen Untreue § 266 StGB).
+>
+> **Rechtsgrundlage:** §§ 826, 31 BGB; § 823 Abs. 2 BGB i.V.m. § 266 StGB.
+>
+> **Ausdrücklicher Hinweis nach § 174 Abs. 2 InsO:** Die Forderung resultiert aus einer **vorsätzlich begangenen unerlaubten Handlung**. Im Falle der Restschuldbefreiung des Schuldners ist die Forderung gemäß § 302 Nr. 1 InsO von der Restschuldbefreiung ausgenommen.
+>
+> **Rang:** § 38 InsO. [...]
+
+---
+
+## Teil H — Häufige Fehlerquellen (Checkliste)
+
+| Fehler | Folge | Abhilfe |
+|---|---|---|
+| Anmeldung beim Insolvenzgericht statt Verwalter | nicht fristwahrend | Verwalter-Adresse aus Eröffnungsbeschluss übernehmen |
+| Frist versäumt | Mehrkosten, Verzögerung | so früh wie möglich anmelden |
+| Vorsatz-Charakter nicht ausdrücklich benannt | Privileg § 302 Nr. 1 InsO verloren | im Anmeldeschreiben prominent unter eigener Überschrift hinweisen |
+| Zinsen über Eröffnung hinaus angemeldet | als nachrangig zurückgestuft | klar bis Eröffnungstag berechnen |
+| Anwaltskosten nach Eröffnung mit angemeldet | nachrangig | nur vor Eröffnung |
+| keine Belege beigelegt | bestritten im Prüfungstermin | Anlagenkonvolut sauber zusammenstellen |
+| Original-Vollstreckungstitel verschickt | Verlust-Risiko | nur Kopie, Original behalten |
+| keine Aussagen zu Sicherheiten | Doppel-Erlangung droht | Sicherheiten offenlegen und nur Ausfall geltend machen |
+| Auslandswährung nicht umgerechnet | Verzögerung | EZB-Kurs Eröffnungstag verwenden |
+| Gesellschafterdarlehen ohne Hinweis auf § 39 Abs. 4 angemeldet | Privileg-Verlust | Sanierungsprivileg prüfen |
+| Bestreitung nicht beachtet | Tabellen-Eintragung scheitert | Klage § 179 InsO innerhalb angemessener Frist |
+| Klage beim Insolvenzgericht eingereicht | unzuständig | Klage beim regulären Prozessgericht |
+| Bankverbindung vergessen | Verteilungen kommen nicht an | IBAN/BIC im Anmeldeschreiben |
+| Anmeldung ohne Aktenzeichen | Verwechslung | Aktenzeichen prominent im Briefkopf |
+
+---
+
+## Querverweise
+
+Innerhalb des `insolvenzrecht`-Plugins:
+
+- `mandat-triage-insolvenzrecht` — Eingangstriage
+- `insolvenzrecht-kaltstart-interview` — Sachverhaltsaufnahme
+- `anfechtungsrechte-pruefen` — Anfechtungsschiene
+- `vorsatzanfechtung-133-inso` — verwandte Norm
+- `glaeubigerantrag-pruefung` — Antragstellung des Gläubigers
+- `glaeubigerausschuss-mitwirkung` — Mitwirkung im Ausschuss
+- `insolvenzgeld-165-sgb-iii` — Arbeitnehmer-Sonderschiene
+- `uebertragende-sanierung-und-asset-deals` — Plan-/Verfahrenswahl
+
+Verwandte Plugins:
+
+- `insolvenzforderungsanmeldungspruefung` — Verwalter-Prüfung im Detail
+- `insolvenzverwaltung/iv-forderungsanmeldung-pruefung` — Verwalter-Workflow
+- `insolvenzverwaltung/iv-tabelle-pruefungstermin` — Tabellen-Mechanik
+
+---
+
+## Mini-Checkliste vor Versand der Anmeldung
+
+- [ ] Forderungstyp geklärt (Insolvenz § 38 / nachrangig § 39 / Masse § 53)
+- [ ] Anmeldefrist im Eröffnungsbeschluss notiert
+- [ ] Anmeldung an Verwalter (nicht Gericht!) adressiert
+- [ ] Hauptforderung, Zinsen bis Eröffnung, vorgerichtliche Kosten getrennt ausgewiesen
+- [ ] Rechtsgrundlage konkret benannt
+- [ ] Forderungsgrund knapp aber identifizierbar dargestellt
+- [ ] Bei Vorsatz: ausdrücklicher Hinweis nach § 174 Abs. 2 InsO mit Tatbestand
+- [ ] Anlagenkonvolut beigefügt und durchnummeriert
+- [ ] Sicherungsrechte offengelegt (Aussonderung/Absonderung)
+- [ ] Wechselkurs zum Eröffnungstag (falls Auslandswährung)
+- [ ] Vollmacht beigefügt
+- [ ] Bankverbindung angegeben
+- [ ] Zweifache Ausfertigung
+- [ ] Eingangsbestätigung erbitten
+- [ ] Termin Prüfungstermin notiert
+
+---
+
+Hinweis: Keine Rechtsberatung. Mechanische Strukturhilfe für Forderungsanmeldung im Insolvenzverfahren. Konkrete Anmeldung im Einzelfall mit Fachanwalt für Insolvenzrecht abstimmen.

--- a/insolvenzrecht/skills/uebertragende-sanierung-und-asset-deals/SKILL.md
+++ b/insolvenzrecht/skills/uebertragende-sanierung-und-asset-deals/SKILL.md
@@ -246,7 +246,7 @@ Die folgenden Klauseltypen lassen sich sowohl im Asset-Deal-Vertrag (Regelverfah
 | Daten Minderjähriger | Art. 8 DSGVO: Einwilligung der Erziehungsberechtigten erforderlich |
 | Bank-/Zahlungsdaten | aufsichtsrechtliche Sonderregeln (BaFin), ggf. KWG/ZAG |
 | Patientendaten | § 203 StGB Schweigepflicht; OLG-Rspr. zur Praxisveräußerung (z.B. BGH IX ZR 80/14) |
-| Telekommunikationsdaten | § 3 TTDSG, § 9 TKG |
+| Telekommunikationsdaten | § 3 TDDDG, § 9 TKG |
 | Bestandskunden vs. Interessenten | Interessenten ohne abgeschlossenen Vertrag i.d.R. nur mit Einwilligung übertragbar |
 
 **Aufsichtsbehörden-Kommunikation:**
@@ -261,7 +261,9 @@ Die folgenden Klauseltypen lassen sich sowohl im Asset-Deal-Vertrag (Regelverfah
 >
 > Damit das möglich ist, müssen wir Ihre Kundendaten (Name, Anschrift, E-Mail, Bestellhistorie, Vertragsdaten) an die [Erwerberin] übertragen. Bitte teilen Sie uns mit, ob Sie damit einverstanden sind.
 >
-> [☐] Ja, ich bin damit einverstanden, dass meine Daten an die [Erwerberin] übertragen werden. Als Dankeschön erhalte ich [Goodie X — z.B. 15-EUR-Willkommensgutschein].
+> Als Dankeschön für Ihre Rückmeldung erhalten Sie unabhängig von Ihrer Entscheidung [Goodie X — z.B. 15-EUR-Willkommensgutschein]. Der Gutschein ist nicht an Ihre Einwilligung gekoppelt (Art. 7 Abs. 4 DSGVO — Kopplungsverbot).
+>
+> [☐] Ja, ich bin damit einverstanden, dass meine Daten an die [Erwerberin] übertragen werden.
 >
 > [☐] Nein, ich möchte keine Übertragung. Meine Daten werden gelöscht, soweit keine gesetzlichen Aufbewahrungspflichten bestehen.
 >

--- a/ki-vo-ai-act-pruefer/skills/hochrisiko-bestaetigt-end-to-end-roadmap/SKILL.md
+++ b/ki-vo-ai-act-pruefer/skills/hochrisiko-bestaetigt-end-to-end-roadmap/SKILL.md
@@ -207,18 +207,28 @@ Dieser Skill liefert den vollständigen Mandanten-Workflow von "Hochrisiko-Diagn
 
 ### Schritt 11 — EU-Datenbank-Registrierung (Art. 49, 71 KI-VO)
 
-**Was:** **vor** Inverkehrbringen / Inbetriebnahme in EU-Datenbank registrieren.
+**Wer ist registrierungspflichtig?**
 
-**Daten:**
+| Konstellation | Pflicht zur EU-DB-Registrierung |
+|---|---|
+| Anbieter Hochrisiko **Anhang III** (außer Strafverfolgung/Migration/Asyl) | ja, Art. 49 Abs. 1 KI-VO |
+| Anbieter Hochrisiko **Anhang III** Strafverfolgung/Migration/Asyl | ja, aber gesonderter, nicht öffentlicher Teil der Datenbank (Art. 49 Abs. 4, Art. 71 Abs. 5 KI-VO) |
+| Anbieter Hochrisiko **Anhang I** (Sicherheitsbauteile) | **nein** — Konformität läuft über den sektoralen Rechtsakt (z.B. MDR, MaschinenVO); KI-VO-EU-Datenbank greift hier grundsätzlich nicht |
+| **Betreiber** als Behörde, EU-Organ oder im Auftrag öffentlicher Stelle | ja, vor Einsatz (Art. 49 Abs. 3 KI-VO) — gilt nur für Anhang-III-Systeme |
+| Anbieter, der sich auf Rückausnahme Art. 6 Abs. 3 beruft | gesonderte Registrierung der Selbsteinschätzung (Art. 49 Abs. 2 KI-VO) |
+
+**Faustregel:** Die EU-Datenbank nach Art. 71 KI-VO ist die **Anhang-III-Schiene**. Anbieter von Sicherheitsbauteilen nach Anhang I (MDR-Implantate, IVDR-Diagnostika, MaschinenVO-Komponenten etc.) erfüllen ihre Eintragungspflichten in den sektoralen Registern (EUDAMED, NANDO, etc.) und sind von Art. 49 KI-VO **nicht** erfasst.
+
+**Was wird registriert (Anhang VIII Abschnitt A KI-VO):**
 - Identität, Kontaktdaten Anbieter (ggf. Bevollmächtigter)
 - Handelsname und etwaige weitere eindeutige Kennung des KI-Systems
 - Anhang-III-Bereich
 - Status der Konformitätsbewertung
 - Kopie der EU-Konformitätserklärung
-- elektronische Gebrauchsanweisung (außer Strafverfolgung/Migration)
+- elektronische Gebrauchsanweisung (außer Strafverfolgung/Migration/Asyl)
 - URL für zusätzliche Informationen
 
-**Betreiber öffentlicher Stellen:** ebenfalls vor Einsatz registrierungspflichtig (Art. 49 Abs. 3 KI-VO).
+**Wann:** vor Inverkehrbringen / Inbetriebnahme.
 
 → Detail-Skill: `eu-datenbank-registrierung-art-49-und-71`
 
@@ -298,7 +308,7 @@ Pflicht für **öffentliche Stellen** und einige private Betreiber (z.B. Banken 
 | **Nationale Marktaufsichtsbehörde** | Aufsicht, Vorfallsmeldung | bei schwerwiegenden Vorfällen (Art. 73), Anfragen, Inspektionen |
 | **Notifizierungsbehörde** | Aufsicht über notifizierte Stellen | indirekt relevant |
 | **EU-KI-Büro** (AI Office, Kommission GD CONNECT) | GPAI-Modelle, Code of Practice | wenn auch GPAI-Anbieter |
-| **EU-KI-Datenbank** | Registrierung Hochrisiko-Systeme | vor Inverkehrbringen |
+| **EU-KI-Datenbank** (Art. 71 KI-VO) | Registrierung Hochrisiko-Systeme | vor Inverkehrbringen — Anhang III; bei Anhang I über sektorale Register (EUDAMED, NANDO etc.) |
 | **EDPB / nationale DSchB** | DSGVO-Schnittstelle | bei personenbezogenen Daten |
 | **Sektor-Regulatoren** (BaFin, BNetzA, BfArM, ...) | sektorale Aufsicht | je nach Anwendungsbereich |
 
@@ -318,7 +328,7 @@ Pflicht für **öffentliche Stellen** und einige private Betreiber (z.B. Banken 
 - [ ] Konformitätsbewertungsverfahren durchlaufen
 - [ ] EU-Konformitätserklärung Anhang V erstellt
 - [ ] CE-Kennzeichnung angebracht
-- [ ] EU-Datenbank-Registrierung erfolgt
+- [ ] EU-Datenbank-Registrierung erfolgt (nur Anhang III; bei Anhang I über sektoralen Rechtsakt)
 - [ ] Post-Market-Monitoring-Plan aktiv
 - [ ] Vorfalls-Meldesystem etabliert
 - [ ] interne Verantwortlichkeiten zugewiesen


### PR DESCRIPTION
## Codex-Befunde

**P1 — EU-DB-Registrierung praezisiert** (`ki-vo-ai-act-pruefer/skills/hochrisiko-bestaetigt-end-to-end-roadmap/SKILL.md`)
Schritt 11 EU-DB-Registrierung (Art. 49 i.V.m. Art. 71 KI-VO) gilt **nur fuer Anhang III**, nicht fuer Anhang I (sektorspezifische Sicherheitsbauteile wie MedizinprodukteVO, MaschinenVO, Aufzugsrichtlinie). Tabelle und Checkliste mit Akteur-Spalte ergaenzt.

**P2 — TTDSG → TDDDG**
Umbenennung 14.5.2024 nachgezogen in beiden Asset-Deal-Skills:
- `insolvenzplan-starug-planwerkstatt/skills/ips-asset-deals-im-plan-grundstuecke-marken-kundendaten/SKILL.md`
- `insolvenzrecht/skills/uebertragende-sanierung-und-asset-deals/SKILL.md`

Tabellenzeile Telekommunikationsdaten: `§ 3 TDDDG, § 9 TKG`.

**P2 — Opt-in-Muster Kopplungsverbot (Art. 7 Abs. 4 DSGVO)**
Goodie war an Einwilligung gekoppelt (nur Ja-Box bekam Gutschein). Umformuliert: Goodie wird jetzt **unabhaengig von der Entscheidung** gewaehrt, mit explizitem Hinweis aufs Kopplungsverbot. Beide Auswahlboxen (Ja/Nein) sind gleichgestellt. Spiegelfix in beiden Asset-Deal-Skills.

## Neuer Skill

`insolvenzrecht/skills/forderungsanmeldung-glaeubiger-174-177-inso/SKILL.md` (350 Z., Slug 43 chars, description 262)

- Teil A Forderungstypen-Triage (einfach / bevorrechtigt / nachrangig / aus- bzw. absonderungsberechtigt / Masseverbindlichkeit)
- Teil B Fristen § 174 + § 177 verspaetete Anmeldung
- Teil C Form/Inhalt mit Vorsatz § 174 Abs. 2 + § 302 Nr. 1 InsO Restschuldbefreiung
- Teil D Sondersituationen (Absonderung, bedingt, Wechselkurs § 45, Gesamtschuld § 43, Arbeitnehmer, Steuern, Dauerschuld, Gesellschafterdarlehen § 39 Abs. 4)
- Teil E Pruefungstermin §§ 176-179, Klage § 184 (Vorsatz-Feststellungsklage)
- Teil F Nachtragsverteilung § 203
- Teil G zwei Muster (einfache + Vorsatz-Anmeldung)
- Teil H 13-Punkte-Fehlerkatalog
- Querverweise zu `mandat-triage`, `anfechtungsrechte-und-vorsatzanfechtung`, `insolvenzforderungsanmeldungspruefung`-Plugin, `insolvenzverwaltung`-Plugin

## Validator

`node scripts/validate-plugin-structure.mjs` → 72 quote-description-Altlasten aus PR #101, **keine neuen Fehler**. Alle Frontmatter-Descriptions ohne `\d,\d`, alle Slug-Namen ≤64 chars.