### PR TITLE
fix(codex): Cap-Table-Rechnung und Vorzugsrechte-Rechtsgrundlage

### DIFF
--- a/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/02-cap-table-und-gesellschafterliste.md
+++ b/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/02-cap-table-und-gesellschafterliste.md
@@ -71,22 +71,29 @@ Annahmen Szenario 1:
 
 | Position | Anteile vor Series A nach Pool-Shuffle | Prozent pre-money fully diluted | Anteile nach Series A | Prozent post-money fully diluted |
 | --- | ---: | ---: | ---: | ---: |
-| Kunigunde Reiter | 12.000 | 28,8 | 12.000 | 20,4 |
-| Meinhard Voss | 9.000 | 21,6 | 9.000 | 15,3 |
-| Walburga Stein | 6.000 | 14,4 | 6.000 | 10,2 |
-| Stahlauge Ventures GmbH | 3.000 | 7,2 | 3.000 | 5,1 |
-| Option Pool reserviert | 5.000 | 12,0 | 5.000 | 8,5 |
-| Tante Ermelind aus Wandlung | 6.700 | 16,1 | 6.700 | 11,4 |
-| Series A Northbridge | 0 | 0 | 13.640 | 23,2 |
-| Series A Kraemer Angels | 0 | 0 | 1.135 | 1,9 |
-| **Fully Diluted Summe** | **41.700** | **100,00** | **58.475** | **100,00** |
+| Kunigunde Reiter | 12.000 | 28,78 | 12.000 | 20,08 |
+| Meinhard Voss | 9.000 | 21,58 | 9.000 | 15,06 |
+| Walburga Stein | 6.000 | 14,39 | 6.000 | 10,04 |
+| Stahlauge Ventures GmbH | 3.000 | 7,19 | 3.000 | 5,02 |
+| Option Pool reserviert | 5.000 | 11,99 | 5.000 | 8,37 |
+| Tante Ermelind aus Wandlung | 6.700 | 16,07 | 6.700 | 11,21 |
+| Series A Northbridge | 0 | 0 | 16.679 | 27,91 |
+| Series A Kraemer Angels | 0 | 0 | 1.390 | 2,33 |
+| **Fully Diluted Summe** | **41.700** | **100,00** | **59.769** | **100,02** |
+
+Die Summe 100,02 in der letzten Spalte ist ein Rundungsrest aus zwei Nachkommastellen je Zeile und kein Rechenfehler. Im Excel-Modell mit hoeherer Genauigkeit rechnen.
 
 Berechnungslogik (Skizze, Senior-Review erforderlich):
 
 - Bestehende Anteile 30.000.
-- Pool-Reservierung 12 Prozent auf fully diluted **vor** Series A: Pool/(30.000 + Pool + Convertible-Anteile) = 0,12. Mit Convertible-Anteilen ca. 6.700 ergibt sich Pool ca. 5.000 Anteile.
-- Convertible Wandlung zum Valuation Cap 10 Mio. EUR fully diluted: ca. 6.700 Anteile fuer Tante Ermelind.
-- Series-A-Preis ca. 287,80 EUR je Anteil bei 12 Mio. EUR Pre-Money und 41.700 Anteilen fully diluted pre-money. Bei 5,2 Mio. EUR Investment ca. 18.075 zusaetzliche Anteile post-Pool. Aufteilung Northbridge zu Kraemer im Verhaeltnis 4,8 zu 0,4.
+- Pool-Reservierung 12 Prozent auf fully diluted **vor** Series A: Pool / (30.000 + Pool + Convertible-Anteile) = 0,12. Mit Convertible-Anteilen ca. 6.700 ergibt sich Pool ca. 5.000 Anteile (genau 5.005 bei rechnerischer Aufloesung, hier auf 5.000 gerundet).
+- Convertible Wandlung zum Valuation Cap 10 Mio. EUR fully diluted: ca. 6.700 Anteile fuer Tante Ermelind (Principal 600.000 EUR plus aufgelaufene PIK-Zinsen, Cap-Preis liegt unter dem Discount-Preis und greift daher).
+- Pre-Money fully diluted total = 12.000 + 9.000 + 6.000 + 3.000 + 5.000 + 6.700 = 41.700 Anteile.
+- Series-A-Preis pro Anteil = 12.000.000 EUR / 41.700 Anteile = ca. 287,77 EUR.
+- Series-A-Anteile total = 5.200.000 EUR / 287,77 EUR = ca. 18.069 Anteile.
+- Aufteilung Lead vs Co-Investor im Verhaeltnis 4,8 zu 0,4 Mio. EUR (gemaess Subscription-Liste in Datei 03 Ziff. 2): Northbridge 4,8/5,2 x 18.069 = ca. 16.679 Anteile; Kraemer Angels 0,4/5,2 x 18.069 = ca. 1.390 Anteile.
+- Post-money fully diluted total = 41.700 + 18.069 = 59.769 Anteile.
+- Plausibilitaetscheck Northbridge-Quote = 16.679 / 59.769 = ca. 27,9 Prozent, konsistent mit der vom Lead intern kommunizierten Zielquote von rund 25 bis 30 Prozent.
 
 Hinweis: Diese Zahlen sind eine **Skizze**. Die exakten Wandlungs- und Pool-Anteile sind im Excel-Modell auszurechnen. Adelheid hat ausdruecklich verboten, sie ohne Verifikation an Northbridge zu kommunizieren.
 

--- a/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/06-associate-arbeitsstand.md
+++ b/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/06-associate-arbeitsstand.md
@@ -52,7 +52,7 @@ Investor Director Approval: Bei GmbH nicht einfach wie Delaware Board behandeln.
 
 To do: Investor Counsel fragen, ob Series A Preferred Shares echte Anteilsklasse oder nur schuldrechtliche Rechte sein sollen.
 
-> **AvW:** Falsche Frage. In Deutschland gibt es **keine** Anteilsklassen wie in Delaware. Es gibt aber **unterschiedliche Geschaeftsanteile mit unterschiedlichen Rechten** (sog. "Geschaeftsanteile mit besonderen Rechten" gemaess § 5 Abs. 3 Satz 1 GmbHG). Diese werden in der Satzung definiert. Das heisst: (a) **Stammanteile** und (b) **Vorzugsanteile** sind in der **Satzung** zu definieren, mit den jeweiligen Liquidations-, Stimm- und Gewinnrechten. Schuldrechtliche Loesungen ueber den SHA sind moeglich, aber riskant bei Insolvenz und gegenueber Rechtsnachfolgern. Empfehlung: dingliche Loesung in Satzung, plus schuldrechtliche Spiegelung im SHA. Das bitte als eigenen Memo-Abschnitt fuer die Mandantin.
+> **AvW:** Falsche Frage. In Deutschland gibt es **keine** Anteilsklassen wie in Delaware. Es gibt aber **Geschaeftsanteile mit Sonderrechten einzelner Gesellschafter**, deren rechtliche Verankerung sich aus der allgemeinen **Satzungsautonomie** ergibt und auf § 14 GmbHG (Sonderrechte und Mitgliedschaft) gestuetzt wird. Hueten Sie sich vor dem Anfaengerfehler, § 5 Abs. 3 GmbHG als Anker zu zitieren — diese Vorschrift regelt **nur**, dass Geschaeftsanteile unterschiedliche **Nennbetraege** haben koennen und in Summe das Stammkapital ergeben muessen; sie betrifft **nicht** die wirtschaftlichen Sonderrechte wie Liquidation Preference oder Anti-Dilution. Die Vorzugsrechte werden in der **Satzung** definiert, mit den jeweiligen Liquidations-, Stimm- und Gewinnrechten. Schuldrechtliche Loesungen ueber den SHA sind moeglich, aber riskant bei Insolvenz und gegenueber Rechtsnachfolgern. Empfehlung: dingliche Loesung in Satzung (mit Aenderungsbeschluss nach § 53 GmbHG), plus schuldrechtliche Spiegelung im SHA. Das bitte als eigenen Memo-Abschnitt fuer die Mandantin.
 
 ## 9 English long-form docs unter deutschem Recht
 
@@ -74,7 +74,7 @@ To do:
 - Investor Counsel fragen, ob Series A Preferred Shares echte Anteilsklasse oder nur schuldrechtliche Rechte sein sollen.
 - Pruefen, ob English long-form docs mit deutscher Notar- und Registerlogik funktionieren.
 
-> **AvW:** Reihenfolge umstellen: **(1) Partnerbriefing zuerst** — kommen Sie morgen 8:00 Uhr in mein Buero. (2) Cap Table mit drei Szenarien (siehe Datei 02). (3) Begriffserklaerung fuer Kunigunde **erst nach** unserem Briefing — wir wollen nicht, dass Sie ihr Halbwissen weitergeben. (4) Notar-Frage klaere ich mit Roswitha Ploeger im Notariat Schwartz direkt. (5) Investor-Counsel-Frage: nicht "Anteilsklasse vs schuldrechtlich" fragen, sondern: "Wir gehen davon aus, dass die Series A Preferred Shares als besondere Geschaeftsanteile gemaess § 5 Abs. 3 GmbHG in der Satzung verankert werden. Stimmen Sie zu?" — das ist der professionelle Aufschlag.
+> **AvW:** Reihenfolge umstellen: **(1) Partnerbriefing zuerst** — kommen Sie morgen 8:00 Uhr in mein Buero. (2) Cap Table mit drei Szenarien (siehe Datei 02). (3) Begriffserklaerung fuer Kunigunde **erst nach** unserem Briefing — wir wollen nicht, dass Sie ihr Halbwissen weitergeben. (4) Notar-Frage klaere ich mit Roswitha Ploeger im Notariat Schwartz direkt. (5) Investor-Counsel-Frage: nicht "Anteilsklasse vs schuldrechtlich" fragen, sondern: "Wir gehen davon aus, dass die Series A Preferred Shares als Geschaeftsanteile mit Sonderrechten einzelner Gesellschafter in der Satzung verankert werden, gestuetzt auf die Satzungsautonomie und § 14 GmbHG. Stimmen Sie zu?" — das ist der professionelle Aufschlag.
 
 ---
 
@@ -88,7 +88,7 @@ OK. Ich habe heute Morgen schon das Glossar (Datei 08) und den Anfaengerfehler-K
 - Vesting-Anrechnung wird verhandelt, nicht akzeptiert.
 - Drag braucht Stimmbindung im SHA, weil Vinkulierung in Satzung 75 % verlangt.
 - Investor "Director" ist kein Board-Director, sondern Beiratsmitglied.
-- Series A Preferred Shares sind besondere Geschaeftsanteile gemaess § 5 Abs. 3 GmbHG.
+- Series A Preferred Shares sind Geschaeftsanteile mit Sonderrechten in der Satzung (Satzungsautonomie, § 14 GmbHG); § 5 Abs. 3 GmbHG ist **nicht** die Rechtsgrundlage.
 - English long-form docs gehen, aber Notar verlangt Deutsch.
 
 Ich bringe morgen 8:00 die Cap Table mit drei Szenarien und einen Memo-Entwurf fuer Kunigunde.

--- a/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/07-erwarteter-output-ohne-musterloesung.md
+++ b/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/07-erwarteter-output-ohne-musterloesung.md
@@ -79,7 +79,7 @@ Maximalpunktzahl 100. Mindestpunktzahl fuer "Bestanden" 70.
 | Drag-/Tag-Schwellen harmonisiert | 5 | Stimmbindung im SHA, Vinkulierung beachtet |
 | Beirat vs Board of Directors | 10 | Geschaeftsordnung erwaehnt |
 | English contract under German law | 10 | Sprache, Notar, Register |
-| § 5 Abs. 3 GmbHG fuer Vorzugsanteile | 5 | Statt "Series A Preferred Shares" als Pseudoklasse |
+| Vorzugsrechte ueber Satzungsautonomie und Sonderrechte | 5 | Vorzugsrechte werden bei der GmbH als Sonderrechte einzelner Gesellschafter in der Satzung verankert (gestuetzt auf § 14 GmbHG und die allgemeine Satzungsautonomie, Satzungsaenderung nach § 53 GmbHG). § 5 Abs. 3 GmbHG ist **nicht** einschlaegig — er regelt nur, dass Geschaeftsanteile unterschiedliche Nennbetraege haben koennen und in Summe das Stammkapital ergeben muessen. "Series A Preferred Shares" als Pseudoklasse bleibt ein Anfaengerfehler. |
 | Disclosure-Schedule-Logik | 5 | DD-Befunde sauber eingeordnet |
 | Senior-Review-Gates gesetzt | 5 | Jede Mandantenantwort durch Partnerin |
 | Notarielle Form korrekt zugeordnet | 5 | § 15, § 53, § 55 GmbHG, § 5 BeurkG |


### PR DESCRIPTION
Behebt zwei Codex-Befunde aus dem Review von Commit 8c30d93002 (PR #122).

## P2 — Cap-Table-Summen-Inkonsistenz (Datei 02)

**Befund:** Die fully-diluted-Summe nach Closing stimmte rechnerisch nicht. Die Einzelpositionen ergaben 56.475, nicht 58.475; die Series-A-Anteilszahl-Aufteilung war nicht mit der 12-Mio-EUR-Pre-Money-Logik konsistent.

**Fix:**
- Series-A-Preis = 12.000.000 / 41.700 = ca. 287,77 EUR/Anteil
- Series-A-Anteile total = 5.200.000 / 287,77 = ca. 18.069
- Aufteilung 4,8 / 0,4 Mio. EUR: Northbridge 16.679, Kraemer 1.390
- Post-money fully diluted = 41.700 + 18.069 = 59.769

Rechenweg unter der Tabelle vollstaendig dokumentiert mit Pre-Money-Preis, Total-Anteilszahl, Aufteilungsverhaeltnis und Plausibilitaetscheck der Northbridge-Quote (27,9 Prozent, konsistent mit Term-Sheet-Erwartung).

## P2 — § 5 Abs. 3 GmbHG als Anker fuer Vorzugsrechte (Dateien 06 und 07)

**Befund:** Pruefraster und Rotstift-Kommentar zitierten § 5 Abs. 3 GmbHG als Grundlage fuer Vorzugsanteile. Diese Vorschrift regelt jedoch nur, dass Geschaeftsanteile unterschiedliche Nennbetraege haben koennen und in Summe das Stammkapital ergeben muessen; sie betrifft **nicht** wirtschaftliche Sonderrechte.

**Fix:** Vorzugsrechte werden bei der GmbH als **Sonderrechte einzelner Gesellschafter** in der Satzung verankert, gestuetzt auf die **Satzungsautonomie** und **§ 14 GmbHG** (Mitgliedschaftsrecht), mit Satzungsaenderung nach § 53 GmbHG. In Datei 06 (Rotstift-Kommentar der Partnerin) und Datei 07 (Pruefraster) entsprechend umgeschrieben; der Anfaengerfehler "\u00a7 5 Abs. 3 GmbHG" wird jetzt explizit als Warnung ausgewiesen.

## QA

- validate-plugin-structure OK
- validate-yaml-frontmatter 0 Fehler, 0 Warnungen
- welle5 Komma-Check 0 Treffer