### PR TITLE
qa: 7 broken Slug-Cross-Refs korrigieren

### DIFF
--- a/fachanwalt-agrarrecht/skills/fachanwalt-agrarrecht-wolfsentnahme-genehmigung-bnatschg/SKILL.md
+++ b/fachanwalt-agrarrecht/skills/fachanwalt-agrarrecht-wolfsentnahme-genehmigung-bnatschg/SKILL.md
@@ -102,7 +102,7 @@ Antrag eines Tierhalters (Schäfer, Rinderhalter, Hobbyhalter) auf Erteilung ein
 ## Querverweise
 
 - `fachanwalt-agrarrecht-orientierung` — allgemeine Triage
-- `fachanwalt-verwaltungsrecht-eilantrag-80-abs-5-vwgo` — Eilrechtsschutz bei Ablehnung
+- `eilantrag-80-abs-5-vwgo` — Eilrechtsschutz bei Ablehnung
 - `fachanwalt-verwaltungsrecht-widerspruchsschrift` — Widerspruch gegen Ablehnung
 
 ## Quellen und Updates

--- a/fachanwalt-agrarrecht/skills/mandat-triage-agrarrecht/SKILL.md
+++ b/fachanwalt-agrarrecht/skills/mandat-triage-agrarrecht/SKILL.md
@@ -101,7 +101,7 @@ Agrarrecht-Mandate sind oft saisonal und förderrechtlich fristbeladen. Triage s
 | Jagdpacht | (Skill jagdrecht — perspektivisch) |
 | Genossenschaft | weiter an `gesellschaftsrecht`-Plugin |
 | Strafverfahren TierSchG | weiter an `mandat-triage-strafrecht` |
-| Hofübergabe steuerlich | weiter an `mandat-triage-steuerrecht` plus ErbSt |
+| Hofübergabe steuerlich | weiter an `anw-mandat-triage-steuerrecht` plus ErbSt |
 
 ## Mandatsannahme
 

--- a/fachanwalt-bau-architektenrecht/skills/fachanwalt-bau-architektenrecht-bautraeger-insolvenz/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/fachanwalt-bau-architektenrecht-bautraeger-insolvenz/SKILL.md
@@ -145,5 +145,5 @@ Mandate von Erwerbern bei Bauträger-Insolvenz — Sicherheiten, Vormerkung, San
 ## Anschluss
 
 - `insolvenzforderungsanmeldungspruefung` — bei Tabellenanmeldung
-- `fachanwalt-insolvenz-sanierungsrecht-anfechtungsklage` — bei InsO-Anfechtung
+- `fachanwalt-insolvenz-sanierungsrecht-anfechtungsklage-verwalter` — bei InsO-Anfechtung
 - `fachanwalt-bau-architektenrecht-abnahme-verweigerung` — bei Mangel-Konstellation

--- a/fachanwalt-erbrecht/skills/mandat-triage-erbrecht/SKILL.md
+++ b/fachanwalt-erbrecht/skills/mandat-triage-erbrecht/SKILL.md
@@ -88,7 +88,7 @@ Erbrechtsmandate sind zeitkritisch (Ausschlagungsfrist) und psychologisch sensib
 | Testamentsanfechtung | (Skill testamentsanfechtung — perspektivisch) |
 | Erbauseinandersetzung | (Skill erbauseinandersetzung — perspektivisch) |
 | Ausschlagung überschuldet | (Skill ausschlagung-nachlassinsolvenz — perspektivisch) |
-| Erbschaftsteuer | weiter an `mandat-triage-steuerrecht` ErbSt-Spezifikum |
+| Erbschaftsteuer | weiter an `anw-mandat-triage-steuerrecht` ErbSt-Spezifikum |
 | Testamentsvollstreckung | (Skill testamentsvollstreckung — perspektivisch) |
 
 ## Mandatsannahme

--- a/fachanwalt-medizinrecht/skills/fachanwalt-medizinrecht-off-label-use-erstattung-gkv-long-covid/SKILL.md
+++ b/fachanwalt-medizinrecht/skills/fachanwalt-medizinrecht-off-label-use-erstattung-gkv-long-covid/SKILL.md
@@ -106,7 +106,7 @@ Voraussetzungen:
 ## Querverweise
 
 - `fachanwalt-medizinrecht-orientierung` — Triage
-- `fachanwalt-sozialrecht-long-covid-bk-3101-anerkennung-bg` — Berufskrankheit-Parallelpfad
+- `fachanwalt-sozialrecht-long-covid-bk-anerkennung-bg` — Berufskrankheit-Parallelpfad
 - `fachanwalt-sozialrecht-gdb-schwerbehinderung` — bei GdB-Antrag
 
 ## Quellen und Updates

--- a/fachanwalt-migrationsrecht/skills/fachanwalt-migrationsrecht-geas-reform-grenzverfahren-2024/SKILL.md
+++ b/fachanwalt-migrationsrecht/skills/fachanwalt-migrationsrecht-geas-reform-grenzverfahren-2024/SKILL.md
@@ -175,7 +175,7 @@ Mit freundlichen Gruessen
 
 - `fachanwalt-migrationsrecht-orientierung` — Triage
 - `fachanwalt-migrationsrecht-asyl-folgeantrag-71` — bei Folgeantrag
-- `fachanwalt-verwaltungsrecht-eilantrag-80-abs-5-vwgo` — Eil-Verfahren
+- `eilantrag-80-abs-5-vwgo` — Eil-Verfahren
 
 ## Quellen und Updates
 

--- a/fachanwalt-verwaltungsrecht/skills/mandat-triage-verwaltungsrecht/SKILL.md
+++ b/fachanwalt-verwaltungsrecht/skills/mandat-triage-verwaltungsrecht/SKILL.md
@@ -86,7 +86,7 @@ Verwaltungsrecht ist hochheterogen — vom Bauantrag bis zur Asylklage. Triage o
 | Schule Versetzung Zulassung | `widerspruch-oder-klage-erstpruefung` |
 | Asyl Ausländerrecht | weiter an `mandat-triage-migrationsrecht` |
 | Sozialleistung | weiter an `mandat-triage-sozialrecht` |
-| Steuerrecht | weiter an `mandat-triage-steuerrecht` |
+| Steuerrecht | weiter an `anw-mandat-triage-steuerrecht` |
 | Polizei-Maßnahme | (Skill polizei-feststellungs-klage — perspektivisch) |
 | Versammlungs-Verbot | `widerspruch-oder-klage-erstpruefung` plus § 80 Abs. 5 VwGO |
 


### PR DESCRIPTION
Im Rahmen der Qualitätsüberprüfung 7 Cross-References gefunden, die ins Leere zeigten — Slug-Tippfehler. Korrigiert auf die tatsächlich existierenden Skill-Slugs.