### PR TITLE
release: v10.0.0 — 24 fa-Kommunikations-Skills (PR #108) + 5 Codex-Fixes + Versions-Bump

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,13 +13,13 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "aktenauszug-gerichtsverfahren",
       "source": "./aktenauszug-gerichtsverfahren",
       "description": "Strukturierter Aktenauszug fuer deutsche Gerichtsverfahren: Verfahrensidentifikation Einleitungssatz Verfahrenszusammenfassung Sachverhaltschronologie Verfahrensgeschichte tabellarische Gegenueberstellung der Parteivortraege Beweismittel und Rechtsargumente fuer schnelle Einarbeitung in Akten.",
-      "version": "9.0.0",
+      "version": "10.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -31,7 +31,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "arbeitsrecht",
@@ -40,7 +40,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "arbeitszeugnis-analyse",
@@ -49,7 +49,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "aussenwirtschaft-zoll-sanktionen",
@@ -58,7 +58,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "bav-strategie-konzern",
@@ -67,7 +67,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "bereicherungs-und-anfechtungsrecht-pruefer",
@@ -76,7 +76,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "berufsrecht-ki-vertragspruefung",
@@ -85,7 +85,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "betreuungsrecht",
@@ -94,7 +94,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "common-law-kompass",
@@ -103,7 +103,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "corporate-kanzlei",
@@ -112,7 +112,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "datenschutzrecht",
@@ -121,7 +121,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "einfache-leichte-sprache-jura",
@@ -130,7 +130,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "email-umformulierer-berufsrecht",
@@ -139,7 +139,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "energierecht",
@@ -148,7 +148,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "europarecht-kompass",
@@ -157,7 +157,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-agrarrecht",
@@ -166,7 +166,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-arbeitsrecht",
@@ -175,7 +175,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-bank-kapitalmarktrecht",
@@ -184,7 +184,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-bau-architektenrecht",
@@ -193,7 +193,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-erbrecht",
@@ -202,7 +202,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-familienrecht",
@@ -211,7 +211,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-gewerblicher-rechtsschutz",
@@ -220,7 +220,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-handels-gesellschaftsrecht",
@@ -229,7 +229,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-insolvenz-sanierungsrecht",
@@ -238,7 +238,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-internationales-wirtschaftsrecht",
@@ -247,7 +247,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-it-recht",
@@ -256,7 +256,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-medizinrecht",
@@ -265,7 +265,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-miet-wohnungseigentumsrecht",
@@ -274,7 +274,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-migrationsrecht",
@@ -283,7 +283,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-sozialrecht",
@@ -292,7 +292,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-sportrecht",
@@ -301,7 +301,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-strafrecht",
@@ -310,7 +310,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-transport-speditionsrecht",
@@ -319,7 +319,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-urheber-medienrecht",
@@ -328,7 +328,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-vergaberecht",
@@ -337,7 +337,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-verkehrsrecht",
@@ -346,7 +346,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-versicherungsrecht",
@@ -355,7 +355,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fachanwalt-verwaltungsrecht",
@@ -364,7 +364,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fluggastrechte",
@@ -373,7 +373,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "forderungsmanagement-klagewerkstatt",
@@ -382,7 +382,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "fortbestehensprognose",
@@ -391,7 +391,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "geldwaeschepraevention-aml-kyc",
@@ -400,7 +400,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "gesellschaftsgruender",
@@ -409,7 +409,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "gesellschaftsrecht",
@@ -418,7 +418,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "gewerblicher-rechtsschutz",
@@ -427,7 +427,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "grosskanzlei-corporate-ma",
@@ -436,7 +436,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "hausarbeitenmacher",
@@ -445,7 +445,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "immobilienrechtspraxis",
@@ -454,7 +454,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "insolvenzforderungsanmeldungspruefung",
@@ -463,7 +463,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "insolvenzplan-starug-planwerkstatt",
@@ -472,7 +472,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "insolvenzrecht",
@@ -481,7 +481,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "insolvenzverwaltung",
@@ -490,7 +490,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "jurastudium",
@@ -499,7 +499,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "jveg-kostenpruefer",
@@ -508,7 +508,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "kanzlei-allgemein",
@@ -517,7 +517,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "kanzlei-builder-hub",
@@ -526,7 +526,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "kanzlei-cowork",
@@ -535,12 +535,12 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "kartellrecht-marktabgrenzung-pruefung",
       "source": "./kartellrecht-marktabgrenzung-pruefung",
-      "version": "9.0.0",
+      "version": "10.0.0",
       "description": "Kritische kartellrechtliche Pruefinstanz fuer vorgelegte Marktabgrenzungen nach Paragraf 18 GWB und Art 101 und 102 AEUV. SSNIP-Test Nachfrage- und Angebotsumstellung raeumlicher Markt Evidenzbasierung Konsistenzcheck EuGH-Leitentscheidungen Red Flags alternative Marktdefinitionen Marktbeherrschung."
     },
     {
@@ -550,7 +550,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "ki-richtlinie-kanzleien",
@@ -559,7 +559,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "ki-vo-ai-act-pruefer",
@@ -568,7 +568,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "krisenfrueherkennung-starug",
@@ -577,14 +577,14 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "legistik-werkstatt",
       "source": "./legistik-werkstatt",
       "description": "Legistik-Werkstatt fuer Bundes- und Landesministerien. Erstellt Referentenentwuerfe Kabinettsentwuerfe Formulierungshilfen Rechtsverordnungen Satzungen mit Begruendung Synopse Lesefassung XML. Pruefung Verfassungsrecht Europarecht Folgenabschaetzung Goldplating. DOCX im offiziellen HdR-Layout.",
       "category": "verwaltung",
-      "version": "9.0.0",
+      "version": "10.0.0",
       "tags": [
         "legistik",
         "gesetzgebung",
@@ -606,7 +606,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "mandantenanfragen-assistent",
@@ -615,7 +615,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "markenrecht-fashion-luxus",
@@ -624,7 +624,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "memorandums-ersteller",
@@ -633,7 +633,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "methodenlehre-buergerliches-recht",
@@ -642,7 +642,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "mietrecht",
@@ -651,7 +651,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "mittelstand-corporate-ma",
@@ -660,7 +660,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "nda-abgleich",
@@ -669,7 +669,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "normenkontrolle-bauleitplanung",
@@ -678,7 +678,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "patentrecherche",
@@ -687,7 +687,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "phishing-vorfall-pruefer",
@@ -696,7 +696,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "produktrecht",
@@ -705,7 +705,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "prozessrecht",
@@ -714,7 +714,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "rechtsberatungsstelle",
@@ -723,7 +723,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "regulatorisches-recht",
@@ -732,7 +732,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "schriftform-und-textform-bgb",
@@ -741,7 +741,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "sozialrecht-kanzlei",
@@ -750,7 +750,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "steuerrecht-anwalt-und-berater",
@@ -759,7 +759,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "strafbefehl-verteidiger",
@@ -768,7 +768,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "subsumtions-pruefer",
@@ -777,7 +777,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "tabellenreview-3d",
@@ -786,7 +786,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "umweltrecht",
@@ -795,13 +795,13 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "urteilsbauer-relationsmacher",
       "source": "./urteilsbauer-relationsmacher",
       "description": "Urteils- und Beschluss-Werkstatt fuer Amts- Land- und Familienrichter sowie Rechtspfleger. Aktenintake Relation Beweiswuerdigung mit Richter-Input Tatbestandsmerkmale Tenor Tatbestand Entscheidungsgruende Rechtsmittelbelehrung. Erzeugt DOCX nach Paragraf 313 ZPO.",
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "verfassungsrecht",
@@ -810,7 +810,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "verkehr-infrastrukturrecht",
@@ -819,7 +819,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "verkehrsowi-verteidiger",
@@ -828,7 +828,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "verlagsredaktion",
@@ -837,7 +837,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "vertragsausfueller",
@@ -846,7 +846,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "vertragsrecht",
@@ -855,7 +855,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "wandeldarlehen-lebenszyklus",
@@ -864,7 +864,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "zitierweise-deutsches-recht",
@@ -873,7 +873,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "zwangsverwaltung-zvg",
@@ -882,7 +882,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     },
     {
       "name": "zwangsvollstreckung",
@@ -891,8 +891,8 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "9.0.0"
+      "version": "10.0.0"
     }
   ],
-  "version": "9.0.0"
+  "version": "10.0.0"
 }

--- a/aktenaufbereiter-strafrecht/.claude-plugin/plugin.json
+++ b/aktenaufbereiter-strafrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aktenaufbereiter-strafrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Aktenaufbereiter fuer die Strafverteidigung. Sechs Excel-faehige Uebersichten — Aktenvorblatt; Personenverzeichnis; Tatkomplexe; Beziehungen; Chronologie; Fristen. Fortlaufend ergaenzbar. Erkennt Luecken und Widersprueche. Kein Ersatz fuer Aktenlektuere.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/aktenauszug-gerichtsverfahren/.claude-plugin/plugin.json
+++ b/aktenauszug-gerichtsverfahren/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aktenauszug-gerichtsverfahren",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Strukturierter Aktenauszug fuer deutsche Gerichtsverfahren: Verfahrensidentifikation Einleitungssatz Verfahrenszusammenfassung Sachverhaltschronologie Verfahrensgeschichte tabellarische Gegenueberstellung der Parteivortraege Beweismittel und Rechtsargumente fuer schnelle Einarbeitung in Akten.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/anlagen-zu-schriftsaetzen/.claude-plugin/plugin.json
+++ b/anlagen-zu-schriftsaetzen/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anlagen-zu-schriftsaetzen",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Zuordnung von Anlagen zu gerichtlichen Schriftsaetzen. Sortiert PDF/Word/Excel nach Schriftsatz-Logik; konvertiert alles nach PDF; benennt beA-konform; stempelt oben rechts Anlage K1/B1/A1 in Arial 12; baut Anlagenkonvolut; Pruefmodus fuer bereits zugeordnete Anlagen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/arbeitsrecht/.claude-plugin/plugin.json
+++ b/arbeitsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "arbeitsrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Arbeitsrecht – Individualkündigung (KSchG-Klage, 3-Wochen-Frist), Aufhebungsvertrag inkl. Sperrzeit, Abmahnung, Anhörung Betriebsrat § 102 BetrVG, AGG-Prüfung, Statusfeststellung, Personalrichtlinien (BetrVG, AGG, ArbZG, MuSchG, BEEG, EFZG, TzBfG).",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/arbeitszeugnis-analyse/.claude-plugin/plugin.json
+++ b/arbeitszeugnis-analyse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "arbeitszeugnis-analyse",
   "displayName": "Arbeitszeugnis-Analyse (Ampelsystem)",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Analyse deutscher Arbeitszeugnisse nach Ampelsystem (Rot/Orange/Gruen). Erkennt den Geheimcode der Zeugnissprache, identifiziert notenrelevante Saetze und klassifiziert sie mit Interpretation der versteckten Bewertung.",
   "author": {
     "name": "Klotzkette"

--- a/aussenwirtschaft-zoll-sanktionen/.claude-plugin/plugin.json
+++ b/aussenwirtschaft-zoll-sanktionen/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aussenwirtschaft-zoll-sanktionen",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Freistehendes Plugin für Außenwirtschaft, Sanktionen, Zoll, Exportkontrolle, BAFA, TARIC, CBAM, Verbrauchsteuer, AWV, AML/KYC und Ermittlungen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/bav-strategie-konzern/.claude-plugin/plugin.json
+++ b/bav-strategie-konzern/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bav-strategie-konzern",
   "displayName": "Betriebliche Altersversorgung Strategie Konzern",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Strategische Beratung zur betrieblichen Altersversorgung in Konzernen: Pensionsmodelle alle fuenf Durchfuehrungswege CTA Pension Buyouts Drei-Stufen-Theorie Versorgungssystem-Harmonisierung internationale Benefits Restrukturierung DB-zu-DC im Duesseldorfer Boutique-Stil.",
   "author": {
     "name": "Klotzkette"

--- a/bereicherungs-und-anfechtungsrecht-pruefer/.claude-plugin/plugin.json
+++ b/bereicherungs-und-anfechtungsrecht-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bereicherungs-und-anfechtungsrecht-pruefer",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Mechanisches Durchpruefen von Bereicherungsrecht SS 812 ff. BGB sowie Anfechtung nach AnfG und SS 129-147 InsO. Weichenstellung Rechtsgrund, Insolvenz, Vollstreckungstitel. Keine Rechtsberatung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/berufsrecht-ki-vertragspruefung/.claude-plugin/plugin.json
+++ b/berufsrecht-ki-vertragspruefung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "berufsrecht-ki-vertragspruefung",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Berufsrechtliche und strafrechtliche Vorpruefung von Vertraegen mit privaten Legal-AI-Anbietern. Fuer Anwaelte StB WP Patentanwaelte Notare. §§ 43e BRAO 62a StBerG 50a WPO 39c PAO 26a BNotO § 203 StGB. DAV-Stellungnahme. Gutachten Rueckfragebrief Klauseln.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/betreuungsrecht/.claude-plugin/plugin.json
+++ b/betreuungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "betreuungsrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Betreuungsrechtliche Skills für Jahresbericht, Vermögensverzeichnis, Genehmigungspflichten, Kontoanalyse und Verdachtsverträge nach BtOG und BGB.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/common-law-kompass/.claude-plugin/plugin.json
+++ b/common-law-kompass/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "common-law-kompass",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Freistehendes Common-Law-Plugin für deutsche Wirtschaftsjuristen: UK/US-False-Friends, Vertragsbegriffe, Consideration, Suretyship, Indemnity, UCC, Precedent, Discovery und bilinguale Drafting-Reviews.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/corporate-kanzlei/.claude-plugin/plugin.json
+++ b/corporate-kanzlei/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corporate-kanzlei",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Corporate-Kanzlei-Plugin: Deal-Kommandocenter, Datenraum, Due Diligence, SPA/APA, Umwandlung, StaRUG, Insolvenzplan, W&I, Signing/Closing, PMI.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/datenschutzrecht/.claude-plugin/plugin.json
+++ b/datenschutzrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "datenschutzrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "DSGVO/BDSG/TDDDG – PIA/DPIA, AVV-Review als Verantwortlicher und Auftragsverarbeiter, Auskunftsersuchen Art. 15, Datenpannenmeldung Art. 33/34, Drittlandstransfer Art. 44 ff., Drift-Monitoring.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/einfache-leichte-sprache-jura/.claude-plugin/plugin.json
+++ b/einfache-leichte-sprache-jura/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "einfache-leichte-sprache-jura",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Juristische Texte in Einfache Sprache oder Leichte Sprache übertragen: experimentelle Standard-Annäherung, Zielgruppe klären, Rechtsinhalt sichern und Qualitätsgate nutzen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/email-umformulierer-berufsrecht/.claude-plugin/plugin.json
+++ b/email-umformulierer-berufsrecht/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "email-umformulierer-berufsrecht",
   "displayName": "E-Mail-Umformulierer (Berufsrechtskonform)",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Formuliert unfreundliche, emotionale oder unsachliche E-Mails in hoefliche, sachliche und berufsrechtskonform formulierte Texte um. Fokus auf BRAO/BORA-Konformitaet, mit Varianten fuer Steuerberater, Notare und allgemeine berufliche Korrespondenz.",
   "author": {
     "name": "Klotzkette"

--- a/energierecht/.claude-plugin/plugin.json
+++ b/energierecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "energierecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Freistehendes Energierecht-Plugin für Stadtwerke, Versorger, Wärme, Netze, Vertrieb, Industrie, EEG, KWKG, Verfahren, Transaktionen und Projektfinanzierung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/europarecht-kompass/.claude-plugin/plugin.json
+++ b/europarecht-kompass/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "europarecht-kompass",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Freistehendes Europarecht-Plugin gegen deutsche Denkfehler: Vorrang, unmittelbare Wirkung, Richtlinien, Verordnungen, Charta, Grundfreiheiten, Beihilfen, Vorlageverfahren und EU-Drafting.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-agrarrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-agrarrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-agrarrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt für Agrarrecht. Höferecht (HöfeO Anerbenrecht Länder) Landpachtrecht BGB §§ 581 ff. GAP EU-Direktzahlungen Cross-Compliance Düngeverordnung Pflanzenschutz Tierschutz Forstrecht. Schnittstelle Plugin fachanwalt-erbrecht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-arbeitsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-arbeitsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-arbeitsrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Arbeitsrecht nach FAO § 10. KSchG Kuendigungsschutzklage Frist drei Wochen § 4 KSchG. BetrVG Betriebsratsanhoerung § 102. TzBfG Befristung. AGG. Schnittstellen arbeitsrecht und kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-arbeitsrecht/skills/fachanwalt-arbeitsrecht-verhandlung-guete-abfindung-arbg/SKILL.md
+++ b/fachanwalt-arbeitsrecht/skills/fachanwalt-arbeitsrecht-verhandlung-guete-abfindung-arbg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fachanwalt-arbeitsrecht-verhandlung-guete-abfindung-arbg
-description: "Vergleichsverhandlung im Arbeitsgericht-Gueteverfahren § 54 ArbGG. Abfindungsstrategie halbes-Bruttogehalt-Faustformel KSchG. Aufhebungsvertrag versus Vergleich nach Kuendigung. Mediation TT-Eingruppierung Bossing-Faelle. Sperrzeit-Vermeidung BA durch konstruktive Vergleichsformulierung. Strategie Eingangs-Korrespondenz Anwaltsschreiben vor Klage. Workflow Kommunikation Vergleichsvorschlag Niederschrift."
+description: "Vergleichsverhandlung im Arbeitsgericht-Gueteverfahren § 54 ArbGG. Aufloesungsantrag § 9 KSchG mit Abfindungs-Obergrenzen § 10 KSchG. Abfindungsstrategie halbes-Bruttogehalt-Faustformel KSchG. Aufhebungsvertrag versus Vergleich nach Kuendigung. Mediation Bossing-Faelle. Sperrzeit-Vermeidung BA durch konstruktive Vergleichsformulierung. Workflow Anwaltsschreiben Vergleichsvorschlag Niederschrift."
 ---
 
 # Güte-Verhandlung Arbeitsgericht / Abfindungs-Vergleich
@@ -21,8 +21,9 @@ Arbeitsrechtliche Vergleichsverhandlung im Güte-Verfahren § 54 ArbGG (ca. 90 %
 ## Rechtlicher Rahmen
 
 - **§ 54 ArbGG** — Güteverhandlung (Pflicht-Termin)
-- **§ 9, 10 KSchG** — Abfindung bei nicht zumutbar Fortsetzung
-- **§ 1a KSchG** — Abfindungsanspruch bei betriebsbed. Kündigung
+- **§ 9 KSchG** — Auflösung des Arbeitsverhältnisses durch Urteil gegen Abfindung (auf Antrag, wenn Fortsetzung unzumutbar)
+- **§ 10 KSchG** — Abfindungsobergrenzen (Regelfall bis 12 Monatsverdienste; bei langer Betriebszugehörigkeit oder höherem Alter bis 15 bzw. 18 Monatsverdienste)
+- **§ 1a KSchG** — Abfindungsanspruch bei betriebsbed. Kündigung (Hinweis im Kündigungsschreiben)
 - **§ 159 SGB III** — Sperrzeit bei Aufhebungsvertrag (12 Wochen)
 - **DurchführungsAnweisungen BA** zur Faustformel (0,5 Brutto/Beschäft.-Jahr)
 - **§ 1 TVG** — Tarifliche Abfindungsregelungen
@@ -76,7 +77,7 @@ Arbeitsrechtliche Vergleichsverhandlung im Güte-Verfahren § 54 ArbGG (ca. 90 %
 
 ```
 1. Beendigung [Datum]
-2. Abfindung EUR [...] gem. §§ 9, 10 KSchG analog
+2. Abfindung EUR [...] in entsprechender Anwendung der Abfindungsregeln §§ 9 und 10 KSchG
 3. Freistellung Abfindung mit Anrechnung Resturlaub
 4. Zeugnis: mindestens "gut", Schluesselformulierungen [konkret]
 5. Erledigungs-Klausel: saemtliche Anspruche aus Arbeitsverhaeltnis erledigt

--- a/fachanwalt-bank-kapitalmarktrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-bank-kapitalmarktrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-bank-kapitalmarktrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Bank- und Kapitalmarktrecht. KWG ZAG WpHG WpIG MiFID-II MAR MiCAR Verbraucherkredit Vermoegensanlage Beratungshaftung. Schnittstellen Plugin gesellschaftsrecht regulatorisches-recht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-bau-architektenrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-bau-architektenrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-bau-architektenrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Bau- und Architektenrecht. BGB Werkvertrag VOB-A VOB-B VOB-C HOAI Bauordnungsrecht. Bauvertrag Maengelhaftung Abnahme Vergaberecht. Schnittstellen Plugin fachanwalt-vergaberecht kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-erbrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-erbrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-erbrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Erbrecht. BGB Erbrecht §§ 1922 ff. Pflichtteil Testament Erbschein Erbauseinandersetzung Erbschaftsteuer EU-ErbVO. Schnittstellen Plugin steuerrecht-anwalt-und-berater kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-familienrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-familienrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-familienrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Familienrecht. Orientierung Normen Mandate Fristen Literatur. Familiengericht FamFG Scheidung Sorge Umgang Unterhalt Zugewinn Ehevertrag eingetragene Lebenspartnerschaft. Ergaenzend zum Plugin kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-familienrecht/skills/fachanwalt-familienrecht-mediation-156-famfg-cochemer/SKILL.md
+++ b/fachanwalt-familienrecht/skills/fachanwalt-familienrecht-mediation-156-famfg-cochemer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fachanwalt-familienrecht-mediation-156-famfg-cochemer
-description: "Mediation im Familienrecht § 156 FamFG Cochemer-Modell. Trennungs- und Scheidungsfolgenvereinbarung Notar. Mediator Familiengericht Jugendamt. Hochkonflikt-Familien-Mediation. Kommunikations-Strategie bei Kindeswohl Schutz § 1666 BGB. Strategie und Taktik Eingangs-Gespraech Mediations-Auftrag Vergleichs-Beurkundung."
+description: "Mediation im Familienrecht § 156 FamFG Cochemer-Modell. Vermittlungsverfahren § 165 FamFG bei Umgangsverweigerung. Trennungs- und Scheidungsfolgenvereinbarung Notar. Mediator Familiengericht Jugendamt. Hochkonflikt-Familien-Mediation. Kommunikations-Strategie bei Kindeswohl Schutz § 1666 BGB. Strategie Taktik Mediations-Auftrag Vergleichs-Beurkundung."
 ---
 
 # Mediation im Familienrecht — § 156 FamFG / Cochemer Modell
@@ -21,6 +21,7 @@ Familienrecht ist das ADR-intensivste Rechtsgebiet. Mediation ist **gesetzlich v
 ## Rechtlicher Rahmen
 
 - **§ 156 FamFG** — Mediation bei Sorgerechts-/Umgangsstreit (Pflicht zur Beratung)
+- **§ 165 FamFG** — Vermittlungsverfahren bei Umgangsverweigerung (gerichtliches Vermittlungsverfahren, niedrigschwellig, bevor Eilantrag/Ordnungsmittel)
 - **§ 17 SGB VIII** — Jugendamt-Beratung
 - **§ 1684, 1697a BGB** — Umgangs- und Sorgerecht
 - **§ 1565 BGB** — Trennung
@@ -67,6 +68,15 @@ Familienrecht ist das ADR-intensivste Rechtsgebiet. Mediation ist **gesetzlich v
 - Mediation während laufendem Verfahren
 - Gerichtsbestellt
 - Aussetzung Verfahren während Mediation
+
+### Pfad 6 — Vermittlungsverfahren § 165 FamFG (Umgangsverweigerung)
+
+- Anwendung: ein Elternteil verweigert/vereitelt vereinbarten oder gerichtlich geregelten Umgang
+- Antrag an Familiengericht; Termin zur Vermittlung **binnen eines Monats**
+- Persönliches Erscheinen beider Eltern + Jugendamt
+- Niedrigschwellig: keine Ordnungsmittel im Termin, Fokus auf Einvernehmen
+- Bei Scheitern: Übergang zu Ordnungsmittel § 89 FamFG oder Sorgerechts-Änderung § 1671 BGB
+- Vorteil gegenüber Eilantrag: weniger eskalativ, oft schneller zum funktionierenden Umgang
 
 ## Workflow
 
@@ -125,4 +135,4 @@ Familienrecht ist das ADR-intensivste Rechtsgebiet. Mediation ist **gesetzlich v
 
 ## Quellen und Updates
 
-Stand: 05/2026. § 156 FamFG, MediationsG, Cochemer Praxis seit ca. 1992. Bei FamFG-Reform aktualisieren.
+Stand: 05/2026. § 156 FamFG, § 165 FamFG, MediationsG, Cochemer Praxis seit ca. 1992. Bei FamFG-Reform aktualisieren.

--- a/fachanwalt-gewerblicher-rechtsschutz/.claude-plugin/plugin.json
+++ b/fachanwalt-gewerblicher-rechtsschutz/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-gewerblicher-rechtsschutz",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer gewerblichen Rechtsschutz nach FAO § 14k. MarkenG. DesignG. UWG. PatG GebrMG. UrhG-Bezuege. Markenanmeldung DPMA EUIPO. UWG-Abmahnung §§ 8 ff. UWG. Designverletzung. Einstweilige Verfuegung Verletzungsklage Lizenzanaloger Schadensersatz.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-handels-gesellschaftsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-handels-gesellschaftsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-handels-gesellschaftsrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Handels- und Gesellschaftsrecht nach FAO § 14i. HGB. AktG. GmbHG. PartGG. UmwG. Geschaeftsfuehrerhaftung §§ 43 GmbHG 93 AktG. Gesellschafterstreit Beschlussanfechtung. Handelsvertreterausgleich § 89b HGB. MoPeG GbR seit 2024. Schnittstellen kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-insolvenz-sanierungsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-insolvenz-sanierungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-insolvenz-sanierungsrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Insolvenz- und Sanierungsrecht nach FAO § 14. InsO Eroeffnung Antragspflicht § 15a Glaeubigerantrag § 14 InsO. StaRUG Restrukturierungsplan. Insolvenzanfechtung §§ 129 ff. InsO. Schnittstellen insolvenzrecht und steuerrecht-anwalt-und-berater.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-internationales-wirtschaftsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-internationales-wirtschaftsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-internationales-wirtschaftsrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Internationales Wirtschaftsrecht. CISG Bruessel Ia Rom I Rom II Schiedsverfahren ICC UNCITRAL Investitionsschutz ICSID WTO EU-Aussenhandel LkSG. Schnittstelle Plugin kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-it-recht/.claude-plugin/plugin.json
+++ b/fachanwalt-it-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-it-recht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Informationstechnologierecht. SaaS Software-Lizenz DSGVO BDSG TTDSG TKG NIS2 DDG DSA DMA EU-KI-VO Open-Source. Schnittstellen Plugin datenschutzrecht ki-governance kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-medizinrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-medizinrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-medizinrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Medizinrecht. Arzthaftung §§ 630a ff. BGB Patientenrechte Vertragsarztrecht Berufsrecht Aerzte SGB V Krankenversicherung MPDG Apothekenrecht. Schnittstellen Plugin sozialrecht-kanzlei kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-miet-wohnungseigentumsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-miet-wohnungseigentumsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-miet-wohnungseigentumsrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Miet- und Wohnungseigentumsrecht nach FAO § 14e. BGB §§ 535 ff. Wohnraummiete und Gewerberaummiete. Mieterhoehung §§ 558 ff. Kuendigung §§ 543 569 573 BGB. WEG-Beschlussanfechtung § 44 WEG. BetrKV. Schnittstellen kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-migrationsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-migrationsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-migrationsrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt für Migrationsrecht. AufenthG AsylG GFK Dublin-VO Verfahrens-RL Qualifikations-RL StAG. Einbürgerung Familiennachzug Notfrist § 36 AsylG eine Woche. Schnittstellen Plugin rechtsberatungsstelle.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-sozialrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-sozialrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-sozialrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Sozialrecht nach FAO § 11. SGB I bis XII Sozialgerichtsbarkeit SGG. Widerspruch § 84 SGG Frist ein Monat. Klage Sozialgericht § 87 SGG. Erwerbsminderungsrente. SGB II Buergergeld Bescheid. Schnittstellen sozialrecht-kanzlei und kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-sportrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-sportrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-sportrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt für Sportrecht. Verbandsrecht (DFB FIFA UEFA IOC DOSB) CAS Schiedsverfahren Spielerverträge Doping WADA-Code NADA Sponsoring Persönlichkeitsrechte Veranstalterhaftung. Schnittstelle Plugin gesellschaftsrecht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-strafrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-strafrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-strafrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Strafrecht. Orientierung StPO StGB Nebenstrafrecht. Strafverteidigung Ermittlungsverfahren Hauptverhandlung Berufung Revision Verfassungsbeschwerde. Ergaenzt aktenaufbereiter-strafrecht und kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-transport-speditionsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-transport-speditionsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-transport-speditionsrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Transport- und Speditionsrecht. HGB §§ 407 ff. Frachtvertrag §§ 453 ff. Spedition CMR COTIF Montrealer Uebereinkommen Haager Visby Regeln ADSp. Schnittstelle Plugin kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-urheber-medienrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-urheber-medienrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-urheber-medienrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Urheber- und Medienrecht. UrhG UWG KUG Recht am eigenen Bild Presserecht Persoenlichkeitsrecht Medienstaatsvertrag. Schnittstellen Plugin gewerblicher-rechtsschutz verlagsredaktion kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-vergaberecht/.claude-plugin/plugin.json
+++ b/fachanwalt-vergaberecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-vergaberecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Vergaberecht. GWB §§ 97 ff. VgV UVgO SektVO KonzVgV VOB-A. EU-Vergabe-RL. Nachpruefungsverfahren Vergabekammer und OLG-Vergabesenat. Schnittstelle Plugin fachanwalt-bau-architektenrecht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-vergaberecht/skills/fachanwalt-vergaberecht-vk-aufklaerung-vergleich/SKILL.md
+++ b/fachanwalt-vergaberecht/skills/fachanwalt-vergaberecht-vk-aufklaerung-vergleich/SKILL.md
@@ -18,8 +18,10 @@ Vergabe-Nachprüfungs-Verfahren ist verfahrensrechtlich straff und schnell (5 Wo
 
 ## Rechtlicher Rahmen
 
-- **§ 155 GWB** — Vergabekammer
-- **§ 156 GWB** — Eilrechtsschutz Suspensiveffekt
+- **§ 155 GWB** — Beginn 2. Teil GWB (Vergabe-Nachpruefungsverfahren)
+- **§ 156 GWB** — Vergabekammern (Zustaendigkeit, Besetzung)
+- **§ 169 GWB** — Suspensiveffekt/Zuschlagsverbot waehrend Nachpruefungsverfahren (Aussetzung des Zuschlags)
+- **§ 160 GWB** — Ruegeobliegenheit Bieter
 - **§ 158 GWB** — Entscheidung VK / Vergleich
 - **§ 160 III GWB** — Rüge vor VK-Antrag (Pflicht)
 - **§ 173 GWB** — Sofortige Beschwerde OLG-Vergabesenat

--- a/fachanwalt-verkehrsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-verkehrsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-verkehrsrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Verkehrsrecht. StVG StVO PflVG VVG-Bezuege. Verkehrsunfall Personen- und Sachschaden Bussgeld Fahrerlaubnis Verkehrsstrafrecht (§§ 315c 316 StGB). Schnittstelle Plugin kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-verkehrsrecht/skills/fachanwalt-verkehrsrecht-versicherer-quotenverhandlung-vergleich/SKILL.md
+++ b/fachanwalt-verkehrsrecht/skills/fachanwalt-verkehrsrecht-versicherer-quotenverhandlung-vergleich/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fachanwalt-verkehrsrecht-versicherer-quotenverhandlung-vergleich
-description: "Kfz-Versicherer-Verhandlung Unfallregulierung Mitverschuldensquote 254 BGB. Vorgerichtliche Korrespondenz Schmerzensgeld-Tabelle Hacks. AG-Vergleich vor 250 ZPO. Mediation bei Personenschaden mit Schwerstverletzung. Workflow Schadensanzeige Quotenermittlung Vergleichsverhandlung."
+description: "Kfz-Versicherer-Verhandlung Unfallregulierung Mitverschuldensquote § 254 BGB. Vorgerichtliche Korrespondenz Schmerzensgeld-Tabelle Hacks. Gerichtlicher Vergleich § 278 Abs. 6 ZPO. Mediation bei Personenschaden mit Schwerstverletzung. Workflow Schadensanzeige Quotenermittlung Vergleichsverhandlung."
 ---
 
 # Versicherer-Verhandlung / Quotenstreit im Verkehrsrecht
@@ -42,11 +42,12 @@ Verkehrsunfall-Mandate enden zu ca. 80 % in Vergleich mit Kfz-Versicherer. Verha
 - Sachverständigen-Gutachten DEKRA / TÜV
 - Bindend für Versicherer
 
-### Pfad 3 — AG-Vergleich § 250 ZPO
+### Pfad 3 — Gerichtlicher Vergleich § 278 ZPO
 
-- Vor Amts/Landgericht
-- Bei mittlerem Streitwert
-- Erörterungstermin
+- Güteverhandlung § 278 Abs. 2 ZPO als Pflicht-Termin vor Beweisaufnahme
+- Vergleichsabschluss zu Protokoll § 160 Abs. 3 Nr. 1 ZPO oder per Beschluss § 278 Abs. 6 ZPO (schriftlicher Vergleich)
+- Vor Amts-/Landgericht; bei mittlerem Streitwert besonders effizient
+- Erörterungstermin mit Quotenvorschlag Gericht
 
 ### Pfad 4 — Mediation bei Schwerstverletzung
 

--- a/fachanwalt-versicherungsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-versicherungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-versicherungsrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt fuer Versicherungsrecht. VVG VAG Berufsunfaehigkeit private Krankenversicherung Lebens- und Rentenversicherung Sachversicherung Haftpflicht D-und-O. Schnittstelle Plugin kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-versicherungsrecht/skills/fachanwalt-versicherungsrecht-ombudsmann-gdv-schlichtung/SKILL.md
+++ b/fachanwalt-versicherungsrecht/skills/fachanwalt-versicherungsrecht-ombudsmann-gdv-schlichtung/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fachanwalt-versicherungsrecht-ombudsmann-gdv-schlichtung
-description: "Versicherungs-Ombudsmann VVR e.V. außergerichtliche Schlichtung bis 10.000 EUR. Ombudsmann private Kranken/Pflegeversicherung PKV. BaFin-Verbraucherbeschwerde. EU-ODR-Plattform bei Online-Versicherung. Sachverständigen-Verfahren § 84 VVG. Workflow Beschwerde Schlichtung Klage."
+description: "Versicherungs-Ombudsmann VVR e.V. außergerichtliche Schlichtung bis 10000 EUR. Ombudsmann private Kranken/Pflegeversicherung PKV. BaFin-Verbraucherbeschwerde. VSBG-Verbraucherstreitbeilegung (EU-ODR-Plattform seit 20.7.2025 abgeschaltet). Sachverständigen-Verfahren § 84 VVG. Workflow Beschwerde Schlichtung Klage."
 ---
 
 # Versicherungs-Ombudsmann / GDV-Schlichtung
@@ -26,7 +26,6 @@ Versicherungsrechts-Streit (Leistung, Anpassung, Kündigung) ist häufig im auß
 - **§ 203 VVG** — Beitragsanpassung PKV
 - **§ 14 UKlaG** — Schlichtungs-Pflicht Verbraucher
 - **VSBG** — Verbraucherstreitbeilegungs-Gesetz
-- **EU-VO 524/2013** — ODR-Plattform
 - **Versicherungs-Ombudsmann-Verfahrensordnung 2021** (geändert 2024)
 
 ### Leitentscheidungen
@@ -56,13 +55,7 @@ Versicherungsrechts-Streit (Leistung, Anpassung, Kündigung) ist häufig im auß
 - Kein Einzelfall-Spruch, aber Hinweis-Wirkung
 - Bei systemischen Mängeln effektiv
 
-### Pfad 4 — EU-ODR-Plattform
-
-- Bei Online-Versicherungsabschluss
-- VO 524/2013
-- Plattform: ec.europa.eu/odr
-
-### Pfad 5 — Sachverständigen-Verfahren § 84 VVG
+### Pfad 4 — Sachverständigen-Verfahren § 84 VVG
 
 - Bei Schadenhöhe-Streit (Hausrat, Gebäude, Kfz)
 - Versicherer + Vers.-Nehmer benennen je 1 Sachverständigen
@@ -117,4 +110,4 @@ Versicherungsrechts-Streit (Leistung, Anpassung, Kündigung) ist häufig im auß
 
 ## Quellen und Updates
 
-Stand: 05/2026. Ombudsmann-Verfahrensordnung 2024-Update. PKV-Linie BGH IV ZR 193/20 stabil. EU-ODR-Plattform aktiv.
+Stand: 05/2026. Ombudsmann-Verfahrensordnung 2024-Update. PKV-Linie BGH IV ZR 193/20 stabil. EU-ODR-Plattform abgeschaltet zum 20.7.2025 (VO (EU) 2024/3228 hat VO 524/2013 aufgehoben); VSBG-Schlichtung nationalen Verbraucherschlichtungsstellen bleibt verfügbar.

--- a/fachanwalt-verwaltungsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-verwaltungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-verwaltungsrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Light-Touch-Plugin Fachanwalt für Verwaltungsrecht. VwGO VwVfG. Anfechtungs- und Verpflichtungsklage Eilrechtsschutz § 80 Abs 5 VwGO einstweilige Anordnung Normenkontrolle Polizei- und Ordnungsrecht. Schnittstelle Plugin kanzlei-cowork.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fluggastrechte/.claude-plugin/plugin.json
+++ b/fluggastrechte/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fluggastrechte",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Fluggastrechte selber geltend machen — VO (EG) Nr. 261/2004 plus EuGH-Rspr. Tickets erfassen Annullierung vs Verspaetung pruefen aussergewoehnliche Umstaende Distanz und Ausgleich Forderungsschreiben Mahnung Klage Amtsgericht. Vollmacht Familie. Katalog Airline-Standardausreden.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/forderungsmanagement-klagewerkstatt/.claude-plugin/plugin.json
+++ b/forderungsmanagement-klagewerkstatt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forderungsmanagement-klagewerkstatt",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Klagewerkstatt für Forderungsmanagement mit Zuständigkeitsprüfung, Mahnvorlauf, Inkasso-Zahlungsklage und Anspruchs-Gatekeeper: Nur klare, fällige und belegte Forderungen werden zur Klage freigegeben.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fortbestehensprognose/.claude-plugin/plugin.json
+++ b/fortbestehensprognose/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fortbestehensprognose",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Fortbestehensprognose § 19 Abs. 2 InsO als Geschaeftsfuehrer-Selbstdokumentation. Bilanzstatus Annahmen Plausibilisierung Zwoelf-Monats-Liquiditaet. Sanierungsbausteine Patronatserklaerung Comfortletter Rangruecktritt Stundung Forderungsverzicht. IDW S 11 StaRUG. Eskalation bei negativer Prognose.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/geldwaeschepraevention-aml-kyc/.claude-plugin/plugin.json
+++ b/geldwaeschepraevention-aml-kyc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "geldwaeschepraevention-aml-kyc",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Freistehendes Plugin für Geldwäscheprävention, AML, KYC, GwG-Risikoanalyse, UBO, PEP, Sanktionen, FIU/goAML, Transparenzregister und Behördenverfahren.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gesellschaftsgruender/.claude-plugin/plugin.json
+++ b/gesellschaftsgruender/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gesellschaftsgruender",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Gruendungsassistent deutsche Gesellschaften (GmbH UG GbR OHG KG GmbH und Co KG PartG mbB gGmbH). Von Rechtsformwahl ueber Gesellschaftsvertrag und Geschaeftsfuehrervertrag bis Notar Handelsregister Gewerbeamt Finanzamt Transparenzregister. MoPeG DiRUG GwG. Kein Ersatz fuer Anwaltsberatung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gesellschaftsrecht/.claude-plugin/plugin.json
+++ b/gesellschaftsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gesellschaftsrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Gesellschaftsrecht – GmbH/AG/Personengesellschaften, M&A-Due-Diligence ohne Discovery (Q&A + Datenraum), Gesellschafterbeschlüsse, HRB/HRA-Anmeldungen, Closing Checklists, Compliance-Fristen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gewerblicher-rechtsschutz/.claude-plugin/plugin.json
+++ b/gewerblicher-rechtsschutz/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gewerblicher-rechtsschutz",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Gewerblicher Rechtsschutz – DPMA/EUIPO-Markenrecherche und -anmeldung, Freedom-to-Operate, Patentscreening, UWG- und Urheberrechts-Abmahnung (Versand und Reaktion), Open-Source-Compliance, IP-Klausel-Review, Schutzrechts-Fristen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/grosskanzlei-corporate-ma/.claude-plugin/plugin.json
+++ b/grosskanzlei-corporate-ma/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "grosskanzlei-corporate-ma",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Freistehendes Big-Law-Corporate/M&A-Plugin: Deal-Kommandocenter, Aktenanlage, Datenraum, Legal DD, Tabellenreview, Liquiditätsvorschau, SPA/APA, W&I, Public M&A, Umwandlung, StaRUG/Insolvenzplan, CP-Kalender, E-Rechnung/GoBD, PMI.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/hausarbeitenmacher/.claude-plugin/plugin.json
+++ b/hausarbeitenmacher/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hausarbeitenmacher",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Didaktisches Plugin fuer juristische Hausarbeiten und Seminararbeiten. Fuehrt sokratisch durch Zivilrecht oeffentliches Recht Strafrecht mit Ausfluegen in Europarecht und Rechtstheorie. Adressaten-Strategie ohne Schleimerei. Liefert keine fertigen Loesungen sondern fuehrt zur eigenen Subsumtion.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/immobilienrechtspraxis/.claude-plugin/plugin.json
+++ b/immobilienrechtspraxis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "immobilienrechtspraxis",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Werkzeuge fuer immobilienrechtliche Rechtsabteilungen: musterbasierte Vertragserstellung mit Klauselschutz; Vertragspruefung gegen Playbook; Grundbuchanalyse; Sachverhaltsermittlung; Mieteranfragen mit BGH-Verankerung; Case Management; projektbasierte Arbeitsweise mit AVV-Pruefung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/insolvenzforderungsanmeldungspruefung/.claude-plugin/plugin.json
+++ b/insolvenzforderungsanmeldungspruefung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insolvenzforderungsanmeldungspruefung",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Freistehendes Plugin für die Insolvenzforderungsanmeldungsprüfung: Intake, § 174 InsO, Belege, Grund, Betrag, Rang, vbuH, Nachforderungen, Tabellenimport, Prüfungstermin, Bestreiten, Feststellung, Tabellenauszug und Verteilung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/insolvenzplan-starug-planwerkstatt/.claude-plugin/plugin.json
+++ b/insolvenzplan-starug-planwerkstatt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insolvenzplan-starug-planwerkstatt",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Freistehendes Plugin für Insolvenzplan und StaRUG-Restrukturierungsplan: Intake, Sanierungskonzept, Vergleichsrechnung, Gruppen, Klassen, darstellender und gestaltender Teil, Anlagen, Abstimmung, Cram-down, Minderheitenschutz, Gericht und Planvollzug.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/insolvenzrecht/.claude-plugin/plugin.json
+++ b/insolvenzrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insolvenzrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Insolvenzrechtliche Skills zu Zahlungsunfähigkeit, Überschuldung, Antragspflicht und Gläubigerantrag.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/insolvenzverwaltung/.claude-plugin/plugin.json
+++ b/insolvenzverwaltung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insolvenzverwaltung",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Freistehendes Insolvenzverwaltungs-Plugin aus Sicht von Insolvenzverwalter, Sachwalter und vorläufiger Verwaltung: Regelverfahren, Eigenverwaltung, Schutzschirm, Anfechtung, § 15b InsO, Masse, Forderungsprüfung, Insolvenzplan, StaRUG-Planwerkstatt, Gutachten, Berichte und Schlussrechnung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/jurastudium/.claude-plugin/plugin.json
+++ b/jurastudium/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jurastudium",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Studium und Referendariat – Prüfungsgespräch nach AG-Tradition, Subsumtionslehre, Methodenlehre (Zivilrecht, Strafrecht, Öffentliches Recht), Rechtsgeschichte, Lernstrategien, Lösungsschemata, Gutachtenstil, Klausurkorrektur, Lernplanung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/jveg-kostenpruefer/.claude-plugin/plugin.json
+++ b/jveg-kostenpruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jveg-kostenpruefer",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Freistehender JVEG-Kostenprüfer für Zeugenentschädigung, Vorschuss, Fahrtkosten, Übernachtung, Verdienstausfall, Sachverständigen- und Dolmetscherkosten, Fristen, Festsetzung, Beschwerde und belegfeste Rechenprotokolle.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kanzlei-allgemein/.claude-plugin/plugin.json
+++ b/kanzlei-allgemein/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanzlei-allgemein",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Kanzlei-Allgemein-Plugin: edles Cowork-Kommandocenter, Mandatsannahme/GwG, Klage/Replik, Vertrag, Rechtsprechung, Handelsregister, beA, Rechnung, UStVA.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kanzlei-builder-hub/.claude-plugin/plugin.json
+++ b/kanzlei-builder-hub/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanzlei-builder-hub",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Findet, prüft und installiert Community-Skills mit Security-Review-Gate vor dem Deployment in die Kanzleiumgebung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kanzlei-cowork/.claude-plugin/plugin.json
+++ b/kanzlei-cowork/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanzlei-cowork",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Cowork-Assistent fuer die deutsche Anwaltskanzlei. Fristenbuch Timesheet RVG-Rechnung Versand-Vor-Check (PDF beA Signatur) beA-Versand Postein- und ausgang Mandantenakte Aktenbestand Honorar-Mahnwesen Mandantenbriefe Geburtstage Weihnachtskarten Tagesbrief. Rechtsgebietsunabhaengig.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kartellrecht-marktabgrenzung-pruefung/.claude-plugin/plugin.json
+++ b/kartellrecht-marktabgrenzung-pruefung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kartellrecht-marktabgrenzung-pruefung",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Kritische kartellrechtliche Pruefinstanz fuer vorgelegte Marktabgrenzungen nach Paragraf 18 GWB und Art 101 und 102 AEUV. SSNIP-Test Nachfrage- und Angebotsumstellung raeumlicher Markt Evidenzbasierung Konsistenzcheck EuGH-Leitentscheidungen Red Flags alternative Marktdefinitionen Marktbeherrschung.",
   "author": {
     "name": "Klotzkette"

--- a/ki-governance/.claude-plugin/plugin.json
+++ b/ki-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ki-governance",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "EU-KI-VO + DSGVO – Use-Case-Triage, KI-Inventar, AIA/DPIA, Vendor-Review, Drift-Monitoring der KI-Richtlinie.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/ki-richtlinie-kanzleien/.claude-plugin/plugin.json
+++ b/ki-richtlinie-kanzleien/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ki-richtlinie-kanzleien",
   "displayName": "KI-Richtlinie fuer Kanzleien und Rechtsabteilungen",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Erstellt und pflegt eine berufsrechtskonforme KI-Nutzungsrichtlinie fuer Kanzleien und Rechtsabteilungen mit Anwaelten und Syndikus-Anwaelten. Beruht auf BRAO, BORA, DSGVO, KI-Verordnung sowie BRAK- und DAV-Hinweisen.",
   "author": {
     "name": "Klotzkette"

--- a/ki-vo-ai-act-pruefer/.claude-plugin/plugin.json
+++ b/ki-vo-ai-act-pruefer/.claude-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
-    "name": "ki-vo-ai-act-pruefer",
-    "version": "9.0.0",
-    "description": "Mechanik-Workflow zur KI-VO (EU 2024/1689): KI-System-Definition, Rollen, Risikoklassen, verbotene Praktiken, Hochrisiko-Diagnose und 12-Schritte-Roadmap bis CE, Konformitaetsbewertung, EU-DB, Marktbeobachtung. Auch Negativ-Diagnose ueber Rueckausnahme Art. 6 Abs. 3, GPAI, Sanktionen.",
-    "license": "Apache-2.0 OR MIT",
-    "author": {
-        "name": "Klotzkette"
-    },
-    "homepage": "https://github.com/Klotzkette/claude-fuer-deutsches-recht"
+  "name": "ki-vo-ai-act-pruefer",
+  "version": "10.0.0",
+  "description": "Mechanik-Workflow zur KI-VO (EU 2024/1689): KI-System-Definition, Rollen, Risikoklassen, verbotene Praktiken, Hochrisiko-Diagnose und 12-Schritte-Roadmap bis CE, Konformitaetsbewertung, EU-DB, Marktbeobachtung. Auch Negativ-Diagnose ueber Rueckausnahme Art. 6 Abs. 3, GPAI, Sanktionen.",
+  "license": "Apache-2.0 OR MIT",
+  "author": {
+    "name": "Klotzkette"
+  },
+  "homepage": "https://github.com/Klotzkette/claude-fuer-deutsches-recht"
 }

--- a/krisenfrueherkennung-starug/.claude-plugin/plugin.json
+++ b/krisenfrueherkennung-starug/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "krisenfrueherkennung-starug",
   "displayName": "Krisenfrüherkennung und StaRUG-Management",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Krisenfrüherkennung und Krisenmanagement nach StaRUG: Pflicht zum 24-Monats-Frühwarnsystem nach § 1 StaRUG, § 102 StaRUG Warnpflicht der Berater, Geschäftsführerhaftung, drohende Zahlungsunfähigkeit, integrierte Planung, Restrukturierungsplan und Stabilisierungsanordnung.",
   "author": {
     "name": "Klotzkette"

--- a/legistik-werkstatt/.claude-plugin/plugin.json
+++ b/legistik-werkstatt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legistik-werkstatt",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Legistik-Werkstatt fuer Bundes- und Landesministerien. Erstellt Referentenentwuerfe Kabinettsentwuerfe Formulierungshilfen Rechtsverordnungen Satzungen mit Begruendung Synopse Lesefassung XML. Pruefung Verfassungsrecht Europarecht Folgenabschaetzung Goldplating. DOCX im offiziellen HdR-Layout.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/liquiditaetsplanung/.claude-plugin/plugin.json
+++ b/liquiditaetsplanung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "liquiditaetsplanung",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Liquiditaetsplanung nach deutschem Recht: 3-Wochen-Vorschau mit BGH-Passiva-II- und 10-Prozent-Schema, 13/26/52-Wochen-Forecast, Excel-Export mit Quote/Luecken-Ampel, Padlet/JSON-Round-Trip, Integration mit Fortbestehensprognose. Krisen-GmbH, Bugwellenrechtsprechung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/mandantenanfragen-assistent/.claude-plugin/plugin.json
+++ b/mandantenanfragen-assistent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mandantenanfragen-assistent",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Assistent fuer Anwaltskanzleien zur Erstantwort auf Mandantenanfragen per E-Mail: dankt foermlich uebernimmt die Anrede aus der eingehenden E-Mail nennt die telefonische Terminvergabe bittet um Sachverhalt per E-Mail oder bietet eine Telefon-Transkription mit DSGVO-Einwilligungshinweis an.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/markenrecht-fashion-luxus/.claude-plugin/plugin.json
+++ b/markenrecht-fashion-luxus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markenrecht-fashion-luxus",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Markenrecht-Boutique fuer Luxus-Modehaeuser - DPMA/EUIPO Alicante/USPTO Lanham Act via NYC-Korrespondenz, alle Markenarten (Wort/Bild/Slogan/Sound/Duft/3D/Position/Haptik/Anti-KI), Widerspruch, Loeschung, Verletzung, Produktpiraterie, Selektivvertrieb.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/memorandums-ersteller/.claude-plugin/plugin.json
+++ b/memorandums-ersteller/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorandums-ersteller",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Wandelt Mandantenunterlagen in ein juristisches Memorandum mit Vier-Teile-Gliederung — Sachverhalt mit Quellenreferenz; Ein-Satz-Fragen; Ein-Satz-Antworten; rechtliche Ausfuehrungen mit Pinpoint-Zitierung. Optional Piercing-Questions. Rechtsgebietsneutral. Alias Memorandumsmacher.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/methodenlehre-buergerliches-recht/.claude-plugin/plugin.json
+++ b/methodenlehre-buergerliches-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "methodenlehre-buergerliches-recht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Methodenlehre und Rechtsanwendung im deutschen buergerlichen Recht aus Anwaltsperspektive. Gutachtenstil. Anspruchsgrundlagen-Reihenfolge. Auslegung Wortlaut System Historie Telos pragmatisch ohne starren Vorrang. Verfassungs- und unionsrechtskonforme Auslegung. Lueckenfuellung. Verjaehrung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/mietrecht/.claude-plugin/plugin.json
+++ b/mietrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mietrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Mietrecht fuer Mieter und Vermieter mit ausschliesslich amtlichen Mietspiegel-Quellen pro Bundesland und fuer Top- und Universitaetsstaedte. Datenerhebung Mieterhoehungs-Widerspruch Mietsenkungsverlangen Nebenkostenpruefung und Erstellung Mieteranfragen Klageentwurf zum Amtsgericht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/mittelstand-corporate-ma/.claude-plugin/plugin.json
+++ b/mittelstand-corporate-ma/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mittelstand-corporate-ma",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Freistehendes Mittelstandsmandat-Corporate/M&A-Plugin: Deal-Kommandocenter, Aktenanlage, Datenraum, Legal DD, Tabellenreview, Liquiditätsvorschau, SPA/APA, W&I, Public M&A, Umwandlung, StaRUG/Insolvenzplan, CP-Kalender, E-Rechnung/GoBD, PMI.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/nda-abgleich/.claude-plugin/plugin.json
+++ b/nda-abgleich/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nda-abgleich",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Gleicht NDA-Entwurf der Gegenseite gegen eigenen Standard ab und setzt Haltelinien chirurgisch im Word-Aenderungsmodus durch. Ampelmatrix ROT/GELB/GRUEN. Ausgabe .docx mit echten Tracked Changes. Keine Absatzloeschungen, keine Klausel-Neufassungen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/normenkontrolle-bauleitplanung/.claude-plugin/plugin.json
+++ b/normenkontrolle-bauleitplanung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "normenkontrolle-bauleitplanung",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Freistehendes Plugin für die Prüfung und Anfechtung von Bebauungsplänen, Flächennutzungsplänen und örtlichen Bauvorschriften nach § 47 VwGO vor BayVGH und OVG. Mandatsperspektive Antragstellervertretung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/patentrecherche/.claude-plugin/plugin.json
+++ b/patentrecherche/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "patentrecherche",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Patentrecherche fuer Patentanwaelte agentisch in Espacenet Google Patents DPMAregister DEPATISnet EPO Register WIPO USPTO. Stand der Technik Neuheit § 3 PatG Art. 54 EPUe erfinderische Taetigkeit § 4 PatG Art. 56 EPUe Problem-Solution-Approach FTO CPC IPC INPADOC Recherchebericht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/phishing-vorfall-pruefer/.claude-plugin/plugin.json
+++ b/phishing-vorfall-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "phishing-vorfall-pruefer",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Freistehender Phishing-Vorfall-Prüfer für Online-Banking: BGB § 675u, § 675v, § 675w, pushTAN, Call-ID-Spoofing, grobe Fahrlässigkeit, Beweislast, Bankpflichten, Schlichtung und Klage.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/produktrecht/.claude-plugin/plugin.json
+++ b/produktrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "produktrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Produktrechtliche Skills für Launch-Review, Impressumspflicht nach DDG und PAngV sowie UWG-Bewertungen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/prozessrecht/.claude-plugin/plugin.json
+++ b/prozessrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prozessrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Prozessrechtliche Skills für Mandate, Fristen, Mahnbescheid, Eilverfahren, Vollstreckung und Schriftsätze.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/rechtsberatungsstelle/.claude-plugin/plugin.json
+++ b/rechtsberatungsstelle/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rechtsberatungsstelle",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Pro-Bono- und Rechtsberatungsstellen (RDG-konform): Mandantenintake, Fristenkontrolle, Übergabe am Semesterende, mandantenfreundliche Briefe.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/regulatorisches-recht/.claude-plugin/plugin.json
+++ b/regulatorisches-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "regulatorisches-recht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Aufsichtsrecht – KWG, ZAG, WpHG, GwG, EnWG, TKG, HeilMWerbG, Umsatzsteuer-Voranmeldung, Inkasso/RDG, Regulator-Feeds, Wochendigest.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/schriftform-und-textform-bgb/.claude-plugin/plugin.json
+++ b/schriftform-und-textform-bgb/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "schriftform-und-textform-bgb",
   "displayName": "Schriftform und Textform im BGB",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Workflow-Organisator zu Formerfordernissen im deutschen Zivilrecht: Schriftform § 126 BGB qES § 126a Textform § 126b Zugang § 130 BGB lernt aus BGH I ZR 202/25 Maklervertrag und BGH VIII ZR 159/23 Mietkündigung Klauselgenerator Mandantenmemos.",
   "author": {
     "name": "Klotzkette"

--- a/sozialrecht-kanzlei/.claude-plugin/plugin.json
+++ b/sozialrecht-kanzlei/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sozialrecht-kanzlei",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Vollassistenz fuer die sozialrechtliche Kanzlei: Bescheidanalyse Widerspruch Klage zum Sozialgericht Eilantrag Akteneinsicht Anlagen. Spezialisiert auf Buergergeld SGB IX Schwerbehinderung Hilfsmittel (Rollstuhl Hoerhilfe Vorlesekraft) Eingliederungshilfe Schulbegleitung. Mit Fristenbuch und PKH.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/steuerrecht-anwalt-und-berater/.claude-plugin/plugin.json
+++ b/steuerrecht-anwalt-und-berater/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "steuerrecht-anwalt-und-berater",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Steuerrecht fuer Anwaltschaft (anw- inkl. Fachanwaltschaft FAO § 9) und Steuerberatung (stb-): Bescheidanalyse Einspruch Klage FG Aussenpruefung Selbstanzeige Strafverteidigung. StB-Tools BWA SuSa Bilanz Ueberschuldungspruefung Liquiditaet Krisenfrueherkennung. Ersetzt fachanwalt-steuerrecht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/strafbefehl-verteidiger/.claude-plugin/plugin.json
+++ b/strafbefehl-verteidiger/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "strafbefehl-verteidiger",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Freistehendes Strafbefehls-Plugin für Verteidigung gegen Strafbefehl, Einspruch, Akteneinsicht, Tagessätze, Nebenfolgen, Pflichtverteidigung, Wiedereinsetzung, Einstellung, Zeugenstrategie und Hauptverhandlung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/subsumtions-pruefer/.claude-plugin/plugin.json
+++ b/subsumtions-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "subsumtions-pruefer",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Interaktiver Subsumtions-Workflow fuer deutsches Recht und Europarecht: Tatbestandsmerkmale zerlegen, Vier-Schritt-Schema anwenden, Rechtsfolgen und Einreden pruefen. Keine Rechtsberatung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/tabellenreview-3d/.claude-plugin/plugin.json
+++ b/tabellenreview-3d/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tabellenreview-3d",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "3D-Tabellenreview als Wuerfel: Spaltenprompts pro Datenpunkt x Zeilenprompts pro Dokument x Arbeitsblatt-Perspektiven (Recht / Steuer / Wirtschaft) gestapelt. Massenpruefung Vertragsstapel M&A-DD Immobilien Vendor-Onboarding mit Excel-Mehrblatt Kreuzblatt-Konsistenz Audit-Trail Belegkette.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/umweltrecht/.claude-plugin/plugin.json
+++ b/umweltrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "umweltrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Freistehendes Umweltrecht-Plugin für BImSchG, TEHG, Abfall, Wasser, Boden, Naturschutz, UIG, Verfahren, Bußgeld, Umwelt-Due-Diligence, Klimaklagen UmwRG, Lieferkettensorgfalt LkSG/CSDDD und ESG-Greenwashing/CSRD.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/urteilsbauer-relationsmacher/.claude-plugin/plugin.json
+++ b/urteilsbauer-relationsmacher/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "urteilsbauer-relationsmacher",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Urteils- und Beschluss-Werkstatt fuer Amts- Land- und Familienrichter sowie Rechtspfleger. Aktenintake Relation Beweiswuerdigung mit Richter-Input Tatbestandsmerkmale Tenor Tatbestand Entscheidungsgruende Rechtsmittelbelehrung. Erzeugt DOCX nach Paragraf 313 ZPO.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verfassungsrecht/.claude-plugin/plugin.json
+++ b/verfassungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verfassungsrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Deutsches Verfassungsrecht unter dem Grundgesetz aus Sicht einer Spezialkanzlei. Rechtsprechungsgetrieben mit Live-Recherche auf bundesverfassungsgericht.de. Acht Skills für Gesetzgebungskompetenz formelle und materielle Verfassungsmäßigkeit Grundrechte und Verfassungsbeschwerde.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verkehr-infrastrukturrecht/.claude-plugin/plugin.json
+++ b/verkehr-infrastrukturrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verkehr-infrastrukturrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Freistehendes Verkehrs- und Infrastrukturrecht-Plugin für Verkehrsplanung, Planfeststellung, Straßenbahn, Ladeinfrastruktur, Parkraum und Verkehrswende.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verkehrsowi-verteidiger/.claude-plugin/plugin.json
+++ b/verkehrsowi-verteidiger/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verkehrsowi-verteidiger",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Freistehendes VerkehrsOWi-Plugin für Bußgeldbescheid, Anhörung, Einspruch, Punkte, Fahrverbot, Rotlicht, Geschwindigkeit, Abstand, Handy, Alkohol, Drogen, Akteneinsicht, Messakte, Zeugenstrategie und Amtsgericht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verlagsredaktion/.claude-plugin/plugin.json
+++ b/verlagsredaktion/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verlagsredaktion",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Verlegerischer Redaktionsassistent fuer juristische Verlage und Autoren. Macht aus disparaten Inputs ein Rohmanuskript fuer Aufsatz Kommentar oder Buchkapitel. Editionssystem ueberarbeitet umgliedert verdichtet erkennt Widersprueche. Hauszitierweise mit Pinpoint-Randnummer.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/vertragsausfueller/.claude-plugin/plugin.json
+++ b/vertragsausfueller/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vertragsausfueller",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Freistehendes Vertragsausfüller-Plugin: DOCX-Vorlagen und Altverträge strippen, Felder erkennen, Term Sheets mappen, Rückfragen führen, neue Verträge erzeugen und Track-Changes-Fassungen nur nach ausdrücklicher Nachfrage vorbereiten.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/vertragsrecht/.claude-plugin/plugin.json
+++ b/vertragsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vertragsrecht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Vertragsrecht – Lieferanten- und Vertriebsverträge, AGB §§ 305 ff. BGB, NDA, SaaS-/MSA-Review, Renewal-Tracking, Eskalations-Routing, Business-Zusammenfassungen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/wandeldarlehen-lebenszyklus/.claude-plugin/plugin.json
+++ b/wandeldarlehen-lebenszyklus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wandeldarlehen-lebenszyklus",
   "displayName": "Wandeldarlehen-Lebenszyklus (Erstellung bis Cap-Table)",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Begleitet den vollstaendigen Lebenszyklus eines Wandeldarlehens fuer GmbH und UG: Vertragserstellung (bilingual/einsprachig), Beurkundungspruefung, Wandelereignisse, Wandlungsberechnung, Cap-Table-Update, Gesellschafterbeschluss und Notar-Paket.",
   "author": {
     "name": "Klotzkette"

--- a/zitierweise-deutsches-recht/.claude-plugin/plugin.json
+++ b/zitierweise-deutsches-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zitierweise-deutsches-recht",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Deutsche juristische Zitierweise v3.0. Rspr. mit Az.-Marker Datum Aktenzeichen Fundstelle Rn. Kommentar mit Bearbeiter Werk Auflage Jahr Rn. Verlag bei Monographien. Diss. Habil. mit Hochschulort. Reihenfolge erst Gerichtshierarchie dann Zeit oder Relevanz. Palandt heißt seit 2022 Grüneberg.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/zwangsverwaltung-zvg/.claude-plugin/plugin.json
+++ b/zwangsverwaltung-zvg/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zwangsverwaltung-zvg",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Freistehendes ZVG-Plugin für Zwangsverwaltung und Versteigerung: Beschlagnahme, Besitz, Mieten, Treuhandkonto, Berichte, Verteilung, ZVG-Portal-Recherche, Bieterangebote und Versteigerungsteilnahme.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/zwangsvollstreckung/.claude-plugin/plugin.json
+++ b/zwangsvollstreckung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zwangsvollstreckung",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Plugin Zwangsvollstreckung §§ 704 ff. ZPO: Mahn-/Vollstreckungsbescheid, PfÜB Bank/Arbeit, § 802l Kontensuche, Vermögensauskunft, Räumung, § 800 ZPO Notar, § 201 InsO, ZVG, EU-Kontenpfändung VO 655/2014, § 765a Härtefall, Schuldnerschutz.",
   "license": "Apache-2.0 OR MIT",
   "author": {


### PR DESCRIPTION
## Release v10.0.0

Versions-Bump aller 98 plugin.json und `.claude-plugin/marketplace.json` von 9.0.0 auf 10.0.0.

## Codex-Befunde (5 Stueck)

**P1 Familienrecht** — `fachanwalt-familienrecht-mediation-156-famfg-cochemer`
§ 165 FamFG (Vermittlungsverfahren bei Umgangsverweigerung, Termin binnen 1 Monat) als Pfad 6 ergaenzt — niedrigschwellig vor § 89 FamFG-Ordnungsmittel.

**P1 Arbeitsrecht** — `fachanwalt-arbeitsrecht-verhandlung-guete-abfindung-arbg`
§ 9 KSchG (Aufloesungsantrag bei Unzumutbarkeit) und § 10 KSchG (Abfindungsobergrenzen 12 / 15 / 18 Monatsverdienste) sauber getrennt — vorher gemeinsam pauschal zitiert.

**P1 Vergaberecht** — `fachanwalt-vergaberecht-vk-aufklaerung-vergleich`
§ 156 GWB ist nicht Suspensiveffekt sondern Vergabekammern. § 169 GWB (Suspensiveffekt/Zuschlagsverbot) und § 160 GWB (Ruegeobliegenheit) ergaenzt.

**P1 Versicherungsrecht** — `fachanwalt-versicherungsrecht-ombudsmann-gdv-schlichtung`
EU-ODR-Plattform VO 524/2013 wurde zum 20.7.2025 abgeschaltet (VO (EU) 2024/3228). Pfad 4 EU-ODR entfernt, frueherer Pfad 5 Sachverstaendigen-Verfahren ist jetzt Pfad 4. Description und Quellen aktualisiert.

**P2 Verkehrsrecht** — `fachanwalt-verkehrsrecht-versicherer-quotenverhandlung-vergleich`
§ 250 ZPO (Aussetzung) ist keine Vergleichsgrundlage. Ersetzt durch § 278 ZPO (Abs. 2 Gueteverhandlung, Abs. 6 schriftlicher Vergleich) und § 160 Abs. 3 Nr. 1 ZPO (Protokollvergleich).

## Validator

`node scripts/validate-plugin-structure.mjs` → 72 quote-description-Altlasten aus PR #101, **keine neuen Fehler**.