### PR TITLE
feat(v29.0.1): EU-RL-Bloecke, GVG-Korrektur, Mietpreisbremse-Verlaengerung

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -40,7 +40,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "28.0.0"
+      "version": "29.0.1"
     },
     {
       "name": "arbeitszeugnis-analyse",
@@ -193,7 +193,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "28.0.0"
+      "version": "29.0.1"
     },
     {
       "name": "fachanwalt-bank-kapitalmarktrecht",
@@ -678,7 +678,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "29.0.0"
+      "version": "29.0.1"
     },
     {
       "name": "nachbarschaftsstreit-pruefer",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# v29.0.1 — EU-Richtlinien-Nachzug, GVG-Streitwert ab 01.01.2026, Mietpreisbremse-Verlaengerung
+
+- **EU-Lohntransparenzrichtlinie 2023/970 nachgetragen** in `arbeitsrecht/skills/bag-equal-pay-paarvergleich-8azr30024/SKILL.md` und `fachanwalt-arbeitsrecht/skills/fachanwalt-arbeitsrecht-bag-equal-pay-paarvergleich/SKILL.md`. Neue Bloecke fassen Art. 5 (vorvertragliche Transparenz, Verbot Gehaltshistorie), Art. 7 (Auskunft binnen zwei Monaten), Art. 9 (Berichtspflichten ab 250 / 150 / 100 Beschaeftigten), Art. 10 (gemeinsame Bewertung ab fuenf Prozent Gefaelle), Art. 16 (Schadensersatz ohne Obergrenze), Art. 18 (Beweislastumkehr bei Pflichtverletzung) und Art. 21 (Verjaehrung mindestens drei Jahre) zusammen. Umsetzungsfrist 07.06.2026; nationale Umsetzung steht zum Stand Mai 2026 noch aus. Quelle: https://eur-lex.europa.eu/eli/dir/2023/970/oj
+- **EU-Plattformarbeitsrichtlinie 2024/2831 ausgearbeitet** in `arbeitsrecht/skills/arbeitnehmer-status/SKILL.md`. Einzeiler aus v29 ersetzt durch ausgearbeiteten Block mit Vermutungsregel zugunsten des Beschaeftigungsverhaeltnisses, Beweislastumkehr und Umsetzungsfrist 02.12.2026. Quelle: https://eur-lex.europa.eu/eli/dir/2024/2831/oj
+- **Mindestlohn ab 01.01.2026 / 01.01.2027 verifiziert** mit Fundstelle Fuenfte MindestlohnAnpassungsverordnung vom 05.11.2025, BGBl. 2025 I Nr. 268 — in `arbeitsrecht/skills/allgemein/SKILL.md` und `arbeitsrecht/skills/mindestlohn-arbeitszeit-erfassung/SKILL.md`. 13,90 EUR ab 01.01.2026; 14,60 EUR ab 01.01.2027.
+- **GVG-Streitwertgrenze korrigiert** in `mietrecht/skills/klageentwurf-amtsgericht/SKILL.md`. Frontmatter und Body benennen jetzt das Gesetz zur Staerkung der Amtsgerichte in Zivilsachen (Bundesrat-Billigung 21.11.2025, Inkrafttreten 01.01.2026) statt der falschen "Justizmodernisierung 2024". Anwaltszwang ebenfalls ab zehntausend Euro; Berufungsbeschwer in § 511 Abs. 2 Nr. 1 ZPO von 600 auf 1.000 Euro angehoben. Uebergangsregelung: vor 01.01.2026 anhaengige Verfahren bleiben bei fünftausend Euro. Quelle: BRAK-Nachrichten 24/2025 vom 26.11.2025.
+- **BGH-Rechtsprechung zur Zahlungsverzugskuendigung ergaenzt** in `mietrecht/skills/mahnung-zahlungsverzug-mieter/SKILL.md`: BGH, Urt. v. 01.07.2020 – VIII ZR 323/18 (Schonfristzahlung beseitigt nur die fristlose Kuendigung, hilfsweise ordentliche bleibt wirksam; § 574 Abs. 1 Satz 2 BGB ausgeschlossen) und BGH, Beschl. v. 08.12.2021 – VIII ZR 32/20 (Erheblichkeit nach § 573 Abs. 2 Nr. 1 BGB anhand der Gesamthoehe des Rueckstands). VIII ZR 287/23 vom 09.07.2025 aus v29 unveraendert erhalten.
+- **Mietpreisbremse-Verlaengerung dokumentiert** in `mietrecht/skills/mietspiegel-quellen/SKILL.md`. Neuer Block zum Verlaengerungsgesetz vom 17.07.2025 (BGBl. 2025 I Nr. 163, § 556d Abs. 2 Satz 4 BGB bis 31.12.2029) sowie BVerfG-Nichtannahmebeschluss vom 08.01.2026 – 1 BvR 183/25 (Verfassungsbeschwerde gegen die Verlaengerung erfolglos; Bestaetigung der Linie aus 1 BvL 1/18).
+- **Versionsbump.** `arbeitsrecht`, `fachanwalt-arbeitsrecht` und `mietrecht` auf `29.0.1` in `<plugin>/.claude-plugin/plugin.json` und in `.claude-plugin/marketplace.json`.
+
+## Qualitätssicherung
+
+- `node scripts/validate-plugin-structure.mjs` — OK
+- `python3 scripts/validate-yaml-frontmatter.py` — 0 Fehler, 0 Warnungen
+- `python3 /tmp/welle5_komma_check.py` — 0 Treffer
+
+---
+
 # v24.2.0 — References-Einzelfix und UNVERIFIABLE-Online-Check
 
 - **Welle 5 — References-Einzelfix.** Die 16 in v24.1.0 noch offenen toten `references/`-Verweise einzeln durchgegangen. 14 waren falsch-positiv (Aufloesungspfade, ASCII-Tree-Beispiele, generierte Skills). 1 echter Bug gefixt: `produktrecht/skills/produktrecht-kaltstart-interview` verwies auf `references/launch-pruefung-framework-de.md`, korrigiert auf den realen Pfad `produktrecht/skills/launch-pruefung/references/seven-category-framework.md`. 2 Laufzeit-Cache-Verweise (`kanzlei-builder-hub`: `registry-cache.json`, `surfaced.json`) durch leere `references/`-Verzeichnisse mit `README.md`-Hinweis dokumentiert.

--- a/arbeitsrecht/.claude-plugin/plugin.json
+++ b/arbeitsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "arbeitsrecht",
-  "version": "28.0.0",
+  "version": "29.0.1",
   "description": "Arbeitsrechtliche Workflows fuer Kuendigung, Befristung, Urlaub, AGG, Aufhebungsvertrag, Betriebsrat, Arbeitszeit, Lohn und Expansion. Rechtsprechung wird nur mit Gericht, Datum, Aktenzeichen und verifizierbarer Quelle verwendet.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/arbeitsrecht/skills/allgemein/SKILL.md
+++ b/arbeitsrecht/skills/allgemein/SKILL.md
@@ -373,5 +373,7 @@ Das Plugin richtet sich an Kanzleien und Syndikusrechtsanwaelte, die sowohl Arbe
 - BAG, 13.09.2022 - 1 ABR 22/21 (Arbeitszeiterfassung) - dejure.org-Vernetzung
 - BAG, 22.09.2022 - 8 AZR 4/21 (NachweisG-Schadensersatz) - dejure.org-Vernetzung
 - BSG, 12.07.2006 - B 11a AL 47/05 R (Sperrzeit-Vermeidung) - dejure.org-Vernetzung
-- Mindestlohn: 12,82 EUR ab 01.01.2025; **13,90 EUR ab 01.01.2026**; 14,60 EUR ab 01.01.2027 (vorgesehen, Fuenfte Mindestlohnanpassungsverordnung) - Quelle: bundesregierung.de / bmas.de
+- Mindestlohn: 12,82 EUR ab 01.01.2025; **13,90 EUR ab 01.01.2026**; 14,60 EUR ab 01.01.2027 (Fuenfte Mindestlohnanpassungsverordnung vom 05.11.2025, BGBl. 2025 I Nr. 268) - Quelle: bundesregierung.de / bmas.de
 - Minijob-Grenze 2026: 603 EUR / Monat - Quelle: Deutsche Rentenversicherung Baden-Wuerttemberg
+- EU-Plattformarbeitsrichtlinie 2024/2831 (ABl. L vom 11.11.2024) - Umsetzungsfrist 02.12.2026: widerlegbare gesetzliche Vermutung eines Arbeitsverhaeltnisses bei Plattformarbeit; Beweislast bei der Plattform; Regelungen zum algorithmischen Management; Umsetzung in deutsches Recht steht aus - Quelle: eur-lex.europa.eu (CELEX 32024L2831)
+- EU-Lohntransparenzrichtlinie 2023/970 (ABl. L 132 vom 17.05.2023) - Umsetzungsfrist 07.06.2026: Auskunftsanspruch zu individuellen und durchschnittlichen Entgelthoehen; Pflicht zur Angabe von Einstiegsentgelt oder Spanne in Stellenausschreibungen; Verbot der Frage nach Gehaltshistorie; Beweislastumkehr bei Verletzung von Transparenzpflichten; Berichterstattung ab 250 Beschaeftigten ab 07.06.2027 jaehrlich; Umsetzung in deutsches Recht steht aus - Quelle: eur-lex.europa.eu (CELEX 32023L0970)

--- a/arbeitsrecht/skills/arbeitnehmer-status/SKILL.md
+++ b/arbeitsrecht/skills/arbeitnehmer-status/SKILL.md
@@ -39,7 +39,14 @@ Bevor losgelegt wird, kläre:
 ## Aktuelle Rechtsprechung
 
 - **BAG, Urteil vom 01.12.2020 - 9 AZR 102/20** (Crowdworker / Plattformarbeit): Auch ein Crowdworker, der ueber eine Smartphone-App Mikroauftraege erfuellt, kann Arbeitnehmer sein, wenn die organisatorische Einbindung (z.B. Anreizsystem mit Stufen / Level / Bewertung) ihn zur staendigen Auftragsannahme veranlasst und faktisch fremdbestimmte Arbeit erzwingt. Eine starre vertragliche Bezeichnung ist unerheblich; entscheidend ist die tatsaechliche Durchfuehrung. Quelle: dejure.org-Vernetzung BAG 01.12.2020 - 9 AZR 102/20.
-- Hinweis: BAG hat den Crowdworker-Status seitdem nicht generell ausgeweitet, jeder Einzelfall ist anhand der typusbildenden Merkmale (Weisungsgebundenheit, persoenliche Abhaengigkeit, Fremdbestimmung) zu pruefen. EuGH-Plattformarbeitsrichtlinie (RL 2024/2831) ist mit Umsetzungsfrist bis Dez. 2026 zu beobachten.
+- Hinweis: BAG hat den Crowdworker-Status seitdem nicht generell ausgeweitet, jeder Einzelfall ist anhand der typusbildenden Merkmale (Weisungsgebundenheit, persoenliche Abhaengigkeit, Fremdbestimmung) zu pruefen.
+- **EU-Plattformarbeitsrichtlinie (EU) 2024/2831 vom 23.10.2024** (ABl. L vom 11.11.2024; CELEX 32024L2831) - Umsetzungsfrist 02.12.2026:
+  - **Widerlegbare gesetzliche Vermutung** eines Arbeitsverhaeltnisses (Art. 5): liegen Tatsachen vor, die auf Steuerung und Kontrolle hindeuten, wird ein Arbeitsverhaeltnis vermutet; **die Beweislast fuer das Nichtbestehen liegt bei der digitalen Arbeitsplattform**; gilt nur fuer Zeitraeume ab 02.12.2026 (keine Rueckwirkung).
+  - **Algorithmisches Management (Kapitel III)**: Verbot der Verarbeitung bestimmter Daten (emotionaler Zustand, Privatgespraeche, Gewerkschaftszugehoerigkeit, sensible Merkmale, biometrische Identifizierung); Pflicht zur Datenschutz-Folgenabschaetzung mit Einbindung der Beschaeftigtenvertreter; Transparenzpflicht ueber Einsatz und Funktionsweise automatisierter Systeme.
+  - **Menschliche Aufsicht**: Entscheidungen ueber **Kontosperrung oder Vertragsbeendigung** muessen zwingend von einem Menschen getroffen werden; Recht auf Erklaerung und Ueberpruefung automatisierter Entscheidungen innerhalb von zwei Wochen.
+  - **Anwendungsbereich**: gilt fuer Plattformarbeitende mit Arbeitsvertrag/Arbeitsverhaeltnis; Vorschriften zum algorithmischen Management auch fuer Personen ohne Arbeitsvertrag.
+  - Umsetzung in deutsches Recht (vermutlich Aenderung BGB, BetrVG, NachweisG) steht aus; Praxis sollte im Mandat bereits ab 2026 die Vermutungsregel mitdenken.
+  - Quelle: eur-lex.europa.eu - https://eur-lex.europa.eu/eli/dir/2024/2831/oj
 - Aktualisierungen vor Schriftsatzverwendung in offenen Quellen (dejure.org, openjur.de, bundesarbeitsgericht.de, bundessozialgericht.de) pruefen.
 
 ## Quellenregel

--- a/arbeitsrecht/skills/bag-equal-pay-paarvergleich-8azr30024/SKILL.md
+++ b/arbeitsrecht/skills/bag-equal-pay-paarvergleich-8azr30024/SKILL.md
@@ -49,6 +49,20 @@ Tragender Punkt: Nach BAG 23.10.2025 - 8 AZR 300/24 genuegt ein Paarvergleich mi
 
 Der Anspruch richtet sich auf Entgeltnachzahlung für den Differenzbetrag (Paragraf 3 Absatz 1, Paragraf 7 EntgTranspG, Paragraf 611a BGB). Zusätzlich kommt Entschädigung nach Paragraf 15 Absatz 2 AGG in Betracht. Die Geltendmachungsfrist nach Paragraf 15 Absatz 4 AGG (zwei Monate) ist zu beachten, betrifft aber nur die Entschädigung, nicht den Anspruch auf gleiches Entgelt.
 
+## Ausblick EU-Lohntransparenzrichtlinie 2023/970
+
+Die Richtlinie (EU) 2023/970 des Europäischen Parlaments und des Rates vom 10. Mai 2023 zur Staerkung der Anwendung des Grundsatzes des gleichen Entgelts fuer Maenner und Frauen bei gleicher oder gleichwertiger Arbeit durch Entgelttransparenz und Durchsetzungsmechanismen (ABl. L 132 vom 17.05.2023, S. 21) ist bis zum 07. Juni 2026 in deutsches Recht umzusetzen. Nationale Umsetzung steht zum Stand Mai 2026 noch aus; ein Referentenentwurf zur Aenderung des EntgTranspG ist angekuendigt. Praxisrelevante Pflichten der Richtlinie:
+
+- Art. 5 — Vorvertragliche Entgelttransparenz: Bewerber haben Anspruch auf Information ueber das Einstiegsentgelt oder dessen Spanne; Verbot, nach der bisherigen Gehaltshistorie zu fragen.
+- Art. 7 — Auskunftsanspruch der Beschaeftigten ueber das eigene Entgelt und das durchschnittliche Entgelt nach Geschlecht fuer gleiche oder gleichwertige Arbeit; Antwort binnen zwei Monaten.
+- Art. 9 — Berichtspflicht des Arbeitgebers ueber das geschlechtsspezifische Entgeltgefaelle: Arbeitgeber ab 250 Beschaeftigten jaehrlich, ab 150 alle drei Jahre, ab 100 alle drei Jahre (nach Uebergangsfristen).
+- Art. 10 — Gemeinsame Entgeltbewertung mit Arbeitnehmervertretung, wenn das Entgeltgefaelle bei einer Arbeitnehmerkategorie mindestens fuenf Prozent betraegt und nicht durch geschlechtsneutrale Faktoren erklaerbar ist.
+- Art. 16 — Schadensersatz ohne Obergrenze; volle Wiedergutmachung einschliesslich entgangenem Entgelt, Boni und Sachleistungen.
+- Art. 18 — Beweislastumkehr zu Lasten des Arbeitgebers, sobald dieser Transparenzpflichten verletzt hat.
+- Art. 21 — Verjaehrungsfrist mindestens drei Jahre ab Kenntnis der Diskriminierung.
+
+Quelle: https://eur-lex.europa.eu/eli/dir/2023/970/oj — vor Beratung ueberpruefen, ob das Umsetzungsgesetz inzwischen verkuendet ist.
+
 ## Anschluss
 
 In Kombination mit `agg-pruefung-bewerber-und-beschaeftigte` für die generelle AGG-Prüfung und `mandat-triage-arbeitsrecht` für die Mandatsaufnahme. Zur Geltendmachung im Prozess die Hinweise aus `kueschk-klageschrift-anwalt-baustein` analog für die Equal-Pay-Klage anwenden.

--- a/arbeitsrecht/skills/mindestlohn-arbeitszeit-erfassung/SKILL.md
+++ b/arbeitsrecht/skills/mindestlohn-arbeitszeit-erfassung/SKILL.md
@@ -89,8 +89,8 @@ Rechtsprechung: keine Entscheidung aus Modellwissen zitieren; vor Ausgabe über 
 |---|---|---|
 | 1.1.2024 | EUR 12,41 | Vierte Mindestlohnanpassungsverordnung |
 | 1.1.2025 | EUR 12,82 | Vierte Mindestlohnanpassungsverordnung |
-| 1.1.2026 | EUR 13,90 | Fuenfte Mindestlohnanpassungsverordnung (Bundeskabinett 2025) |
-| 1.1.2027 | EUR 14,60 (vorgesehen) | Fuenfte Mindestlohnanpassungsverordnung |
+| 1.1.2026 | EUR 13,90 | Fuenfte Mindestlohnanpassungsverordnung vom 05.11.2025 (BGBl. 2025 I Nr. 268) |
+| 1.1.2027 | EUR 14,60 | Fuenfte Mindestlohnanpassungsverordnung vom 05.11.2025 (BGBl. 2025 I Nr. 268) |
 | Kuenftig | Empfehlung der Mindestlohn-Kommission, Umsetzung durch Verordnung BMAS | § 11 MiLoG |
 
 Quelle: bundesregierung.de / bmas.de (Pressemitteilung "Mindestlohn steigt zum 1. Januar 2026 auf 13,90 Euro"). Die Minijob-Verdienstgrenze passt sich an: 2026 = 603 EUR (Deutsche Rentenversicherung Baden-Wuerttemberg, Pressemitteilung 22.12.2025).

--- a/fachanwalt-arbeitsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-arbeitsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-arbeitsrecht",
-  "version": "28.0.0",
+  "version": "29.0.1",
   "description": "Fachanwalt-Arbeitsrecht nach FAO Paragraf 10: KSchG, BetrVG, TzBfG, AGG, EntgTranspG, Urlaub, Betriebsrat, Befristung und Vergleichspraxis. Rechtsprechung nur mit Datum, Aktenzeichen und verifizierter Quelle.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-arbeitsrecht/skills/fachanwalt-arbeitsrecht-bag-equal-pay-paarvergleich/SKILL.md
+++ b/fachanwalt-arbeitsrecht/skills/fachanwalt-arbeitsrecht-bag-equal-pay-paarvergleich/SKILL.md
@@ -67,6 +67,20 @@ Verbindung mit `fachanwalt-arbeitsrecht-orientierung` zur Mandatsaufnahme. Bei z
 
 - Rechtsprechung: keine Entscheidung aus Modellwissen zitieren; vor Ausgabe über offizielle oder frei zugängliche Quelle mit Gericht, Entscheidungsform, Datum, Aktenzeichen und tragender Aussage verifizieren.
 
+## EU-Lohngerechtigkeitsrichtlinie 2023/970 (Umsetzungsfrist 07.06.2026)
+
+Die Richtlinie (EU) 2023/970 vom 10. Mai 2023 (ABl. L 132 vom 17.05.2023, S. 21) verpflichtet die Mitgliedstaaten zur Umsetzung bis zum 07. Juni 2026. Die nationale Umsetzung in deutsches Recht steht zum Stand Mai 2026 noch aus. Beratungsrelevante Pflichten:
+
+- Art. 5 — Vorvertragliche Entgelttransparenz: Auskunftspflicht des Arbeitgebers ueber Einstiegsgehalt oder Gehaltsspanne; Verbot, Bewerber nach der Gehaltshistorie zu fragen.
+- Art. 7 — Individueller Auskunftsanspruch ueber Durchschnittsentgelt nach Geschlecht fuer gleiche oder gleichwertige Arbeit; Frist zwei Monate.
+- Art. 9 — Berichtspflicht ueber das geschlechtsspezifische Entgeltgefaelle: ab 250 Beschaeftigten jaehrlich, ab 150 alle drei Jahre, ab 100 alle drei Jahre (gestaffelte Uebergangsfristen).
+- Art. 10 — Gemeinsame Entgeltbewertung mit Arbeitnehmervertretung bei einem Entgeltgefaelle ab fuenf Prozent ohne sachliche Rechtfertigung.
+- Art. 16 — Schadensersatz ohne Obergrenze; volle Wiedergutmachung.
+- Art. 18 — Beweislastumkehr zu Lasten des Arbeitgebers bei Verletzung der Transparenzpflichten.
+- Art. 21 — Verjaehrungsfrist mindestens drei Jahre ab Kenntnis.
+
+Praxishinweis: Mandanten auf Geltungszeitpunkt hinweisen — unmittelbare Wirkung der Richtlinie greift nach Ablauf der Umsetzungsfrist, soweit Bestimmungen hinreichend bestimmt sind; richtlinienkonforme Auslegung des EntgTranspG ab Stichtag pruefen. Quelle: https://eur-lex.europa.eu/eli/dir/2023/970/oj
+
 ## Paragrafenkette
 
 - Art. 157 AEUV — Gleiches Entgelt für gleiche Arbeit

--- a/mietrecht/.claude-plugin/plugin.json
+++ b/mietrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mietrecht",
-  "version": "29.0.0",
+  "version": "29.0.1",
   "description": "Mietrecht für Mieter und Vermieter mit ausschließlich amtlichen Mietspiegel-Quellen pro Bundesland und für Top- und Universitaetsstaedte. Datenerhebung Mieterhoehungs-Widerspruch Mietsenkungsverlangen Nebenkostenprüfung und Erstellung Mieteranfragen Klageentwurf zum Amtsgericht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/mietrecht/skills/klageentwurf-amtsgericht/SKILL.md
+++ b/mietrecht/skills/klageentwurf-amtsgericht/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: klageentwurf-amtsgericht
-description: Beide Rollen — entwirf eine Klageschrift zum Amtsgericht in einer Mietsache. Sachliche Zuständigkeit für Wohnraummietsachen nach § 23 Nr. 2a GVG ohne Rücksicht auf den Streitwert; bei Geschäftsraummiete allgemeine AG-Grenze nach § 23 Nr. 1 GVG (zehntausend Euro seit Reform 2024). Örtliche Zuständigkeit am Belegenheitsort der Mietsache (§ 29a ZPO). Streitwertberechnung Anträge Sachverhalt rechtliche Würdigung Beweisangebote und formgerechte Anlagen. Kein Anwaltszwang vor dem Amtsgericht aber dringende Empfehlung anwaltlicher Prüfung. Disclaimer mehrfach.
+description: Beide Rollen — entwirf eine Klageschrift zum Amtsgericht in einer Mietsache. Sachliche Zuständigkeit für Wohnraummietsachen nach § 23 Nr. 2a GVG ohne Rücksicht auf den Streitwert; bei Geschäftsraummiete allgemeine AG-Grenze nach § 23 Nr. 1 GVG zehntausend Euro ab 01.01.2026 durch das Gesetz zur Stärkung der Amtsgerichte in Zivilsachen; davor fünftausend Euro. Örtliche Zuständigkeit am Belegenheitsort der Mietsache (§ 29a ZPO). Streitwertberechnung Anträge Sachverhalt rechtliche Würdigung Beweisangebote und formgerechte Anlagen. Kein Anwaltszwang vor dem Amtsgericht aber dringende Empfehlung anwaltlicher Prüfung. Disclaimer mehrfach.
 ---
 
 # Klageentwurf zum Amtsgericht (Mietsache)
@@ -14,7 +14,7 @@ Eine Klageschrift ist ein Rechtsschriftsatz mit erheblichen Konsequenzen (Gerich
 ### Schritt 1 — Sachliche Zuständigkeit
 
 - **Wohnraummietsachen** — Amtsgericht ist nach § 23 Nr. 2a GVG zuständig für Streitigkeiten aus Mietverhältnissen über Wohnraum **ohne Rücksicht auf den Streitwert**.
-- **Geschäftsraummiete** — allgemeine Streitwertgrenze des § 23 Nr. 1 GVG: AG bis **zehntausend Euro** (Erhöhung von zuvor fünftausend Euro durch die Justizmodernisierung 2024); darüber LG (§ 71 GVG).
+- **Geschäftsraummiete** — allgemeine Streitwertgrenze des § 23 Nr. 1 GVG: AG bis **zehntausend Euro** ab dem 01.01.2026 durch das Gesetz zur Stärkung der Amtsgerichte in Zivilsachen (Bundesrat-Billigung 21.11.2025, Inkrafttreten 01.01.2026); darüber LG (§ 71 GVG). Übergangsregelung: Für vor dem 01.01.2026 anhängig gewordene Verfahren bleibt die alte Wertgrenze von fünftausend Euro maßgeblich. Quelle: BRAK-Nachrichten 24/2025 vom 26.11.2025. Anwaltszwang vor dem Landgericht greift ebenfalls erst ab zehntausend Euro Streitwert; die Berufungsbeschwer in § 511 Abs. 2 Nr. 1 ZPO wurde zugleich von 600 Euro auf 1.000 Euro angehoben.
 - Streitwert ist in jedem Fall zu berechnen (für Kosten und Berufungssumme).
 
 ### Schritt 2 — Örtliche Zuständigkeit (§ 29a ZPO)

--- a/mietrecht/skills/mahnung-zahlungsverzug-mieter/SKILL.md
+++ b/mietrecht/skills/mahnung-zahlungsverzug-mieter/SKILL.md
@@ -89,6 +89,8 @@ Vor Versand der fristlosen Kündigung: fachanwaltliche Prüfung der Rückstandsb
 ## Aktuelle Rechtsprechung — Leitsaetze
 
 - BGH, Urt. v. 09.07.2025 – Az. VIII ZR 287/23 — Schonfristzahlung nach § 569 Abs. 3 Nr. 2 BGB heilt nur die fristlose, nicht die ordentliche Kuendigung wegen Zahlungsverzugs. Klarstellung des Streits mit dem LG Berlin II. Folge: Doppelkuendigung (fristlos hilfsweise ordentlich) bleibt die strategisch sichere Loesung fuer den Vermieter. Quelle: https://dejure.org/dienste/vernetzung/rechtsprechung?Gericht=BGH&Datum=09.07.2025&Aktenzeichen=VIII+ZR+287/23
+- BGH, Urt. v. 01.07.2020 – Az. VIII ZR 323/18 — Schonfristzahlung (§ 569 Abs. 3 Nr. 2 BGB) beseitigt nur die fristlose Kuendigung wegen Zahlungsverzugs; eine hilfsweise erklaerte ordentliche Kuendigung nach § 573 Abs. 2 Nr. 1 BGB bleibt wirksam. Ein Ausschluss der Sozialklausel § 574 Abs. 1 Satz 2 BGB greift, weil ein Grund vorliegt, der den Vermieter zur fristlosen Kuendigung berechtigt hätte. Quelle: https://dejure.org/dienste/vernetzung/rechtsprechung?Gericht=BGH&Datum=01.07.2020&Aktenzeichen=VIII+ZR+323/18
+- BGH, Beschl. v. 08.12.2021 – Az. VIII ZR 32/20 — Erheblichkeit des Mietrueckstands im Sinne von § 573 Abs. 2 Nr. 1 BGB; massgeblich ist die Gesamthoehe des Rueckstands, nicht die Aufgliederung in einzelne Monatsbetraege. Bestaetigt die Wertungslinie zur ordentlichen Kuendigung neben der fristlosen. Quelle: https://dejure.org/dienste/vernetzung/rechtsprechung?Gericht=BGH&Datum=08.12.2021&Aktenzeichen=VIII+ZR+32/20
 - Weitere Rechtsprechungslinien des VIII. ZS zu § 543, § 569 BGB vor Ausgabe ueber https://www.bundesgerichtshof.de und https://dejure.org verifizieren.
 
 ## Basiszinssatz § 247 BGB und Verzug

--- a/mietrecht/skills/mietspiegel-quellen/SKILL.md
+++ b/mietrecht/skills/mietspiegel-quellen/SKILL.md
@@ -166,6 +166,13 @@ Der Skill übergibt an `mieterhoehung-pruefen-widersprechen` mit `ergebnis.bewer
 
 Diese Quellensammlung ersetzt keine Rechtsberatung. Sie ist ein Werkzeug zur Recherche amtlicher Quellen. Vor jeder Verwendung den Aktualitätsstand auf der jeweiligen amtlichen Seite prüfen. Die Letztverantwortung für die Anwendung im Einzelfall liegt beim Anwalt.
 
+## Aktueller Gesetzgebungsstand zur Mietpreisbremse (Bund)
+
+- **Verlängerungsgesetz vom 17.07.2025** — BGBl. 2025 I Nr. 163. § 556d Abs. 2 Satz 4 BGB wurde dahingehend geaendert, dass die Ermächtigung der Landesregierungen zum Erlass von Mietpreisbremse-Verordnungen bis zum 31.12.2029 verlängert wurde. Ohne diese Verlängerung wären die Landesverordnungen spätestens Ende 2025 ausgelaufen.
+- **BVerfG, Nichtannahmebeschluss vom 08.01.2026 – Az. 1 BvR 183/25** — Verfassungsbeschwerde gegen die Verlängerung der Mietpreisbremse erfolglos. Das BVerfG hält an seiner Linie aus 1 BvL 1/18 vom 18.07.2019 fest: §§ 556d ff. BGB sind mit Art. 14 GG vereinbar; die Verlängerung ist ein verhältnismässiger Eingriff in die Eigentumsgarantie.
+- **Praxisfolge**: Für Neuvermietungen ab dem 01.01.2026 in Bundesländern mit Mietpreisbremse-Verordnung gilt die Begrenzung auf 110 Prozent der ortsueblichen Vergleichsmiete fort. Vor Beratung pruefen, ob die jeweilige Landesverordnung selbst noch in Kraft ist oder verlängert wurde — die Bundesregelung ermächtigt nur, sie verpflichtet nicht.
+- Quellen: BGBl. 2025 I Nr. 163 — https://www.recht.bund.de/bgbl/1/2025/163 ; BVerfG-Entscheidungssuche — https://www.bundesverfassungsgericht.de/SiteGlobals/Forms/Suche/EN/Entscheidungensuche_Formular.html
+
 ## Aktuelle Rechtsprechung — Leitsaetze Mietspiegel
 
 - Rechtsprechung: keine Entscheidung aus Modellwissen zitieren; vor Ausgabe über offizielle oder frei zugängliche Quelle mit Gericht, Entscheidungsform, Datum, Aktenzeichen und tragender Aussage verifizieren.


### PR DESCRIPTION
Nachzug auf v29: ergaenzt die in v29 noch nicht abgedeckten EU-Richtlinien (Lohntransparenz 2023/970, Plattformarbeit 2024/2831), korrigiert die falsche Begruendung der Amtsgerichts-Streitwertgrenze und dokumentiert die Verlaengerung der Mietpreisbremse.

## Faktische Updates
- EU-Lohntransparenzrichtlinie 2023/970 in beiden bag-equal-pay-Skills (Umsetzungsfrist 07.06.2026)
- EU-Plattformarbeitsrichtlinie 2024/2831 in arbeitnehmer-status (Umsetzungsfrist 02.12.2026)
- Mindestlohn 13,90 EUR ab 01.01.2026 mit BGBl. 2025 I Nr. 268 belegt
- GVG-Streitwertgrenze: 'Gesetz zur Staerkung der Amtsgerichte in Zivilsachen' (01.01.2026) statt 'Justizmodernisierung 2024'
- BGH VIII ZR 323/18 und VIII ZR 32/20 in mahnung-zahlungsverzug-mieter ergaenzt; VIII ZR 287/23 erhalten
- Mietpreisbremse-Verlaengerung BGBl. 2025 I Nr. 163 und BVerfG 1 BvR 183/25 in mietspiegel-quellen

## Versionsbump
arbeitsrecht / fachanwalt-arbeitsrecht / mietrecht -> 29.0.1

## Qualitaetssicherung
- node scripts/validate-plugin-structure.mjs OK
- python3 scripts/validate-yaml-frontmatter.py 0 Fehler 0 Warnungen
- python3 /tmp/welle5_komma_check.py 0 Treffer