### PR TITLE
v35.0.0: Agio-Dogmatik in 3 Plugins + Codex-Round-2-Fixes + Umlaute

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -121,7 +121,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "29.0.0"
+      "version": "30.0.0"
     },
     {
       "name": "datenschutzrecht",
@@ -436,7 +436,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "29.0.0"
+      "version": "30.0.0"
     },
     {
       "name": "gesellschaftsrecht-legal-english",
@@ -445,7 +445,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "34.0.0"
+      "version": "35.0.0"
     },
     {
       "name": "gewerblicher-rechtsschutz",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# v35.0.0 — Agio-Dogmatik in drei Plugins, Codex-Round-2-Fixes, Umlaut-Hygiene Testakte
+
+- **Codex-Round-2-Fixes in `testakten/gesellschaftsrecht-legal-english-frankfurt-startup/`.** Der `§ 14 GmbHG`-Anker für Sonderrechte/Vorzugsanteile wurde in den Dateien `06-associate-arbeitsstand.md` und `07-erwarteter-output-ohne-musterloesung.md` durch den korrekten Anker `Satzungsautonomie + § 35 BGB analog` ersetzt; gestützt auf ständige Rechtsprechung (BGHZ 123, 15; BGH II ZR 89/79 = LM BGB § 35 Nr. 4; OLG Nürnberg 12 U 813/99). § 14 GmbHG (Einlagepflicht/Nennbetrag) wird explizit als Nicht-Anker markiert. In `02-cap-table-und-gesellschafterliste.md` wurde der irreführende Verweis auf eine angebliche Subscription-Liste in Datei 03 Ziff. 2 berichtigt — die 4,8/0,4-Aufteilung steht in Datei 02 selbst (CFO-Slack-Thread vom 28.05.2026); Datei 03 Ziff. 2 verlangt nur eine Lead-Mindestquote von 75 Prozent.
+- **Umlaut-Hygiene Testakte.** Sämtliche deutschen Wörter in der Testakte wurden auf korrekte Umlaute (ä/ö/ü/ß) umgestellt. Wortgrenzen-basiertes Ersetzungsskript mit expliziter Wörterliste; englische Termini (gross proceeds, business, issued, less, loss, passu, Voss, Stein, Goetheplatz, ...) bleiben unangetastet. 17 Dateien geändert.
+- **Agio-Dogmatik in drei Plugins.** Echtes/korporatives vs. unechtes/schuldrechtliches Agio bei der GmbH; § 3 Abs. 2 GmbHG mit Dauerwirkung auch bei Kapitalerhöhung; Differenzierung nach Fälligkeit (Fall 1 keine Satzungsaufnahme erforderlich, Fall 2 Eintragungshindernis bei Nichtaufnahme); Sachagio im Rahmen des qualifizierten Anteilstauschs § 21 UmwStG; § 272 Abs. 2 Nr. 1 vs. Nr. 4 HGB; § 27 KStG steuerliches Einlagekonto. Rechtsprechung verifiziert: BGH II ZR 216/06; BGH BGHZ 80, 129; BGH BGHZ 71, 40 (Kali+Salz); BFH I R 53/08; BFH IX R 12/22.
+  - **Neuer Skill `gesellschaftsrecht/skills/agio-und-kapitalruecklage`** mit voller Dogmatik, Praxismuster-Formulierungen, US-Term-Sheet-Übersetzung und Anfängerfehler-Katalog.
+  - **Neuer Skill `corporate-kanzlei/skills/corporate-kanzlei-agio-und-kapitalerhoehungsstruktur`** mit Schnittstellen-Management (Notar, Steuerberater, Investor Counsel, CFO), Strukturierungsentscheidungen und Streitpunkten in der Praxis.
+  - **Neue Testakten-Datei `24-agio-und-kapitalruecklage-streitfrage.md`** in der Frankfurt-Testakte mit Mandatsbezug (Kometenfalter Series A), Notiz Adelheid von Westarp an Hildemar K., US-Term-Sheet-Bezug (Original Purchase Price, Par Value, APIC, Liquidation Preference) und Aufgabenkatalog für den Associate.
+- **Plugin-Versionsbump.** `gesellschaftsrecht` 29.0.0 → 30.0.0; `corporate-kanzlei` 29.0.0 → 30.0.0; `gesellschaftsrecht-legal-english` 34.0.0 → 35.0.0 in den jeweiligen `<plugin>/.claude-plugin/plugin.json` und `.claude-plugin/marketplace.json`.
+
+## Qualitätssicherung
+
+- `node scripts/validate-plugin-structure.mjs` — OK
+- `python3 scripts/validate-yaml-frontmatter.py` — 0 Fehler 0 Warnungen
+- `python3 /tmp/welle5_komma_check.py` — 0 Treffer
+- Forbidden-Frontmatter-Check: keine Treffer
+- description-Längen ≤ 1024 Zeichen, Skill-Namen ≤ 64 ASCII
+- Verifikation aller Rechtsprechungs-Zitate über dejure.org und bundesfinanzhof.de
+
+---
+
 # v34.0.0 - Corporate Legal English didaktisiert, Multi-Format-Testakte
 
 - **`gesellschaftsrecht-legal-english` didaktisch nachgeschärft.** Der `allgemein`-Skill startet jetzt mit einem echten 90-Sekunden-Kaltstart: Sofortdiagnose, Erfahrungslevel, drei Rückfragen, Skill-Routing und Mini-Arbeitsprodukt. Der `rookie-modus` wurde vom bloßen Prüfraster zum Lerncoach mit 30-Minuten-Plan, Begriffskarten, Mini-Übungen und klaren Senior-Review-Gates.

--- a/corporate-kanzlei/.claude-plugin/plugin.json
+++ b/corporate-kanzlei/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corporate-kanzlei",
-  "version": "29.0.0",
+  "version": "30.0.0",
   "description": "Corporate-Kanzlei-Plugin: Deal-Kommandocenter, Datenraum, Due Diligence, SPA/APA, Umwandlung, StaRUG, Insolvenzplan, W&I, Signing/Closing, PMI.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/corporate-kanzlei/skills/corporate-kanzlei-agio-und-kapitalerhoehungsstruktur/SKILL.md
+++ b/corporate-kanzlei/skills/corporate-kanzlei-agio-und-kapitalerhoehungsstruktur/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: corporate-kanzlei-agio-und-kapitalerhoehungsstruktur
+description: "Strukturierung von Kapitalerhöhungen mit Agio bei VC-Finanzierungsrunden Holding-Aufbauten und M&A-Sekundärfinanzierungen. Übersetzung US-Term-Sheet-Begriffe (Original Purchase Price Par Value APIC Liquidation Preference) in deutsche Kategorien (Ausgabebetrag Nennbetrag Kapitalrücklage Vorzugsrecht). Differenzierung echtes vs. unechtes Agio. Sachagio im Rahmen des qualifizierten Anteilstauschs § 21 UmwStG. Eintragungshindernisse beim Handelsregister vermeiden. Schnittstellen zu Notar Steuerberater Investor Counsel. Lädt bei VC-Runden Series A/B/C Anteilstauschen Bridge-Finanzierungen und Convertible-Wandlungen."
+---
+
+# Agio und Kapitalerhöhungsstruktur in der Corporate-Praxis
+
+## Triage zu Beginn
+
+Vor dem ersten Term-Sheet-Markup klären:
+
+1. **Dealtyp:** Erste VC-Runde Folgerunde Bridge Convertible-Wandlung Anteilstausch nach § 21 UmwStG oder Sekundärtransaktion mit Kapitalmaßnahme?
+2. **Beteiligungsstruktur des Lead Investors:** Deutsche GmbH KG US-LP Luxemburg-SCS oder andere Auslandsstruktur? Beeinflusst Beurkundungsbedarf und Steuerlogik.
+3. **Stammkapital aktuell und post-money:** Wie viel zusätzliches Stammkapital wird ausgegeben wie viel Agio? Standardmuster bei VC-Runden 99 Prozent Agio.
+4. **Agio-Charakter:** Echtes (korporatives) oder unechtes (schuldrechtliches) Agio? Beim qualifizierten Anteilstausch § 21 UmwStG ist echtes Agio Voraussetzung für Buchwertfortführung.
+5. **Fälligkeit des Agios:** Bei Closing in voller Höhe (Fall 1) oder gestaffelt (Fall 2)? Bei Fall 2 muss das Agio in den aktualisierten Satzungstext sonst Eintragungshindernis.
+6. **Liquidation Preference:** Bezugsgröße Ausgabebetrag (Nennbetrag plus Agio) oder fälschlich nur Nennbetrag?
+7. **Steuerliche Strukturierung:** Soll das Agio in das steuerliche Einlagekonto § 27 KStG fließen für spätere steuerneutrale Rückgewähr?
+
+## Zentrale Schnittstellen
+
+- **Notar** (Beurkundung Kapitalerhöhungsbeschluss Übernahmeerklärung Satzungsneufassung).
+- **Steuerberater** (UmwStG-Konformität § 27 KStG-Erfassung Buchwertfortführung).
+- **Investor Counsel** (oft US- oder UK-Kanzlei mit Delaware-Denke).
+- **CFO und Tax** der Mandantin (Cashflow-Planung Bilanzaufstellung).
+- **Handelsregister** (Anmeldung neue Anteilsstruktur Gesellschafterliste § 40 GmbHG).
+
+## Standardmuster Series-A-Runde
+
+| Komponente | Typische Größenordnung |
+|---|---|
+| Stammkapital vor Runde | EUR 25.000 bis 50.000 |
+| Investitionsvolumen | EUR 3 bis 20 Mio |
+| Nennbetrag je neuem Geschäftsanteil | EUR 1,00 |
+| Anzahl neuer Geschäftsanteile | 5.000 bis 30.000 |
+| Ausgabebetrag je Anteil | abhängig von Pre-Money und Cap Table |
+| Agio je Anteil | Ausgabebetrag minus EUR 1,00 |
+| Agio-Anteil an Investition | typisch 99 bis 99,9 Prozent |
+| Stammkapital nach Runde | EUR 35.000 bis 75.000 |
+
+Das ist nicht atypisch sondern Standard. Wer mit einem Lead Investor verhandelt der das Agio vermeiden will hat in den meisten Fällen einen Atypiker am Tisch oder einen Investor der die deutsche GmbH-Struktur nicht versteht.
+
+## Übersetzungstabelle US-Term-Sheet zu deutscher Satzung
+
+| US-Begriff | Deutsche Entsprechung | Häufige Fehler |
+|---|---|---|
+| Original Purchase Price (OPP) | Ausgabebetrag je Geschäftsanteil | wird mit Kaufpreis übersetzt — falsch |
+| Original Issue Price (OIP) | Ausgabebetrag je Geschäftsanteil | wie OPP |
+| Par Value | Nennbetrag § 5 Abs. 2 GmbHG | wird mit Nennwert übersetzt — akzeptabel aber nicht juristisch präzise |
+| Additional Paid-In Capital (APIC) | Kapitalrücklage § 272 Abs. 2 Nr. 1 HGB | wörtlich Zusätzliches eingezahltes Kapital — falsche Bilanzposition |
+| Premium over par | Agio Aufgeld | wird mit Aufpreis übersetzt — umgangssprachlich nicht falsch aber unpräzise |
+| Stated Capital | Gezeichnetes Kapital Stammkapital | manchmal mit Grundkapital verwechselt (das ist AG-Begriff § 6 AktG) |
+| Issued Shares | Ausgegebene Geschäftsanteile | bei der GmbH gibt es keine Shares im US-Sinne |
+| Outstanding Shares | Ausgegebene und nicht eingezogene Geschäftsanteile | dasselbe wie Issued Shares minus Treasury Shares (in DE selten relevant) |
+| Authorized Capital | Genehmigtes Kapital (in der AG § 202 AktG in der GmbH gibt es das so nicht) | gelegentlich mit Stammkapital verwechselt |
+| Pre-Money Valuation | Pre-Money-Bewertung Vor-Investitionsbewertung | unkritisch |
+| Post-Money Valuation | Post-Money-Bewertung | unkritisch |
+| Liquidation Preference 1x OPP | Einfache Liquidationspräferenz auf den Ausgabebetrag | wird oft als 1x Nennbetrag interpretiert — katastrophal für den Investor |
+| Anti-Dilution Adjustment | Anti-Dilution-Anpassung des Ausgabebetrags | wird oft als Anpassung der Nennbeträge missverstanden — § 5 Abs. 2 GmbHG verbietet das |
+| Conversion Price | Wandlungspreis | unkritisch |
+| Conversion Ratio | Wandlungsverhältnis | unkritisch |
+
+## Strukturierungsentscheidungen mit Kostenrelevanz
+
+### Wieviel Stammkapital wird ausgegeben?
+
+Die Versuchung des unerfahrenen Berators ist groß, das Stammkapital möglichst hoch anzusetzen — etwa weil der Investor mehr Stammkapital als ehrenhafter ansieht. Das ist ein Fehler:
+
+- Hohes Stammkapital = dauerhafte Kapitalbindung § 30 GmbHG.
+- Kapitalherabsetzung später nur über §§ 58 ff. GmbHG mit Sperrjahr Gläubigeraufruf und 6-Monats-Frist.
+- Geschäftsführerhaftung steigt mit der Stammkapitalhöhe wegen § 43 Abs. 3 GmbHG in Verbindung mit § 30 GmbHG.
+
+Praxismuster: Nennbetrag je Anteil bei EUR 1,00 belassen Stammkapital nur um Anzahl der neuen Anteile erhöhen — der Rest als Agio in die Kapitalrücklage.
+
+### Echtes oder unechtes Agio?
+
+| Anwendungsfall | Empfehlung |
+|---|---|
+| VC-Runde mit Lead Investor | Echtes Agio |
+| Bridge-Finanzierung durch Altgesellschafter | Echtes Agio einfacher zu erklären |
+| Convertible-Wandlung | Echtes Agio (Wandlungspreis als Ausgabebetrag) |
+| Quersubventionierung zwischen Gesellschaftern | Unechtes Agio (schuldrechtliche Nebenabrede) |
+| Holding-Strukturierung § 21 UmwStG | Echtes Sachagio zwingend für Buchwertfortführung |
+| Mitarbeiterbeteiligung (ESOP) | Hängt vom Modell ab — bei echter Anteilsausgabe echtes Agio bei virtueller Beteiligung kein Agio |
+
+### Fälligkeit des Agios
+
+Standardmuster: Fälligkeit bei Eintragung der Kapitalerhöhung in das Handelsregister. Damit greift Fall 1 — keine Aufnahme des Agios in den Satzungstext erforderlich Kapitalerhöhungsbeschluss und Übernahmeerklärung genügen.
+
+Abweichende Konstellationen bei denen Fall 2 (Aufnahme in Satzungstext) angezeigt ist:
+
+- Staged Closings (z.B. Tranche bei Closing Tranche bei Erreichen von Milestones).
+- Earn-out-ähnliche Strukturen mit nachgelagertem Agio.
+- Bridge-to-Series-A-Strukturen mit Wandlungsverzögerung.
+- Sachagio mit nachgelagerter Werthaltigkeitsprüfung.
+
+Bei Fall 2 unbedingt in den neuen § 3a oder § 4 der Satzung aufnehmen sonst Eintragungshindernis und doppelter Notartermin.
+
+## Schnittstellenmanagement im Deal
+
+### Notar
+
+- Notar verlangt deutsche Beurkundungssprache § 5 BeurkG. Term Sheet bleibt englisch Satzung wird zweisprachig oder deutsch.
+- Notar muss Agio in Kapitalerhöhungsbeschluss und Übernahmeerklärung sauber wiederfinden — sonst Beanstandung.
+- Bei Sachagio: Sachgründungsbericht analog § 5 Abs. 4 GmbHG mit Werthaltigkeitsbeleg.
+- Vor dem Notartermin: Liste der zu beurkundenden Dokumente mit dem Notariat abstimmen.
+
+### Steuerberater
+
+- Bestätigung dass Buchwertfortführung nach § 21 UmwStG möglich ist (qualifizierter Anteilstausch).
+- Bestätigung dass das Agio korrekt in das steuerliche Einlagekonto § 27 KStG fließt.
+- Bei Verlustvorträgen Prüfung des § 8c KStG (schädlicher Beteiligungserwerb bei mehr als 50 Prozent Übergang).
+- Bei US-Investoren mit LP-Struktur: Quellensteuerprüfung DBA-Anwendung.
+
+### Investor Counsel
+
+- US- oder UK-Kanzlei denkt in Delaware-Kategorien — Par Value 0,0001 USD APIC selbstverständlich.
+- Erklärungsbedarf für deutsche Spezialitäten: notarielle Beurkundung Vinkulierung § 15 Abs. 5 GmbHG keine echten Anteilsklassen Sonderrechte über Satzungsautonomie und § 35 BGB analog.
+- Investor Counsel will oft Liquidation Preference 1x non-participating preferred. Das ist sauber zu übersetzen als einfache Liquidationspräferenz auf den Ausgabebetrag mit Catch-up oder ohne.
+
+### CFO der Mandantin
+
+- Cashflow-Planung: wann fließt das Agio? Voll bei Closing oder gestaffelt?
+- Bilanzielle Behandlung: Erhöhung Kapitalrücklage § 272 Abs. 2 Nr. 1 HGB nicht Stammkapital.
+- Reporting an Bestandsgesellschafter: wie wird die Verwässerung kommuniziert?
+
+## Häufige Streitpunkte und ihre Lösung
+
+### Liquidation Preference auf Nennbetrag oder Ausgabebetrag
+
+Standard: **Ausgabebetrag** (Nennbetrag plus Agio). Eine Liquidation Preference 1x Nennbetrag wäre für den Investor wirtschaftlich katastrophal — bei einem 99 Prozent Agio bleiben dem Investor 1 Prozent seiner Investition als Vorrecht. Das ist kein Markt.
+
+### Anti-Dilution mit Folgewirkung auf Liquidation Preference
+
+Wenn der Anti-Dilution-Mechanismus den Conversion Price (deutsch: Wandlungspreis) anpasst muss die Liquidation Preference darauf reagieren. Häufig anzutreffen: Weighted Average broad-based oder narrow-based oder Full Ratchet. Bei der GmbH wird das technisch über Anpassung des wirtschaftlichen Bezugswertes umgesetzt nicht über Anpassung des Nennbetrags (§ 5 Abs. 2 GmbHG verbietet Nennbeträge unter EUR 1).
+
+### Pari-passu oder Senior bei mehreren Series
+
+In Series-B-Runden stellt sich die Frage ob die Series-B-Liquidation-Preference pari passu mit Series A oder senior dazu ist. Pari passu ist Markt für Bestandsinvestoren senior typisch für Lead-getriebene B-Runden. Die Satzung muss das eindeutig formulieren — andernfalls Auslegungsstreit.
+
+### Bezugsrechtsausschluss bei Down-Rounds
+
+Bei Down-Rounds (Pre-Money unter letztem Post-Money) ist ein Bezugsrechtsausschluss zugunsten des Lead Investors oft notwendig. Sachliche Rechtfertigung nach Kali+Salz-Grundsatz (BGHZ 71, 40) erforderlich. Das Agio in der Down-Round ist niedriger oder negativ — was wirtschaftlich heißt: Verwässerung der Altgesellschafter mit höherer Hebelwirkung.
+
+## Anfängerfehler im Corporate-Kontext
+
+- Annahme Lead Investor will hohes Stammkapital. Falsch — Lead Investor will hohe Liquidation Preference und niedriges Stammkapital um spätere Rückgewähr zu erleichtern.
+- Annahme das Agio ist ein steuerlicher Trick. Falsch — Agio ist zivilrechtlich begründet steuerlich nur die Erfassung folgt automatisch.
+- Annahme jeder Kapitalerhöhungsbeschluss muss das Agio in der Satzung verankern. Falsch — Differenzierung nach Fälligkeit (Fall 1 nein Fall 2 ja).
+- Übersetzung der Liquidation Preference auf Nennbetrag. Falsch — Bezugsgröße Ausgabebetrag.
+- Versuch das Agio durch Sondervergünstigungen an einzelne Gesellschafter zu umgehen. Riskant — meist kapitalerhaltungswidrig (§ 30 GmbHG) und steuerlich als verdeckte Gewinnausschüttung qualifizierbar.
+
+## Aktuelle Rechtsprechung
+
+- BGH Urt. v. 15.10.2007 — II ZR 216/06 GmbHR 2008, 147 (Sachagio bei Gründung § 3 Abs. 2 GmbHG zwingend).
+- BGH Urt. v. 16.02.1981 — II ZR 168/79 BGHZ 80, 129 (Sachkapitalerhöhung Beschluss mit satzungsändernder Wirkung).
+- BGH Urt. v. 13.03.1978 — II ZR 142/76 BGHZ 71, 40 (Kali+Salz Bezugsrechtsausschluss).
+- BFH Urt. v. 27.05.2009 — I R 53/08 BFHE 226, 500 BStBl II 2010, 1004 (Aufgeld als Anschaffungskosten).
+- BFH Urt. v. 03.05.2023 — IX R 12/22 (Überpari-Emission kein § 42 AO-Missbrauch).
+- Rechtsprechung: keine weitere Entscheidung aus Modellwissen zitieren; vor Ausgabe über offizielle oder frei zugängliche Quelle mit Gericht Entscheidungsform Datum Aktenzeichen und tragender Aussage verifizieren.
+
+## Verwaltungspraxis
+
+- UmwSt-Erlass v. 11.11.2011 BStBl. I 2011, 1314 Rn. 21.09 ff. (qualifizierter Anteilstausch und Sachagio).
+
+## Outputs
+
+- Term-Sheet-Markup mit Übersetzungstabelle Original Purchase Price etc.
+- Memo zur Strukturierung der Kapitalerhöhung mit Empfehlung Stammkapitalhöhe und Agio-Aufteilung.
+- Kapitalerhöhungsbeschluss-Entwurf für den Notar.
+- Übernahmeerklärung-Entwurf je neuem Gesellschafter.
+- Satzungsneufassung mit oder ohne Aufnahme des Agios je nach Fall 1 oder Fall 2.
+- Steuerliche Stellungnahme zur Erfassung im Einlagekonto und zur Buchwertfortführung.
+- Cap-Table-Update mit Pre-Money Post-Money und Verwässerungsrechnung.
+- Closing-Checkliste mit allen Conditions Precedent (siehe corporate-kanzlei-signing-closing-conditions).
+
+## Abgrenzung
+
+- Gesellschaftsrechtliche Dogmatik des Agios siehe Skill agio-und-kapitalruecklage im Plugin gesellschaftsrecht.
+- Bewertung des Sachagio-Gegenstands siehe Skill mittelstand-corporate-ma-transaktionsstruktur.
+- Steuerliche Vertiefung siehe Plugin steuerrecht-anwalt-und-berater.
+- Signing- und Closing-Mechanik siehe Skill corporate-kanzlei-signing-closing-conditions.
+
+## Senior-Review-Gate
+
+Kein Term-Sheet-Markup geht an den Investor Counsel bevor der Senior das Agio-Konzept abgezeichnet hat. Bei Holding-Strukturierung und qualifiziertem Anteilstausch ist ein gemeinsamer Termin mit Steuerberater Notar und Investor Counsel obligatorisch — die Schnittstellen zwischen Gesellschaftsrecht Steuerrecht Bilanzrecht und Notariat sind hier eng und fehleranfällig.

--- a/gesellschaftsrecht-legal-english/.claude-plugin/plugin.json
+++ b/gesellschaftsrecht-legal-english/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gesellschaftsrecht-legal-english",
-  "version": "34.0.0",
+  "version": "35.0.0",
   "description": "Didaktisches Gesellschaftsrechts-Plugin fuer Corporate Legal English: Kaltstart, Dealroom-Lernpfad, Multi-Format-Auswertung, Cap Table, Term Sheet, SHA, Vesting, Drag/Tag, Liquidation Preference, Anti-Dilution, SPA, DD und Big-Law-Anfaengertraining.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gesellschaftsrecht/.claude-plugin/plugin.json
+++ b/gesellschaftsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gesellschaftsrecht",
-  "version": "29.0.0",
+  "version": "30.0.0",
   "description": "Gesellschaftsrecht – GmbH/AG/Personengesellschaften, M&A-Due-Diligence ohne Discovery (Q&A + Datenraum), Gesellschafterbeschlüsse, HRB/HRA-Anmeldungen, Closing Checklists, Compliance-Fristen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gesellschaftsrecht/skills/agio-und-kapitalruecklage/SKILL.md
+++ b/gesellschaftsrecht/skills/agio-und-kapitalruecklage/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: agio-und-kapitalruecklage
+description: "Echtes (korporatives) und unechtes (schuldrechtliches) Agio in der GmbH bei Gründung und Kapitalerhöhung; § 3 Abs. 2 GmbHG als Anker; § 272 Abs. 2 Nr. 1 vs. Nr. 4 HGB; Sachagio im Rahmen des qualifizierten Anteilstauschs nach § 21 UmwStG; steuerliches Einlagekonto § 27 KStG; Differenzierung nach Fälligkeit bei Kapitalerhöhung; Eintragungshindernis vs. Unwirksamkeit. Lädt bei Mandaten zu VC-Finanzierungsrunden Holding-Strukturierungen Sachagio-Einbringungen und Satzungsformulierungen mit Aufgeld."
+---
+
+# Agio und Kapitalrücklage in der GmbH
+
+## Triage zu Beginn
+
+Vor der Bearbeitung folgende Fragen klären:
+
+1. **Stadium:** Gründung (§ 3 Abs. 2 GmbHG zwingend) oder Kapitalerhöhung (Differenzierung nach Fälligkeit)?
+2. **Art des Agios:** Bar-Agio oder Sach-Agio? Beim Sachagio sind die Anforderungen des § 5 Abs. 4 GmbHG analog zu berücksichtigen.
+3. **Charakter:** Echtes (korporatives) oder unechtes (schuldrechtliches) Agio? Entscheidet über § 272 Abs. 2 Nr. 1 vs. Nr. 4 HGB und über Kapitalbindung.
+4. **Fälligkeit:** Wird das Agio bis zur Eintragung der Kapitalerhöhung geleistet (Fall 1) oder erst danach (Fall 2)? Entscheidet über Erfordernis der Satzungsaufnahme.
+5. **Steuerlicher Kontext:** Holding-Strukturierung oder qualifizierter Anteilstausch nach § 21 UmwStG? Buchwertfortführung gewünscht?
+6. **Mandanteninteresse:** Welche Bilanzwirkung soll das Agio entfalten — sofortige steuerliche Wirksamkeit, spätere steuerneutrale Rückgewähr, oder beides?
+
+## Zentrale Normen
+
+§ 3 Abs. 2 GmbHG (besondere Bestimmungen Nebenleistungspflichten) — § 5 Abs. 1 GmbHG (Stammkapital mindestens 25.000 EUR) — § 5 Abs. 4 GmbHG (Sachgründungsbericht Sacheinlagefestsetzung) — § 53 Abs. 2 GmbHG (notarielle Beurkundung Satzungsänderung) — § 55 GmbHG (Kapitalerhöhung gegen Einlagen) — § 56 GmbHG (Kapitalerhöhung mit Sacheinlagen) — § 272 Abs. 2 Nr. 1 HGB (Kapitalrücklage Beträge bei Ausgabe über Nennbetrag) — § 272 Abs. 2 Nr. 4 HGB (andere Zuzahlungen) — § 27 KStG (steuerliches Einlagekonto) — § 21 UmwStG (qualifizierter Anteilstausch Buchwertfortführung) — § 30 GmbHG (Kapitalerhaltung) — §§ 58 ff. GmbHG (Kapitalherabsetzung)
+
+## Grundbegriff Agio (Aufgeld)
+
+Das Agio ist der Aufpreis auf den Nennbetrag der übernommenen Stammeinlage. Es wird vom übernehmenden Gesellschafter zusätzlich zur Nennbetragsleistung erbracht. Bilanziell fließt es nicht in das gezeichnete Kapital (Stammkapital), sondern in die Kapitalrücklage nach § 272 Abs. 2 HGB.
+
+Bei einer Series-A-Finanzierungsrunde mit Ausgabebetrag 287,77 EUR pro Geschäftsanteil und Nennbetrag 1,00 EUR ist das Agio 286,77 EUR pro Anteil — also rund 99,7 Prozent der Investition. Das ist nicht atypisch, sondern Standardmuster bei VC-finanzierten GmbHs.
+
+## Echtes vs. unechtes Agio
+
+| Kriterium | Echtes (korporatives) Agio | Unechtes (schuldrechtliches) Agio |
+|---|---|---|
+| Rechtsgrund | Gesellschaftsrechtlich (Satzung Kapitalerhöhungsbeschluss) | Schuldrechtliche Nebenabrede |
+| Bilanzposten | § 272 Abs. 2 Nr. 1 HGB | § 272 Abs. 2 Nr. 4 HGB (andere Zuzahlungen) |
+| Kapitalbindung | Ja | Geringer |
+| Steuerliches Einlagekonto | Ja § 27 KStG | Ja § 27 KStG ebenfalls |
+| Anschaffungskosten beim Gesellschafter | Ja erhöht AK (BFH I R 53/08) | Ja erhöht AK (st. Rspr.) |
+| Wirksamkeit bei Gründung ohne Satzungsaufnahme | Unwirksam | Unbeachtlich (rein schuldrechtlich) |
+| Standardgestaltung bei VC | Ja | Nein |
+
+Für VC-Runden mit Holding-Struktur und qualifiziertem Anteilstausch ist regelmäßig das echte Agio erforderlich. Die Buchwertfortführung nach § 21 UmwStG setzt voraus, dass das Sachagio korporativ wirksam wird.
+
+## Gründungsstadium: § 3 Abs. 2 GmbHG zwingend
+
+Bei der Gründung ist das echte Agio eine Nebenleistungspflicht im Sinne des § 3 Abs. 2 GmbHG und muss zwingend in den Gesellschaftsvertrag (Satzung) aufgenommen werden. Die fehlende Aufnahme führt zur Unwirksamkeit der Agioverpflichtung.
+
+Maßgebliche Rechtsprechung: BGH, Urt. v. 15.10.2007 — II ZR 216/06, GmbHR 2008, 147.
+
+Praktisch besonders relevant bei der Etablierung von Holding-Strukturen, in denen die Tochter-GmbH durch Bargründung mit gleichzeitiger Sachagio-Einbringung von Anteilen entsteht. Der Sachagio-Gegenstand ist als Nebenleistung in der Satzung festzusetzen.
+
+## Kapitalerhöhung: Differenzierung nach Fälligkeit
+
+§ 3 Abs. 2 GmbHG gilt sachlich nicht nur bei Gründung sondern dauerhaft (Strukturnorm). Gleichwohl ist die Aufnahme in den aktualisierten Satzungstext bei der Kapitalerhöhung differenziert zu beurteilen.
+
+**Parallele zur Sachkapitalerhöhung:** Obwohl § 5 Abs. 4 GmbHG bei der Gründung die Festsetzung des Sacheinlagegegenstandes als Wirksamkeitsvoraussetzung verlangt ist nach allgemeiner Meinung bei der Sachkapitalerhöhung die Aufnahme in den Kapitalerhöhungsbeschluss und die Übernahmeerklärung ausreichend. Eine Wiedergabe im aktualisierten Satzungswortlaut ist nicht erforderlich weil der Kapitalerhöhungsbeschluss selbst satzungsändernde Wirkung entfaltet. Vgl. BGH BGHZ 80, 129.
+
+**Fall 1 — Agio bis Eintragung fällig und geleistet:** Eine Aufnahme in den Satzungstext wäre rechtshistorische Reminiszenz ohne normativen Mehrwert. Die Nebenleistungspflicht ist erloschen — kein Regelungsgegenstand mehr für die Satzung. Keine Aufnahme in den Satzungstext erforderlich.
+
+**Fall 2 — Agio erst nach Eintragung fällig:** Die Nebenleistungspflicht besteht über die Eintragung hinaus fort. § 3 Abs. 2 GmbHG greift ratione materiae. Aufnahme in den aktualisierten Satzungstext systematisch geboten.
+
+## Rechtsfolge bei Nichtaufnahme im Fall 2
+
+Anders als im Gründungsfall führt die fehlende Aufnahme nicht zur Unwirksamkeit der Agioverpflichtung sondern lediglich zu einem Eintragungshindernis beim Handelsregister. Begründung:
+
+- Der Kapitalerhöhungsbeschluss entfaltet inklusive Agio-Begründung satzungsändernde Wirkung kraft eigener Rechtsnatur (§ 53 Abs. 2 GmbHG).
+- Der Beschluss ist im Registerordner einsehbar — dem Publizitätsgedanken ist Genüge getan.
+- Eine Nichtigkeitsfolge wäre unverhältnismäßig da ein formwirksamer notariell beurkundeter Beschluss vorliegt.
+
+Praxisempfehlung: Im Fall 2 die Aufnahme in den Satzungstext vorsorglich vornehmen um Eintragungshindernisse zu vermeiden. Im Fall 1 die Aufnahme entbehrlich aber unschädlich.
+
+## Steuerliche Behandlung
+
+Das Agio fließt unabhängig davon ob echtes oder unechtes Agio in das steuerliche Einlagekonto nach § 27 KStG. Spätere Rückzahlungen aus der Kapitalrücklage gelten als steuerneutrale Einlagenrückgewähr und unterliegen nicht der Kapitalertragsbesteuerung.
+
+Beim Gesellschafter erhöht das Agio die Anschaffungskosten der Beteiligung an der GmbH. Maßgebliche Rechtsprechung:
+
+- BFH Urt. v. 27.05.2009 — I R 53/08 BFHE 226, 500, BStBl II 2010, 1004 (Aufgeld als Anschaffungskosten ausschließlich des neu erworbenen Anteils nicht der Altanteile).
+- BFH Urt. v. 03.05.2023 — IX R 12/22 (Überpari-Emission Bestätigung kein § 42 AO-Missbrauch).
+
+Beim qualifizierten Anteilstausch nach § 21 UmwStG ermöglicht das Sachagio die Buchwertfortführung ohne dass die einzubringenden Anteile vollständig in Stammkapital umgesetzt werden müssen. Das vermeidet hohes kapitalbindendes Stammkapital und erhält gleichwohl die Steuerneutralität. Die Finanzverwaltung knüpft an die materielle gesellschaftsrechtliche Wirksamkeit an nicht an die formale Satzungsredaktion (UmwSt-Erlass v. 11.11.2011 BStBl. I 2011, 1314, Rn. 21.09 ff.).
+
+## Wirtschaftliche Funktion
+
+Das Agio ist nicht ein bloß rechentechnischer Posten sondern erfüllt simultan mehrere wirtschaftliche Funktionen:
+
+1. **Bewertungsdifferenz Verkehrswert vs. Nennwert.** Das Agio bildet die Differenz zwischen dem niedrigen Nennbetrag und dem hohen Verkehrswert ab und schützt Altgesellschafter vor wirtschaftlicher Verwässerung.
+2. **Verwässerungsschutz und Quotensteuerung.** Mit einem Agio lässt sich die Beteiligungsquote des Neugesellschafters von der Höhe der Investition entkoppeln.
+3. **Eigenkapitalstärkung ohne starre Kapitalbindung.** Das Agio fließt in die Kapitalrücklage und unterliegt den §§ 30, 58 ff. GmbHG nicht im selben Ausmaß wie das Stammkapital.
+4. **Steueroptimierung.** Erfassung im Einlagekonto § 27 KStG und spätere steuerneutrale Rückgewähr.
+5. **Vermeidung der Stammkapital-Inflation.** Würde der gesamte Investitionsbetrag als Stammkapital gezeichnet hätte die GmbH ein künstlich aufgeblähtes Stammkapital das dauerhaft der Kapitalbindung des § 30 GmbHG unterläge.
+6. **Signalwirkung.** Die Höhe des Agios dokumentiert die Pre-Money-Bewertung und ist Bezugspunkt für künftige Finanzierungsrunden ESOP-Ausgabepreise und Anti-Dilution-Berechnungen.
+7. **Bezugsrechtsschutz.** Bei Kapitalerhöhung unter Bezugsrechtsausschluss ist ein angemessenes Agio regelmäßig zwingend (Kali+Salz BGHZ 71, 40).
+
+## Praxismuster Formulierungen
+
+**Kapitalerhöhungsbeschluss bei Fall 1 (Agio bei Closing fällig):**
+
+Das Stammkapital wird um EUR 18.069 von EUR 30.000 auf EUR 48.069 erhöht durch Ausgabe von 18.069 neuen Geschäftsanteilen zu je EUR 1,00. Der Ausgabebetrag je neuem Geschäftsanteil beträgt EUR 287,77 und setzt sich zusammen aus dem Nennbetrag von EUR 1,00 und einem Agio von EUR 286,77. Das Agio ist in die Kapitalrücklage nach § 272 Abs. 2 Nr. 1 HGB einzustellen. Der Ausgabebetrag einschließlich des Agios ist mit Eintragung der Kapitalerhöhung in das Handelsregister zur Zahlung fällig.
+
+**Satzungsbestimmung bei Fall 2 (Agio nach Eintragung fällig):**
+
+In den neu zu fassenden § 3a der Satzung ist aufzunehmen: Die Übernehmer der im Kapitalerhöhungsbeschluss vom [Datum] ausgegebenen neuen Geschäftsanteile sind verpflichtet zusätzlich zum Nennbetrag ein Aufgeld (Agio) je Geschäftsanteil in Höhe von EUR 286,77 in die Kapitalrücklage zu leisten. Die Fälligkeit des Agios ist im Kapitalerhöhungsbeschluss geregelt. Die Aufnahme dieser Bestimmung in die Satzung erfolgt zur Vermeidung von Eintragungshindernissen.
+
+**Liquidationspräferenz-Klausel:** Die Inhaber der Series-A-Geschäftsanteile haben im Falle der Auflösung der Gesellschaft eines Verkaufs aller wesentlichen Vermögensgegenstände oder eines Kontrollwechsels Anspruch auf vorrangige Zahlung in Höhe des einfachen Ausgabebetrags (Nennbetrag zuzüglich Agio) je Series-A-Geschäftsanteil. Nicht: in Höhe des einfachen Nennbetrags. Letzteres wäre für den Investor wirtschaftlich katastrophal.
+
+## US-Term-Sheet-Übersetzung
+
+| US-Begriff | Deutsche Entsprechung |
+|---|---|
+| Original Purchase Price (OPP) | Ausgabebetrag je Geschäftsanteil |
+| Original Issue Price | Ausgabebetrag je Geschäftsanteil |
+| Par Value | Nennbetrag § 5 Abs. 2 GmbHG |
+| Additional Paid-In Capital (APIC) | Kapitalrücklage § 272 Abs. 2 Nr. 1 HGB |
+| Premium over par | Agio Aufgeld |
+| Liquidation Preference 1x OPP | Einfache Liquidationspräferenz auf den Ausgabebetrag |
+| Anti-Dilution adjustment to OPP | Anti-Dilution-Anpassung des Ausgabebetrags (mit Folgewirkung für die Liquidationspräferenz) |
+
+Häufige Übersetzungsfehler:
+
+- Original Purchase Price wird mit Kaufpreis übersetzt. Falsch — bei Kapitalerhöhung werden Anteile emittiert nicht verkauft. Ausgabebetrag.
+- Liquidation Preference 1x OPP wird als 1x Nennbetrag interpretiert. Falsch — das wären bei einer Series-A-Runde mit hohem Agio nur 0,3 Prozent der Investition. Korrekt: Nennbetrag plus Agio.
+
+## Anfängerfehler
+
+- Annahme das Agio sei nur Buchhaltung. Falsch — bei Gründung zwingend nach § 3 Abs. 2 GmbHG bei Kapitalerhöhung mit nachgelagerter Fälligkeit ebenfalls.
+- Einordnung des echten Agios als § 272 Abs. 2 Nr. 4 HGB. Falsch — echtes Agio ist Nr. 1. Nr. 4 ist für sonstige Zuzahlungen.
+- Annahme bei der Kapitalerhöhung müsse jedes Agio zwingend in den Satzungstext. Falsch — nur bei Fall 2 (nachgelagerte Fälligkeit) und auch dort als Eintragungshindernis nicht als Unwirksamkeitsgrund.
+- Verwechslung von Sachagio und Sacheinlage. Sacheinlage ist die Aufbringung des Nennbetrags durch eine Sache (§ 5 Abs. 4 GmbHG). Sachagio ist die Aufbringung des Aufgelds durch eine Sache zusätzlich zur Bareinlage des Nennbetrags. Praktisch relevant beim qualifizierten Anteilstausch.
+- Annahme das Agio sei eine verdeckte Einlage wenn die Summe aus Nennbetrag und Agio den Verkehrswert übersteigt. Falsch — st. Rspr. des BFH (I R 53/08 IX R 12/22): Aufgeld ist Anschaffungskosten des neu erworbenen Anteils auch bei Überpari-Emission.
+
+## Aktuelle Rechtsprechung
+
+- BGH Urt. v. 15.10.2007 — II ZR 216/06 GmbHR 2008, 147 (Sachagio bei Gründung § 3 Abs. 2 GmbHG zwingend).
+- BGH Urt. v. 16.02.1981 — II ZR 168/79 BGHZ 80, 129 (Sachkapitalerhöhung Beschluss mit satzungsändernder Wirkung).
+- BGH Urt. v. 13.03.1978 — II ZR 142/76 BGHZ 71, 40 (Kali+Salz Bezugsrechtsausschluss sachliche Rechtfertigung).
+- BFH Urt. v. 27.05.2009 — I R 53/08 BFHE 226, 500 BStBl II 2010, 1004 (Aufgeld als Anschaffungskosten des neu erworbenen Anteils nicht der Altanteile).
+- BFH Urt. v. 03.05.2023 — IX R 12/22 (Überpari-Emission Bestätigung I R 53/08 kein § 42 AO-Missbrauch).
+- BFH Urt. v. 14.03.2007 — I R 35/05 BFHE 218, 97 BStBl II 2008, 253 (Aufgeld bei Sacheinlage).
+- Rechtsprechung: keine weitere Entscheidung aus Modellwissen zitieren; vor Ausgabe über offizielle oder frei zugängliche Quelle mit Gericht Entscheidungsform Datum Aktenzeichen und tragender Aussage verifizieren.
+
+## Verwaltungspraxis
+
+- UmwSt-Erlass v. 11.11.2011 BStBl. I 2011, 1314 Rn. 21.09 ff. (qualifizierter Anteilstausch und Sachagio).
+- BMF-Schreiben zum steuerlichen Einlagekonto § 27 KStG (laufend aktualisiert).
+
+## Literatur
+
+- Bayer in Lutter/Hommelhoff GmbHG 21. Aufl. 2023 § 5 Rn. 32 ff.
+- Fastrich in Noack/Servatius/Haas GmbHG 23. Aufl. 2022 § 5 Rn. 41.
+- J. Vetter in MüKoGmbHG 4. Aufl. 2022 § 3 Rn. 109 ff.
+- Lieder in MüKoGmbHG 4. Aufl. 2022 § 55 Rn. 71 ff.
+- Roth in Roth/Altmeppen GmbHG 10. Aufl. 2021 § 3 Rn. 41.
+- Scholz GmbHG § 3 (14. Aufl. 2027 Verlag Dr. Otto Schmidt im Erscheinen — Differenzierung nach Fälligkeit bei Kapitalerhöhung).
+- Schwandtner Das Agio im GmbH- und Aktienrecht 2006 Duncker & Humblot.
+- Baums Agio und sonstige Zuzahlungen im Aktienrecht ILF Working Paper No. 124.
+- Zöllner/Fastrich in Baumbach/Hueck GmbHG 22. Aufl. 2019 § 55 Rn. 14.
+
+## Prüfungsschritte für die Mandatsbearbeitung
+
+1. Stadium klären — Gründung oder Kapitalerhöhung?
+2. Charakter klären — echtes (korporatives) oder unechtes (schuldrechtliches) Agio?
+3. Fälligkeit klären — Fall 1 (bis Eintragung) oder Fall 2 (nach Eintragung)?
+4. Bei Sachagio — Werthaltigkeitsprüfung nach § 5 Abs. 4 GmbHG analog organisieren.
+5. Satzungsentwurf prüfen — bei Fall 2 Aufnahme in Satzungstext.
+6. Kapitalerhöhungsbeschluss prüfen — Ausgabebetrag Nennbetrag Agio Fälligkeit korrekt formuliert?
+7. Übernahmeerklärung prüfen — Verweisstruktur sauber?
+8. Liquidationspräferenz prüfen — Bezugsgröße Ausgabebetrag nicht Nennbetrag?
+9. Steuerliche Behandlung mit Steuerberater abstimmen — § 27 KStG § 21 UmwStG.
+10. Senior-Review vor Notartermin.
+
+## Outputs
+
+- Memo zur Strukturierung der Kapitalerhöhung mit Agio.
+- Satzungstext mit oder ohne Aufnahme des Agios je nach Fall.
+- Kapitalerhöhungsbeschluss-Entwurf mit klarer Differenzierung Nennbetrag Agio.
+- Übernahmeerklärung-Entwurf.
+- Steuerliche Stellungnahme zum Einlagekonto und zur Buchwertfortführung.
+- Mandantengerechte Erläuterung der wirtschaftlichen Funktion des Agios.
+
+## Senior-Review-Gate
+
+Kein Agio-Konstrukt geht an den Notar bevor der Senior es abgezeichnet hat. Insbesondere bei Holding-Strukturierung und qualifiziertem Anteilstausch ist ein gemeinsamer Termin mit Steuerberater Notar und Investor Counsel obligatorisch — die Schnittstellen zwischen Gesellschaftsrecht Steuerrecht Bilanzrecht und Notariat sind hier eng und fehleranfällig.

--- a/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/00-deal-personen-und-zeitleiste.md
+++ b/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/00-deal-personen-und-zeitleiste.md
@@ -85,6 +85,6 @@ Fiktive Akte zu Schulungszwecken. Alle Namen, Unternehmen, Daten, Adressen, Betr
 - Sensibilität für Anfängerfehler: blinde Eindeutschung, Cap-Table-Gesellschafterlisten-Verwechslung, Übersehen des Wandeldarlehens, Beirat als Board behandeln.
 - Sauberer Übergang in Partnerbriefing, Mandantenmemo und Liste an Investor Counsel.
 
-## Wichtig fuer den Test
+## Wichtig für den Test
 
 Diese Akte ist bewusst unrund. Sie enthält Widersprüche zwischen Term Sheet, Satzung, Seed-SHA, Wandeldarlehen und VSOP. Die Aufgabe besteht **nicht** darin, eine perfekte Verhandlungsposition zu schreiben, sondern die Widersprüche zu erkennen, in Partnerbriefing und Mandantenmemo zu übersetzen und für die Verhandlung sortiert vorzulegen.

--- a/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/01-partnerauftrag-email.md
+++ b/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/01-partnerauftrag-email.md
@@ -48,7 +48,7 @@ zwei Sachen vergessen:
 
 9. Beirat steht in der Satzung als beratend, soll laut Term Sheet aber Investor Director Approval erteilen. Mapping in das deutsche Organrecht in Datei 14 nutzen.
 
-Ausserdem: ich sehe heute morgen im Postfach die Antwortmail von Brackenmuir über den Roundtrip-Markup, siehe Datei 11. Bitte bevor Sie loslegen, beide Mails parallel lesen. Es bringt nichts, das Term Sheet zu übersetzen, wenn der Markup schon weiterzieht.
+Außerdem: ich sehe heute morgen im Postfach die Antwortmail von Brackenmuir über den Roundtrip-Markup, siehe Datei 11. Bitte bevor Sie loslegen, beide Mails parallel lesen. Es bringt nichts, das Term Sheet zu übersetzen, wenn der Markup schon weiterzieht.
 
 A.
 

--- a/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/02-cap-table-und-gesellschafterliste.md
+++ b/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/02-cap-table-und-gesellschafterliste.md
@@ -47,7 +47,7 @@ Gegenstand: Entwicklung und Vertrieb von Software zur automatisierten Energieopt
 
 ### V19a Current Cap Table, Stand 28.05.2026
 
-| Position | Geschaeftsanteile | Prozent stamm | Bemerkung |
+| Position | Geschäftsanteile | Prozent stamm | Bemerkung |
 | --- | ---: | ---: | --- |
 | Kunigunde Reiter | 12.000 | 40,00 | Stammanteile |
 | Meinhard Voss | 9.000 | 30,00 | Stammanteile |
@@ -55,7 +55,7 @@ Gegenstand: Entwicklung und Vertrieb von Software zur automatisierten Energieopt
 | Stahlauge Ventures GmbH | 3.000 | 10,00 | Seed-Vorzugsanteile, 1x non-participating preference |
 | **Summe ausgegeben** | **30.000** | **100,00** | entspricht Stammkapital 30.000 EUR |
 
-VSOP: 900 virtuelle Anteile zugesagt, davon 360 vested. Keine echten Geschaeftsanteile. Cap-Table-Block separat, nicht in Summe oben.
+VSOP: 900 virtuelle Anteile zugesagt, davon 360 vested. Keine echten Geschäftsanteile. Cap-Table-Block separat, nicht in Summe oben.
 
 Wandeldarlehen Tante Ermelind: Principal 600.000 EUR plus aufgelaufene Zinsen ca. 100.000 EUR per Stand 28.05.2026. Convertible, nicht in Summe oben.
 
@@ -78,39 +78,39 @@ Annahmen Szenario 1:
 | Option Pool reserviert | 5.000 | 11,99 | 5.000 | 8,37 |
 | Tante Ermelind aus Wandlung | 6.700 | 16,07 | 6.700 | 11,21 |
 | Series A Northbridge | 0 | 0 | 16.679 | 27,91 |
-| Series A Kraemer Angels | 0 | 0 | 1.390 | 2,33 |
+| Series A Krämer Angels | 0 | 0 | 1.390 | 2,33 |
 | **Fully Diluted Summe** | **41.700** | **100,00** | **59.769** | **100,02** |
 
-Die Summe 100,02 in der letzten Spalte ist ein Rundungsrest aus zwei Nachkommastellen je Zeile und kein Rechenfehler. Im Excel-Modell mit hoeherer Genauigkeit rechnen.
+Die Summe 100,02 in der letzten Spalte ist ein Rundungsrest aus zwei Nachkommastellen je Zeile und kein Rechenfehler. Im Excel-Modell mit höherer Genauigkeit rechnen.
 
 Berechnungslogik (Skizze, Senior-Review erforderlich):
 
 - Bestehende Anteile 30.000.
-- Pool-Reservierung 12 Prozent auf fully diluted **vor** Series A: Pool / (30.000 + Pool + Convertible-Anteile) = 0,12. Mit Convertible-Anteilen ca. 6.700 ergibt sich Pool ca. 5.000 Anteile (genau 5.005 bei rechnerischer Aufloesung, hier auf 5.000 gerundet).
-- Convertible Wandlung zum Valuation Cap 10 Mio. EUR fully diluted: ca. 6.700 Anteile fuer Tante Ermelind (Principal 600.000 EUR plus aufgelaufene PIK-Zinsen, Cap-Preis liegt unter dem Discount-Preis und greift daher).
+- Pool-Reservierung 12 Prozent auf fully diluted **vor** Series A: Pool / (30.000 + Pool + Convertible-Anteile) = 0,12. Mit Convertible-Anteilen ca. 6.700 ergibt sich Pool ca. 5.000 Anteile (genau 5.005 bei rechnerischer Auflösung, hier auf 5.000 gerundet).
+- Convertible Wandlung zum Valuation Cap 10 Mio. EUR fully diluted: ca. 6.700 Anteile für Tante Ermelind (Principal 600.000 EUR plus aufgelaufene PIK-Zinsen, Cap-Preis liegt unter dem Discount-Preis und greift daher).
 - Pre-Money fully diluted total = 12.000 + 9.000 + 6.000 + 3.000 + 5.000 + 6.700 = 41.700 Anteile.
 - Series-A-Preis pro Anteil = 12.000.000 EUR / 41.700 Anteile = ca. 287,77 EUR.
 - Series-A-Anteile total = 5.200.000 EUR / 287,77 EUR = ca. 18.069 Anteile.
-- Aufteilung Lead vs Co-Investor im Verhaeltnis 4,8 zu 0,4 Mio. EUR (gemaess Subscription-Liste in Datei 03 Ziff. 2): Northbridge 4,8/5,2 x 18.069 = ca. 16.679 Anteile; Kraemer Angels 0,4/5,2 x 18.069 = ca. 1.390 Anteile.
+- Aufteilung Lead vs Co-Investor im Verhältnis 4,8 zu 0,4 Mio. EUR (intern festgelegte Subscription-Aufteilung gemäß CFO-Slack-Thread vom 28.05.2026, dokumentiert oben in dieser Datei; Datei 03 Ziff. 2 verlangt insoweit nur eine Lead-Mindestquote von 75 Prozent und legt die genauen Anteile der Co-Investoren nicht fest): Northbridge 4,8/5,2 x 18.069 = ca. 16.679 Anteile; Krämer Angels 0,4/5,2 x 18.069 = ca. 1.390 Anteile.
 - Post-money fully diluted total = 41.700 + 18.069 = 59.769 Anteile.
-- Plausibilitaetscheck Northbridge-Quote = 16.679 / 59.769 = ca. 27,9 Prozent, konsistent mit der vom Lead intern kommunizierten Zielquote von rund 25 bis 30 Prozent.
+- Plausibilitätscheck Northbridge-Quote = 16.679 / 59.769 = ca. 27,9 Prozent, konsistent mit der vom Lead intern kommunizierten Zielquote von rund 25 bis 30 Prozent.
 
-Hinweis: Diese Zahlen sind eine **Skizze**. Die exakten Wandlungs- und Pool-Anteile sind im Excel-Modell auszurechnen. Adelheid hat ausdruecklich verboten, sie ohne Verifikation an Northbridge zu kommunizieren.
+Hinweis: Diese Zahlen sind eine **Skizze**. Die exakten Wandlungs- und Pool-Anteile sind im Excel-Modell auszurechnen. Adelheid hat ausdrücklich verboten, sie ohne Verifikation an Northbridge zu kommunizieren.
 
 ### V19c Projected Post-Closing Cap Table (Szenario 2: Pool 12 Prozent post-money)
 
 Annahmen Szenario 2:
 
-- Pool wird **post-money** 12 Prozent fully diluted. Mathematisch traegt Northbridge den Pool anteilig mit.
-- Series-A-Subscription unveraendert 5,2 Mio. EUR.
+- Pool wird **post-money** 12 Prozent fully diluted. Mathematisch trägt Northbridge den Pool anteilig mit.
+- Series-A-Subscription unverändert 5,2 Mio. EUR.
 
-Wirtschaftlicher Effekt: Bestandsgesellschafter haben hier rund 1,5 Prozentpunkte hoehere Quoten als in Szenario 1, Northbridge etwas weniger. Vorrechnung im Excel-Modell, mit Mandantin am Tisch durchgehen.
+Wirtschaftlicher Effekt: Bestandsgesellschafter haben hier rund 1,5 Prozentpunkte höhere Quoten als in Szenario 1, Northbridge etwas weniger. Vorrechnung im Excel-Modell, mit Mandantin am Tisch durchgehen.
 
-## Stueck-fuer-Stueck-Rechnung mit Pruefschritten
+## Stück-für-Stück-Rechnung mit Prüfschritten
 
 Schritt 1: Stammkapital und ausgegebene Anteile (entspricht V19a oben).
 
-Schritt 2: VSOP-Block separat ausweisen. Virtuelle Anteile fuehren nicht zu Geschaeftsanteilen. Cap-Table-Behandlung haengt vom Series-A-SHA ab.
+Schritt 2: VSOP-Block separat ausweisen. Virtuelle Anteile führen nicht zu Geschäftsanteilen. Cap-Table-Behandlung hängt vom Series-A-SHA ab.
 
 Schritt 3: Wandeldarlehen mit Discount-Variante und Valuation-Cap-Variante rechnen, niedrigere Conversion Price greift. Annahme bei Series-A-Pre-Money 12 Mio. EUR: Valuation Cap wirkt.
 
@@ -118,16 +118,16 @@ Schritt 4: Pool-Shuffle ausrechnen, beide Szenarien (Pre-Money und Post-Money).
 
 Schritt 5: Series-A-Preis je Anteil bestimmen, Subscription Amount durch Preis je Anteil teilen, Aufteilung Lead und Co-Investor nach Subscription-Anteilen.
 
-Schritt 6: Fully-diluted-Summe pruefen, Quoten ausrechnen, Konsistenz mit Term-Sheet-Erwartung (etwa 25 Prozent Northbridge post-money fully diluted) verifizieren.
+Schritt 6: Fully-diluted-Summe prüfen, Quoten ausrechnen, Konsistenz mit Term-Sheet-Erwartung (etwa 25 Prozent Northbridge post-money fully diluted) verifizieren.
 
 ## Was Kunigunde wissen muss
 
-- **Gesellschafterliste** ist die offizielle Liste der eingetragenen Geschaeftsanteile.
+- **Gesellschafterliste** ist die offizielle Liste der eingetragenen Geschäftsanteile.
 - **Cap Table** ist das interne Bild, das alles abbildet: Anteile, Optionen, Convertibles, virtuelle Beteiligungen.
-- **Pre-Money-Pool-Shuffle** trifft wirtschaftlich die Gruender, weil die zusaetzlichen Pool-Anteile aus dem Pre-Money-Bestand herausgerechnet werden.
+- **Pre-Money-Pool-Shuffle** trifft wirtschaftlich die Gründer, weil die zusätzlichen Pool-Anteile aus dem Pre-Money-Bestand herausgerechnet werden.
 - **Wandeldarlehen Tante Ermelind** bekommt rechnerisch mehr Anteile als Investoren, die zum gleichen Zeitpunkt frisches Geld einbringen, weil Discount oder Valuation Cap greifen.
-- **VSOP** verwaessert ebenfalls, sobald virtuelle Anteile in Vergleichsmechaniken einbezogen werden.
+- **VSOP** verwässert ebenfalls, sobald virtuelle Anteile in Vergleichsmechaniken einbezogen werden.
 
-## Senior-Review-Gate vor jeder Aussenkommunikation
+## Senior-Review-Gate vor jeder Außenkommunikation
 
-Kein Cap-Table-Zahlenwert geht an Northbridge oder Brackenmuir, bevor Adelheid die V19 abgezeichnet hat. Excel-Modell mit Pruefblatt, das alle Inputs gegen Quelldokumente verlinkt.
+Kein Cap-Table-Zahlenwert geht an Northbridge oder Brackenmuir, bevor Adelheid die V19 abgezeichnet hat. Excel-Modell mit Prüfblatt, das alle Inputs gegen Quelldokumente verlinkt.

--- a/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/04-sha-satzung-und-vesting-notizen.md
+++ b/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/04-sha-satzung-und-vesting-notizen.md
@@ -2,7 +2,7 @@
 
 > Fiktive Lehrakte. Aehnlichkeiten zu realen Transaktionen sind nicht beabsichtigt.
 
-Diese Datei ist eine Arbeitsunterlage des Associates, die zentrale Bestimmungen der Satzung und des Seed-SHA dem Term Sheet (Datei 03) und dem geplanten Series-A-SHA gegenueberstellt. Sie ist bewusst tabellarisch und nicht beurkundungsreif. Die Partnerin Adelheid von Westarp hat den Auftrag erteilt, jede Diskrepanz als Verhandlungsfrage zu markieren.
+Diese Datei ist eine Arbeitsunterlage des Associates, die zentrale Bestimmungen der Satzung und des Seed-SHA dem Term Sheet (Datei 03) und dem geplanten Series-A-SHA gegenüberstellt. Sie ist bewusst tabellarisch und nicht beurkundungsreif. Die Partnerin Adelheid von Westarp hat den Auftrag erteilt, jede Diskrepanz als Verhandlungsfrage zu markieren.
 
 ---
 
@@ -10,72 +10,72 @@ Diese Datei ist eine Arbeitsunterlage des Associates, die zentrale Bestimmungen 
 
 ### § 3 Stammkapital
 
-Das Stammkapital der Gesellschaft betraegt EUR 25.000 und ist eingeteilt in 25.000 Geschaeftsanteile zu je EUR 1,00.
+Das Stammkapital der Gesellschaft beträgt EUR 25.000 und ist eingeteilt in 25.000 Geschäftsanteile zu je EUR 1,00.
 
-### § 4 Geschaeftsfuehrung und Vertretung
+### § 4 Geschäftsführung und Vertretung
 
-Die Gesellschaft hat einen oder mehrere Geschaeftsfuehrer. Ist nur ein Geschaeftsfuehrer bestellt, vertritt er die Gesellschaft allein. Sind mehrere Geschaeftsfuehrer bestellt, wird die Gesellschaft durch zwei Geschaeftsfuehrer gemeinschaftlich oder durch einen Geschaeftsfuehrer in Gemeinschaft mit einem Prokuristen vertreten. Einzelvertretungsbefugnis und Befreiung von § 181 BGB koennen durch Gesellschafterbeschluss eingeraeumt werden.
+Die Gesellschaft hat einen oder mehrere Geschäftsführer. Ist nur ein Geschäftsführer bestellt, vertritt er die Gesellschaft allein. Sind mehrere Geschäftsführer bestellt, wird die Gesellschaft durch zwei Geschäftsführer gemeinschaftlich oder durch einen Geschäftsführer in Gemeinschaft mit einem Prokuristen vertreten. Einzelvertretungsbefugnis und Befreiung von § 181 BGB können durch Gesellschafterbeschluss eingeräumt werden.
 
-### § 5 Geschaeftsjahr
+### § 5 Geschäftsjahr
 
-Das Geschaeftsjahr ist das Kalenderjahr.
+Das Geschäftsjahr ist das Kalenderjahr.
 
-### § 6 Uebertragung von Geschaeftsanteilen
+### § 6 Übertragung von Geschäftsanteilen
 
-Die Abtretung von Geschaeftsanteilen oder Teilen von Geschaeftsanteilen sowie jede Belastung beduerfen der vorherigen Zustimmung der Gesellschafterversammlung mit einer Mehrheit von 75 Prozent der abgegebenen Stimmen. Die Zustimmung darf nur aus wichtigem Grund verweigert werden. Vinkulierungsklauseln gemaess § 15 Abs. 5 GmbHG.
+Die Abtretung von Geschäftsanteilen oder Teilen von Geschäftsanteilen sowie jede Belastung bedürfen der vorherigen Zustimmung der Gesellschafterversammlung mit einer Mehrheit von 75 Prozent der abgegebenen Stimmen. Die Zustimmung darf nur aus wichtigem Grund verweigert werden. Vinkulierungsklauseln gemäß § 15 Abs. 5 GmbHG.
 
 ### § 7 Einziehung
 
-Geschaeftsanteile koennen aus den in der Satzung genannten Gruenden (insbesondere bei wesentlicher Vertragsverletzung, Insolvenz des Gesellschafters, Pfaendung) ohne Zustimmung des betroffenen Gesellschafters eingezogen werden. Das Einziehungsentgelt entspricht dem Verkehrswert, im Bad-Leaver-Fall jedoch dem Nominalwert.
+Geschäftsanteile können aus den in der Satzung genannten Gründen (insbesondere bei wesentlicher Vertragsverletzung, Insolvenz des Gesellschafters, Pfändung) ohne Zustimmung des betroffenen Gesellschafters eingezogen werden. Das Einziehungsentgelt entspricht dem Verkehrswert, im Bad-Leaver-Fall jedoch dem Nominalwert.
 
-### § 8 Beschluesse
+### § 8 Beschlüsse
 
-Beschluesse werden mit einfacher Mehrheit der abgegebenen Stimmen gefasst, soweit Gesetz oder Satzung keine hoehere Mehrheit vorsehen. Satzungsaenderungen, Kapitalmassnahmen, Aufloesung und Verschmelzungen beduerfen einer Mehrheit von 75 Prozent.
+Beschlüsse werden mit einfacher Mehrheit der abgegebenen Stimmen gefasst, soweit Gesetz oder Satzung keine höhere Mehrheit vorsehen. Satzungsänderungen, Kapitalmaßnahmen, Auflösung und Verschmelzungen bedürfen einer Mehrheit von 75 Prozent.
 
 ### § 9 Gesellschafterversammlung
 
-Die ordentliche Gesellschafterversammlung findet einmal im Jahr statt. Ausserordentliche Versammlungen koennen von der Geschaeftsfuehrung oder Gesellschaftern, die zusammen mindestens 10 Prozent der Stimmen halten, einberufen werden.
+Die ordentliche Gesellschafterversammlung findet einmal im Jahr statt. Außerordentliche Versammlungen können von der Geschäftsführung oder Gesellschaftern, die zusammen mindestens 10 Prozent der Stimmen halten, einberufen werden.
 
 ### § 10 Gewinnverwendung
 
-Soweit nicht durch Gesellschafterbeschluss eine andere Verwendung beschlossen wird, wird der Bilanzgewinn an die Gesellschafter im Verhaeltnis ihrer Geschaeftsanteile ausgeschuettet.
+Soweit nicht durch Gesellschafterbeschluss eine andere Verwendung beschlossen wird, wird der Bilanzgewinn an die Gesellschafter im Verhältnis ihrer Geschäftsanteile ausgeschüttet.
 
 ### § 11 Beirat
 
-Die Gesellschaft kann durch Gesellschafterbeschluss einen Beirat einrichten. Der Beirat beraet die Geschaeftsfuehrung. Eigenstaendige Entscheidungsbefugnisse stehen ihm nicht zu, soweit ihm solche nicht durch gesonderte Geschaeftsordnung uebertragen werden.
+Die Gesellschaft kann durch Gesellschafterbeschluss einen Beirat einrichten. Der Beirat berät die Geschäftsführung. Eigenständige Entscheidungsbefugnisse stehen ihm nicht zu, soweit ihm solche nicht durch gesonderte Geschäftsordnung übertragen werden.
 
 ### § 12 Bekanntmachungen
 
-Bekanntmachungen erfolgen ausschliesslich im Bundesanzeiger.
+Bekanntmachungen erfolgen ausschließlich im Bundesanzeiger.
 
 ---
 
 ## B Seed-SHA Auszug (Stand: 12.01.2024)
 
-Parteien: die Gruender (Kunigunde, Meinhard, Walburga), die Gesellschaft, Stahlauge Ventures GmbH, der Kraemer Angel Pool GbR.
+Parteien: die Gründer (Kunigunde, Meinhard, Walburga), die Gesellschaft, Stahlauge Ventures GmbH, der Krämer Angel Pool GbR.
 
 ### Ziff. 3 Informationsrechte Stahlauge
 
 - Monatsreporting bis zum 15. Folgemonat.
-- Quartalsgespraech (jour fixe).
-- Budgetentwurf zum 15.11. fuer das Folgejahr.
+- Quartalsgespräch (jour fixe).
+- Budgetentwurf zum 15.11. für das Folgejahr.
 - Auditierter Jahresabschluss bis 30.06.
 
 ### Ziff. 4 Vinkulierung und Transfers
 
-- Gruender duerfen ohne Zustimmung der Gesellschafterversammlung und der Stahlauge keine Geschaeftsanteile uebertragen.
+- Gründer dürfen ohne Zustimmung der Gesellschafterversammlung und der Stahlauge keine Geschäftsanteile übertragen.
 - Permitted Transfers: Holdingvehikel, Verwandte ersten Grades.
 
-### Ziff. 5 Vesting der Gruender
+### Ziff. 5 Vesting der Gründer
 
-- Reverse Vesting ueber 36 Monate ab 01.01.2024.
+- Reverse Vesting über 36 Monate ab 01.01.2024.
 - Kein Cliff (alter Investor wollte ihn nicht).
 - Monatliches Vesting in 36 gleichen Raten.
 
 ### Ziff. 6 Leaver
 
-- Bad Leaver: ausserordentliche Kuendigung aus wichtigem Grund, Straftat zulasten der Gesellschaft, vorsaetzliche Pflichtverletzung; Call zum Nennwert auf alle nicht-gevesteten und auf 50 Prozent der gevesteten Anteile.
-- Good Leaver: Tod, dauerhafte Berufsunfaehigkeit, Kuendigung ohne wichtigen Grund durch die Gesellschaft; Call zum Nennwert auf nicht-gevestete Anteile, Verkehrswert auf gevestete.
+- Bad Leaver: außerordentliche Kündigung aus wichtigem Grund, Straftat zulasten der Gesellschaft, vorsätzliche Pflichtverletzung; Call zum Nennwert auf alle nicht-gevesteten und auf 50 Prozent der gevesteten Anteile.
+- Good Leaver: Tod, dauerhafte Berufsunfähigkeit, Kündigung ohne wichtigen Grund durch die Gesellschaft; Call zum Nennwert auf nicht-gevestete Anteile, Verkehrswert auf gevestete.
 
 ### Ziff. 7 Drag-Along
 
@@ -83,7 +83,7 @@ Parteien: die Gruender (Kunigunde, Meinhard, Walburga), die Gesellschaft, Stahla
 
 ### Ziff. 8 Tag-Along
 
-- Tag bei Verkauf von mehr als 30 Prozent der Geschaeftsanteile durch Gruender.
+- Tag bei Verkauf von mehr als 30 Prozent der Geschäftsanteile durch Gründer.
 
 ### Ziff. 9 Liquidation Preference
 
@@ -91,7 +91,7 @@ Parteien: die Gruender (Kunigunde, Meinhard, Walburga), die Gesellschaft, Stahla
 
 ### Ziff. 10 Wettbewerbsverbot
 
-- 12 Monate post-termination, auf Markt und Geographie der Gesellschaft beschraenkt.
+- 12 Monate post-termination, auf Markt und Geographie der Gesellschaft beschränkt.
 
 ---
 
@@ -99,17 +99,17 @@ Parteien: die Gruender (Kunigunde, Meinhard, Walburga), die Gesellschaft, Stahla
 
 | Thema | Satzung 12.01.2024 | Seed-SHA 12.01.2024 | Term Sheet Series A (Datei 03) | Anpassungsbedarf |
 |---|---|---|---|---|
-| Vinkulierung | 75 Prozent Gesellschafter | Plus Stahlauge-Zustimmung | "Series A Majority" | Mehrheitserfordernisse harmonisieren; Stahlauge-Veto klaeren |
-| Vesting Cliff | n/a | kein Cliff | 12 Monate Cliff | Cliff fuer alte Anteile politisch heikel |
+| Vinkulierung | 75 Prozent Gesellschafter | Plus Stahlauge-Zustimmung | "Series A Majority" | Mehrheitserfordernisse harmonisieren; Stahlauge-Veto klären |
+| Vesting Cliff | n/a | kein Cliff | 12 Monate Cliff | Cliff für alte Anteile politisch heikel |
 | Vesting Dauer | n/a | 36 Monate ab 01.01.2024 | 48 Monate ab Closing | Anrechnung Seed-Vesting verhandeln |
 | Vesting Reset | n/a | n/a | impliziter Reset ab Closing | Wirtschaftlich harter Reset; Partnerbriefing |
 | Bad Leaver Call | n/a | Nennwert auf 100 Prozent unvested + 50 Prozent vested | Nennwert auf 100 Prozent unvested + Option auf vested | Schwellen abstimmen |
 | Good Leaver Call | n/a | Verkehrswert auf vested | Verkehrswert auf vested | konsistent |
 | Drag-Along | n/a | 70 Prozent ohne Investor-Mehrheit | 60 Prozent plus Series A Majority | Schwelle harmonisieren |
-| Tag-Along | n/a | Verkauf > 30 Prozent durch Gruender | Verkauf > 5 Prozent durch jeden | Schwellen anpassen |
-| Liquidation Pref | n/a | 1x non-participating Seed | 1x non-participating Series A; "higher of" | Stack klaeren: pari passu oder Senior |
+| Tag-Along | n/a | Verkauf > 30 Prozent durch Gründer | Verkauf > 5 Prozent durch jeden | Schwellen anpassen |
+| Liquidation Pref | n/a | 1x non-participating Seed | 1x non-participating Series A; "higher of" | Stack klären: pari passu oder Senior |
 | Anti-Dilution | n/a | keine | broad-based weighted average | neu in Satzung implementieren |
-| Beirat | "kann eingerichtet werden" (§ 11 Satzung) | nicht geregelt | 5 Mitglieder, Investor Director, Reserved Matters | Satzung & Geschaeftsordnung neu schreiben |
+| Beirat | "kann eingerichtet werden" (§ 11 Satzung) | nicht geregelt | 5 Mitglieder, Investor Director, Reserved Matters | Satzung & Geschäftsordnung neu schreiben |
 | Wettbewerbsverbot | n/a | 12 Monate | 24 Monate | Wirksamkeitsrisiko § 110 HGB analog/BGH-Rspr. zu GF-Wettbewerbsverboten |
 | Information Rights | n/a | Stahlauge nur | Series A plus Stahlauge (MFN aus Side Letter) | konsistente Reports |
 | Kosten der Investoren | n/a | n/a | Cap EUR 90.000 plus VAT, ggf. EUR 45.000 | neu |
@@ -120,19 +120,19 @@ Parteien: die Gruender (Kunigunde, Meinhard, Walburga), die Gesellschaft, Stahla
 
 ## D Unklare Punkte aus CFO-Kommentar (Olaf Eichholtz, 18.05.2026, 23:07 Uhr per Slack)
 
-1. Die Series-A-Vesting-Regel startet am Closing erneut. Gruender meinen, die Seed-Vesting-Zeit muesse angerechnet werden. Wirtschaftlich harter Reset von circa 28 Monaten.
-2. Der Beirat soll laut Term Sheet "investor director approval" erteilen. Nach aktueller Satzung beraet er nur. Frage Olaf: "Brauchen wir eine neue Satzung oder reicht eine Geschaeftsordnung?"
+1. Die Series-A-Vesting-Regel startet am Closing erneut. Gründer meinen, die Seed-Vesting-Zeit müsse angerechnet werden. Wirtschaftlich harter Reset von circa 28 Monaten.
+2. Der Beirat soll laut Term Sheet "investor director approval" erteilen. Nach aktueller Satzung berät er nur. Frage Olaf: "Brauchen wir eine neue Satzung oder reicht eine Geschäftsordnung?"
 3. Drag-Schwelle im Seed-SHA 70 Prozent, im Series-A-Term-Sheet 60 Prozent plus Series A Majority. "Welche gilt nach Closing?"
 4. Vinkulierung in Satzung verlangt 75 Prozent. Term Sheet spricht nur von Series A Majority. "Konflikt zwischen Satzung und schuldrechtlichem SHA?"
-5. Es gibt keine deutsche Fassung des Term Sheets. Olaf fragt: "Reicht die englische Fassung fuer den Notar?"
-6. Wettbewerbsverbot von 24 Monaten: "Walburga hat einen Beratungsvertrag mit einer befreundeten Firma. Faellt das darunter?"
+5. Es gibt keine deutsche Fassung des Term Sheets. Olaf fragt: "Reicht die englische Fassung für den Notar?"
+6. Wettbewerbsverbot von 24 Monaten: "Walburga hat einen Beratungsvertrag mit einer befreundeten Firma. Fällt das darunter?"
 7. Liquidation Preference: "Stehen Stahlauge und Northbridge dann pari passu oder senior?"
-8. Anti-Dilution: "Greift die auch, wenn wir spaeter ein Wandeldarlehen auflegen?"
+8. Anti-Dilution: "Greift die auch, wenn wir später ein Wandeldarlehen auflegen?"
 9. Tante Ermelind: "Tante Ermelind will Series-A-Preferred-Shares zum Cap-Preis. Welcher Preis ist das genau?"
-10. Krämer Angel Pool: "Der Pool ist eine GbR. Hat der ueberhaupt Tag-Along-Rechte oder muessen wir die einzeln aufnehmen?"
+10. Krämer Angel Pool: "Der Pool ist eine GbR. Hat der überhaupt Tag-Along-Rechte oder müssen wir die einzeln aufnehmen?"
 
 ---
 
 ## E Notiz Hildemar K. zu § 6 Satzung und Vinkulierung
 
-Die Vinkulierung verlangt 75 Prozent. Wenn das Term Sheet "Series A Majority" verlangt, ist das eine schuldrechtliche Zusatzhuerde, keine gesellschaftsrechtliche Erleichterung. Eine Aenderung der Satzung waere theoretisch denkbar, aber die Altgesellschafter Stahlauge und Kraemer-Pool wuerden zustimmen muessen. Vorschlag: Vinkulierung in Satzung beibehalten und im SHA eine Zustimmungspflicht der Series A Majority ergaenzen; im Innenverhaeltnis verpflichten sich alle, ihre Stimmen entsprechend abzugeben. Klassischer SHA-Trick, sollte aber von Adelheid abgesegnet werden.
+Die Vinkulierung verlangt 75 Prozent. Wenn das Term Sheet "Series A Majority" verlangt, ist das eine schuldrechtliche Zusatzhürde, keine gesellschaftsrechtliche Erleichterung. Eine Änderung der Satzung wäre theoretisch denkbar, aber die Altgesellschafter Stahlauge und Krämer-Pool würden zustimmen müssen. Vorschlag: Vinkulierung in Satzung beibehalten und im SHA eine Zustimmungspflicht der Series A Majority ergänzen; im Innenverhältnis verpflichten sich alle, ihre Stimmen entsprechend abzugeben. Klassischer SHA-Trick, sollte aber von Adelheid abgesegnet werden.

--- a/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/05-dd-red-flags-und-client-fragen.md
+++ b/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/05-dd-red-flags-und-client-fragen.md
@@ -2,7 +2,7 @@
 
 > Fiktive Lehrakte. Aehnlichkeiten zu realen Transaktionen sind nicht beabsichtigt.
 
-Dieses Dokument ist ein **Working Draft** des DD-Index aus dem virtuellen Datenraum "comet-moth-2026". Die Partnerin Adelheid von Westarp hat Hildemar K. beauftragt, jeden Befund mit (i) DD-Findung, (ii) Risiko-Einordnung, (iii) Frage an die Mandantin und (iv) moeglichem Closing-Mechanismus zu versehen. Der Datenraumindex selbst hat ueber 600 Eintraege; die nachfolgende Liste filtert die fuer Corporate-Legal-English-Didaktik relevanten Befunde.
+Dieses Dokument ist ein **Working Draft** des DD-Index aus dem virtuellen Datenraum "comet-moth-2026". Die Partnerin Adelheid von Westarp hat Hildemar K. beauftragt, jeden Befund mit (i) DD-Findung, (ii) Risiko-Einordnung, (iii) Frage an die Mandantin und (iv) möglichem Closing-Mechanismus zu versehen. Der Datenraumindex selbst hat über 600 Einträge; die nachfolgende Liste filtert die für Corporate-Legal-English-Didaktik relevanten Befunde.
 
 ---
 
@@ -35,7 +35,7 @@ Dieses Dokument ist ein **Working Draft** des DD-Index aus dem virtuellen Datenr
 09_Data_Protection
 ```
 
-Hildemar hat die fuer das Plugin relevanten Funde in den nachfolgenden Abschnitten zusammengefasst. Die Quelle ist immer der Datenraum, nicht externe Datenbanken.
+Hildemar hat die für das Plugin relevanten Funde in den nachfolgenden Abschnitten zusammengefasst. Die Quelle ist immer der Datenraum, nicht externe Datenbanken.
 
 ---
 
@@ -43,38 +43,38 @@ Hildemar hat die fuer das Plugin relevanten Funde in den nachfolgenden Abschnitt
 
 ### B.1 Gesellschafterliste vs Cap Table
 
-| Punkt | Befund | Risiko | Massnahme |
+| Punkt | Befund | Risiko | Maßnahme |
 |---|---|---|---|
-| Eingereichte Gesellschafterliste | Stand Maerz 2024, ohne VSOP, ohne Wandeldarlehen | mittel | Pre-Closing-Liste durch Notar zum Stand nach Closing |
+| Eingereichte Gesellschafterliste | Stand März 2024, ohne VSOP, ohne Wandeldarlehen | mittel | Pre-Closing-Liste durch Notar zum Stand nach Closing |
 | CFO-Cap-Table | Stand Mai 2026, inkl. VSOP (Phantom) und Tante-Ermelind-Wandeldarlehen | hoch | Trennung Cap Table (wirtschaftlich) vs Gesellschafterliste (§ 40 GmbHG) sauber dokumentieren |
 | Diskrepanz | Prozentwerte abweichend, weil Pool, Wandeldarlehen und VSOP eingerechnet | hoch | Reconciliation Sheet anlegen, Disclosure Schedule erstellen |
 
-Client-Frage Olaf (CFO): "Ist die Gesellschafterliste falsch?" — Antwort: Nein, sie ist nicht falsch, sondern bildet nur den Status quo der formalen Geschaeftsanteile ab. Cap Table ist eine wirtschaftliche Projektion.
+Client-Frage Olaf (CFO): "Ist die Gesellschafterliste falsch?" — Antwort: Nein, sie ist nicht falsch, sondern bildet nur den Status quo der formalen Geschäftsanteile ab. Cap Table ist eine wirtschaftliche Projektion.
 
 ### B.2 Wandeldarlehen Tante Ermelind Capital UG
 
 | Punkt | Befund | Risiko |
 |---|---|---|
-| Form | DocuSign | gering fuer das schuldrechtliche Darlehen selbst |
-| Wandlung | "shall convert into Series A Preferred Shares" | hoch — Wandlung beduerfte Kapitalerhoehung mit Beurkundung § 53 GmbHG i.V.m. § 55 GmbHG |
-| Definitionsverweis | "customary long-form documents" | mittel — Auslegungsstreit moeglich |
+| Form | DocuSign | gering für das schuldrechtliche Darlehen selbst |
+| Wandlung | "shall convert into Series A Preferred Shares" | hoch — Wandlung bedürfte Kapitalerhöhung mit Beurkundung § 53 GmbHG i.V.m. § 55 GmbHG |
+| Definitionsverweis | "customary long-form documents" | mittel — Auslegungsstreit möglich |
 | Discount, Cap | 20 Prozent, EUR 10 Mio. | dokumentiert |
 | Zinsen | 8 Prozent PIK p.a. | dokumentiert |
-| Vorzeitige Rueckzahlung | nicht geregelt | offener Punkt |
+| Vorzeitige Rückzahlung | nicht geregelt | offener Punkt |
 
-Client-Frage Walburga: "Tante Ermelind glaubt, sie sei schon Gesellschafterin." — Antwort: Nein, ein Wandeldarlehen begruendet einen schuldrechtlichen Anspruch auf kuenftige Geschaeftsanteile, keine bestehende Gesellschafterstellung.
+Client-Frage Walburga: "Tante Ermelind glaubt, sie sei schon Gesellschafterin." — Antwort: Nein, ein Wandeldarlehen begründet einen schuldrechtlichen Anspruch auf künftige Geschäftsanteile, keine bestehende Gesellschafterstellung.
 
 ### B.3 Beirat und Board Minutes
 
-Der Beirat hat seit Gruendung sieben Sitzungen abgehalten, aber nur drei Protokolle wurden ordentlich gefertigt. Die uebrigen liegen als Slack-Threads vor. Wenn der Series-A-SHA Reserved-Matters-Zustimmungen verlangt, muessen wir eine saubere Geschaeftsordnung und ein Protokollbuch einrichten.
+Der Beirat hat seit Gründung sieben Sitzungen abgehalten, aber nur drei Protokolle wurden ordentlich gefertigt. Die übrigen liegen als Slack-Threads vor. Wenn der Series-A-SHA Reserved-Matters-Zustimmungen verlangt, müssen wir eine saubere Geschäftsordnung und ein Protokollbuch einrichten.
 
 ### B.4 Powers of Attorney
 
-Es existieren zwei generelle Vollmachten zugunsten Meinhards, beide notariell beurkundet 2023. Eine davon ist auf "Bankgeschaefte" beschraenkt. Im Datenraum fehlt eine aktualisierte Generalvollmacht fuer Notartermine zugunsten Adelheids. Pre-Closing erforderlich.
+Es existieren zwei generelle Vollmachten zugunsten Meinhards, beide notariell beurkundet 2023. Eine davon ist auf "Bankgeschäfte" beschränkt. Im Datenraum fehlt eine aktualisierte Generalvollmacht für Notartermine zugunsten Adelheids. Pre-Closing erforderlich.
 
 ### B.5 VSOP-Plan 2024
 
-Phantom-Stock-Plan, virtuelle Anteile, Vesting 48 Monate mit 12-Monats-Cliff. Aktuelle Allokation: 850.000 EUR an virtuellem Wert auf 14 Mitarbeiter, davon ein Schluesselentwickler mit 280.000 EUR. Trigger-Events: Exit. Im Datenraum kein Acceleration-Mechanismus dokumentiert.
+Phantom-Stock-Plan, virtuelle Anteile, Vesting 48 Monate mit 12-Monats-Cliff. Aktuelle Allokation: 850.000 EUR an virtuellem Wert auf 14 Mitarbeiter, davon ein Schlüsselentwickler mit 280.000 EUR. Trigger-Events: Exit. Im Datenraum kein Acceleration-Mechanismus dokumentiert.
 
 ---
 
@@ -84,36 +84,36 @@ Phantom-Stock-Plan, virtuelle Anteile, Vesting 48 Monate mit 12-Monats-Cliff. Ak
 
 Englische Klausel: "All work product, including but not limited to source code, designs and documentation, shall be deemed work made for hire and shall vest exclusively in the Company."
 
-Risiko: Die Rechtsfigur "work made for hire" gibt es im deutschen Urheberrecht nicht. Eine wirksame Uebertragung der ausschliesslichen Nutzungsrechte nach § 31 UrhG verlangt nach deutscher Rechtslage zumindest eine zweckorientierte Auslegung (Zweckuebertragungslehre, § 31 Abs. 5 UrhG). Die generische "work made for hire"-Klausel ist im Zweifel unwirksam fuer die hier benoetigten ausschliesslichen Rechte.
+Risiko: Die Rechtsfigur "work made for hire" gibt es im deutschen Urheberrecht nicht. Eine wirksame Übertragung der ausschließlichen Nutzungsrechte nach § 31 UrhG verlangt nach deutscher Rechtslage zumindest eine zweckorientierte Auslegung (Zweckübertragungslehre, § 31 Abs. 5 UrhG). Die generische "work made for hire"-Klausel ist im Zweifel unwirksam für die hier benötigten ausschließlichen Rechte.
 
-Massnahme: Pre-Closing Nachbesserungsvertrag mit den betroffenen Entwicklern, der die Rechteuebertragung nach deutschem Recht klarstellt.
+Maßnahme: Pre-Closing Nachbesserungsvertrag mit den betroffenen Entwicklern, der die Rechteübertragung nach deutschem Recht klarstellt.
 
 ### C.2 Open-Source-Inventar
 
-Im Datenraum eine Excel-Liste mit 47 verwendeten OSS-Komponenten. Drei davon stehen unter AGPL. Risiko: Bei Distribution der Software (z.B. SaaS-Sonderfaelle) Copyleft-Effekt moeglich.
+Im Datenraum eine Excel-Liste mit 47 verwendeten OSS-Komponenten. Drei davon stehen unter AGPL. Risiko: Bei Distribution der Software (z.B. SaaS-Sonderfälle) Copyleft-Effekt möglich.
 
-Frage an die Mandantin: Wird die Software je beim Kunden installiert oder ausschliesslich als SaaS betrieben? Die Antwort entscheidet, ob die AGPL-Komponenten neutralisiert werden muessen.
+Frage an die Mandantin: Wird die Software je beim Kunden installiert oder ausschließlich als SaaS betrieben? Die Antwort entscheidet, ob die AGPL-Komponenten neutralisiert werden müssen.
 
 ### C.3 Marken
 
-Wortmarke "Comet Moth" angemeldet beim DPMA und EUIPO, aber im Datenraum ist nur die DPMA-Anmeldung in Bestaetigungsphase. EUIPO-Status: "Pruefungsverfahren". Risiko: gering bis mittel.
+Wortmarke "Comet Moth" angemeldet beim DPMA und EUIPO, aber im Datenraum ist nur die DPMA-Anmeldung in Bestätigungsphase. EUIPO-Status: "Prüfungsverfahren". Risiko: gering bis mittel.
 
 ---
 
 ## D Employment Findings
 
-### D.1 Geschaeftsfuehrer-Anstellungsvertraege
+### D.1 Geschäftsführer-Anstellungsverträge
 
-Drei Anstellungsvertraege fuer die Gruender, alle in englischer Sprache, mit deutschem Recht (Vertragsstatut). Punkte:
+Drei Anstellungsverträge für die Gründer, alle in englischer Sprache, mit deutschem Recht (Vertragsstatut). Punkte:
 
-- Kuendigungsfrist: "six months notice". Achtung: GmbH-Geschaeftsfuehrer unterliegen nicht dem KSchG, aber besondere Schutzregelungen gelten nicht ohne weiteres analog.
+- Kündigungsfrist: "six months notice". Achtung: GmbH-Geschäftsführer unterliegen nicht dem KSchG, aber besondere Schutzregelungen gelten nicht ohne weiteres analog.
 - Gehalt: jeweils EUR 120.000, plus Bonus bis 30 Prozent.
-- Wettbewerbsverbot post-termination: 12 Monate, Entschaedigung 50 Prozent. Series-A-Term-Sheet will 24 Monate. Frage an Partnerin: Reicht eine Ergaenzungsvereinbarung oder muss der Anstellungsvertrag neu gefasst werden?
-- D&O-Versicherung: nicht erwaehnt.
+- Wettbewerbsverbot post-termination: 12 Monate, Entschädigung 50 Prozent. Series-A-Term-Sheet will 24 Monate. Frage an Partnerin: Reicht eine Ergänzungsvereinbarung oder muss der Anstellungsvertrag neu gefasst werden?
+- D&O-Versicherung: nicht erwähnt.
 
 ### D.2 Mitarbeiter
 
-48 Mitarbeiter, alle in Deutschland angestellt. Keine Betriebsraete. Keine Tarifbindung.
+48 Mitarbeiter, alle in Deutschland angestellt. Keine Betriebsräte. Keine Tarifbindung.
 
 ### D.3 Whistleblowing
 
@@ -125,17 +125,17 @@ Hinweisgebersystem nach HinSchG existiert nicht. Die Gesellschaft hat 48 Mitarbe
 
 ### E.1 Enterprise-Kunde mit Change-of-Control-Klausel
 
-Vertrag mit Mertensbrueder & Co. KG vom 14.08.2025, Auftragsvolumen 1,4 Mio. EUR p.a. Klausel: "The customer may terminate this agreement with immediate effect upon any change of control affecting more than 50 percent of the voting rights of the supplier."
+Vertrag mit Mertensbrüder & Co. KG vom 14.08.2025, Auftragsvolumen 1,4 Mio. EUR p.a. Klausel: "The customer may terminate this agreement with immediate effect upon any change of control affecting more than 50 percent of the voting rights of the supplier."
 
-Frage: Ist die Series-A-Runde ein Change of Control? — In der Regel nicht, da die Gruender vor und nach Closing weiterhin die Stimmenmehrheit auf Stammkapitalebene halten. Aber: Wenn man die Reserved Matters und den Investor-Director-Sitz wirtschaftlich einbezieht, kann ein Gericht eine andere Sicht haben. Massnahme: Vorab ein Waiver oder zumindest eine Notification an Mertensbrueder.
+Frage: Ist die Series-A-Runde ein Change of Control? — In der Regel nicht, da die Gründer vor und nach Closing weiterhin die Stimmenmehrheit auf Stammkapitalebene halten. Aber: Wenn man die Reserved Matters und den Investor-Director-Sitz wirtschaftlich einbezieht, kann ein Gericht eine andere Sicht haben. Maßnahme: Vorab ein Waiver oder zumindest eine Notification an Mertensbrüder.
 
-### E.2 Lieferantenvertraege
+### E.2 Lieferantenverträge
 
-Ein wesentlicher Cloud-Vertrag (Frachtkosten-Cloud GmbH) hat eine 24-monatige Restlaufzeit und keine ordentliche Kuendigung. Risiko: keine.
+Ein wesentlicher Cloud-Vertrag (Frachtkosten-Cloud GmbH) hat eine 24-monatige Restlaufzeit und keine ordentliche Kündigung. Risiko: keine.
 
 ### E.3 Partnerships
 
-Joint-Development-Agreement mit Echolot-Beratungs-GmbH, das eine Exklusivitaet im DACH-Markt vorsieht. Risiko: Konflikt mit Northbridge-Wunsch nach internationaler Skalierung. Frage an Mandantin und ggf. Anpassung.
+Joint-Development-Agreement mit Echolot-Beratungs-GmbH, das eine Exklusivität im DACH-Markt vorsieht. Risiko: Konflikt mit Northbridge-Wunsch nach internationaler Skalierung. Frage an Mandantin und ggf. Anpassung.
 
 ---
 
@@ -143,70 +143,70 @@ Joint-Development-Agreement mit Echolot-Beratungs-GmbH, das eine Exklusivitaet i
 
 ### F.1 Wandeldarlehen Tante Ermelind
 
-Steuerliche Behandlung der PIK-Zinsen aus Sicht der Gesellschaft: Aufwand. Aus Sicht Tante Ermelind: jaehrlich zu versteuernder Zinsertrag, ungeachtet der Faelligkeit. Im Datenraum keine Steuerbescheinigung. Frage an Tante Ermelind via Notariat: Wurden die PIK-Zinsen jaehrlich versteuert?
+Steuerliche Behandlung der PIK-Zinsen aus Sicht der Gesellschaft: Aufwand. Aus Sicht Tante Ermelind: jährlich zu versteuernder Zinsertrag, ungeachtet der Fälligkeit. Im Datenraum keine Steuerbescheinigung. Frage an Tante Ermelind via Notariat: Wurden die PIK-Zinsen jährlich versteuert?
 
 ### F.2 § 8c KStG / § 8d KStG
 
-Verlustvortraege Stand 31.12.2025: ca. EUR 4,2 Mio. Risiko: Series-A-Runde fuehrt zu schaedlichem Beteiligungserwerb gemaess § 8c Abs. 1 KStG bei Ueberschreitung der 50-Prozent-Schwelle. Da Northbridge plus Tante-Ermelind-Wandlung in Summe einen wesentlichen Beteiligungserwerb darstellt, ist eine Pruefung erforderlich. Optionen:
+Verlustvorträge Stand 31.12.2025: ca. EUR 4,2 Mio. Risiko: Series-A-Runde führt zu schädlichem Beteiligungserwerb gemäß § 8c Abs. 1 KStG bei Überschreitung der 50-Prozent-Schwelle. Da Northbridge plus Tante-Ermelind-Wandlung in Summe einen wesentlichen Beteiligungserwerb darstellt, ist eine Prüfung erforderlich. Optionen:
 
-- Anwendung des fortfuehrungsgebundenen Verlustvortrags gemaess § 8d KStG (Antrag erforderlich, strikte Voraussetzungen).
-- Reorganisationsklausel gemaess § 8c Abs. 1a KStG (nicht einschlaegig, da kein Sanierungsfall).
-- Stille-Reserven-Klausel gemaess § 8c Abs. 1 Satz 4 ff. KStG (Pruefung).
+- Anwendung des fortführungsgebundenen Verlustvortrags gemäß § 8d KStG (Antrag erforderlich, strikte Voraussetzungen).
+- Reorganisationsklausel gemäß § 8c Abs. 1a KStG (nicht einschlägig, da kein Sanierungsfall).
+- Stille-Reserven-Klausel gemäß § 8c Abs. 1 Satz 4 ff. KStG (Prüfung).
 
-Hildemar: "Das gehoert eigentlich an die Steuer-Praxisgruppe. Ich notiere es als DD-Red-Flag und ueberlasse den Mechanismus den Steuerleuten."
+Hildemar: "Das gehört eigentlich an die Steuer-Praxisgruppe. Ich notiere es als DD-Red-Flag und überlasse den Mechanismus den Steuerleuten."
 
 ### F.3 Umsatzsteuer
 
-Keine Auffaelligkeiten.
+Keine Auffälligkeiten.
 
 ---
 
 ## G Litigation Findings
 
-Eine arbeitsgerichtliche Klage einer ehemaligen Praktikantin (Streitwert EUR 8.400) anhaengig vor dem ArbG Frankfurt am Main. Risiko: gering. Disclosure noetig.
+Eine arbeitsgerichtliche Klage einer ehemaligen Praktikantin (Streitwert EUR 8.400) anhängig vor dem ArbG Frankfurt am Main. Risiko: gering. Disclosure nötig.
 
 ---
 
 ## H Data Protection Findings
 
-DSGVO-Verzeichnis von Verarbeitungstaetigkeiten existiert, ist aber zwoelf Monate alt. Datenschutzbeauftragter intern bestellt (CFO Olaf), was bei 48 Mitarbeitern grundsaetzlich zulaessig ist, aber der Lead Investor wird wahrscheinlich einen externen DSB verlangen.
+DSGVO-Verzeichnis von Verarbeitungstätigkeiten existiert, ist aber zwölf Monate alt. Datenschutzbeauftragter intern bestellt (CFO Olaf), was bei 48 Mitarbeitern grundsätzlich zulässig ist, aber der Lead Investor wird wahrscheinlich einen externen DSB verlangen.
 
 ---
 
 ## I Insurance Findings
 
-D&O-Versicherung existiert (Deckung EUR 3 Mio.), aber Selbstbehalt 25.000 EUR und ausdruecklicher Ausschluss "Anspruche von Gesellschaftern gegen Geschaeftsfuehrer im Zusammenhang mit Kapitalmassnahmen". Risiko: hoch bei kuenftigen Investor-Director-Sitzen. Massnahme: Side-A-Erweiterung oder neue Police vor Closing.
+D&O-Versicherung existiert (Deckung EUR 3 Mio.), aber Selbstbehalt 25.000 EUR und ausdrücklicher Ausschluss "Anspruche von Gesellschaftern gegen Geschäftsführer im Zusammenhang mit Kapitalmaßnahmen". Risiko: hoch bei künftigen Investor-Director-Sitzen. Maßnahme: Side-A-Erweiterung oder neue Police vor Closing.
 
 ---
 
 ## J Fragenkatalog an die Mandantin Kunigunde
 
-1. Heisst fully diluted, dass ich sofort weniger Anteile habe?
+1. Heißt fully diluted, dass ich sofort weniger Anteile habe?
 2. Ist Liquidation Preference nur relevant, wenn die GmbH pleitegeht?
-3. Koennen wir ein englisches Investment Agreement unter deutschem Recht unterschreiben?
+3. Können wir ein englisches Investment Agreement unter deutschem Recht unterschreiben?
 4. Bedeutet Bad Leaver, dass mir alles weggenommen werden kann?
 5. Ist Investor Director dasselbe wie ein Beiratsmitglied?
 6. Warum ist der Cap Table nicht einfach die Gesellschafterliste?
 7. Was muss der Notar sehen?
 8. Bedeutet "covenant", dass wir etwas versprechen — und wenn ja, wem genau?
-9. Was passiert mit unseren Verlustvortraegen?
-10. Wenn Mertensbrueder kuendigt, ist das ein "MAC"?
+9. Was passiert mit unseren Verlustvorträgen?
+10. Wenn Mertensbrüder kündigt, ist das ein "MAC"?
 11. Tante Ermelind ist beleidigt, weil wir sie nicht beurkundet zur Gesellschafterin gemacht haben. Was sage ich ihr?
-12. Wenn der Investor Director gegen den Budget-Beschluss stimmt, kann ich ihn dann ueberstimmen?
+12. Wenn der Investor Director gegen den Budget-Beschluss stimmt, kann ich ihn dann überstimmen?
 
 ---
 
-## K Hildemars Bewertung (intern, nicht fuer den Datenraum)
+## K Hildemars Bewertung (intern, nicht für den Datenraum)
 
-Hauptrisiken in absteigender Reihenfolge fuer das Deal-Closing:
+Hauptrisiken in absteigender Reihenfolge für das Deal-Closing:
 
-1. IP-Rechteuebertragung "work made for hire" (kann gefixt werden, aber kostet Zeit).
+1. IP-Rechteübertragung "work made for hire" (kann gefixt werden, aber kostet Zeit).
 2. § 8c KStG Verlustvortrag (kostet Geld, falls keine Sicherung).
-3. Mertensbrueder-Change-of-Control-Klausel (Waiver erforderlich).
+3. Mertensbrüder-Change-of-Control-Klausel (Waiver erforderlich).
 4. Beurkundungsbedarf der Wandlung Tante Ermelind (logistisch handhabbar, aber Notar-Slots eng).
 5. Vinkulierungs-/Drag-Mehrheiten-Konflikt zwischen Satzung und Term Sheet.
-6. D&O-Ausschluss "Kapitalmassnahmen" (Versicherer ansprechen).
+6. D&O-Ausschluss "Kapitalmaßnahmen" (Versicherer ansprechen).
 7. AGPL-Komponenten.
 8. Vesting-Reset und Cliff-Diskussion.
 
-Empfehlung: Disclosure Schedule mit allen acht Punkten an Brackenmuir uebergeben, bevor das erste Markup zurueckkommt. Adelheid muss vor jeder Mandantenkommunikation gegenzeichnen.
+Empfehlung: Disclosure Schedule mit allen acht Punkten an Brackenmuir übergeben, bevor das erste Markup zurückkommt. Adelheid muss vor jeder Mandantenkommunikation gegenzeichnen.

--- a/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/06-associate-arbeitsstand.md
+++ b/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/06-associate-arbeitsstand.md
@@ -2,95 +2,95 @@
 
 > Fiktive Lehrakte. Aehnlichkeiten zu realen Transaktionen sind nicht beabsichtigt.
 
-Dieses Dokument ist Hildemar K.s Arbeitsstand vom 20.05.2026, 02:14 Uhr. Adelheid von Westarp hat am 21.05.2026 vormittags mit rotem Stift Anmerkungen vermerkt. Die Anmerkungen sind hier als Block-Quote unter dem jeweiligen Satz eingefuegt. Sinn der Datei: dem Nachwuchs zeigen, wie eine Partnerin Anfaengertexte umarbeitet — sachlich, hart, lehrreich.
+Dieses Dokument ist Hildemar K.s Arbeitsstand vom 20.05.2026, 02:14 Uhr. Adelheid von Westarp hat am 21.05.2026 vormittags mit rotem Stift Anmerkungen vermerkt. Die Anmerkungen sind hier als Block-Quote unter dem jeweiligen Satz eingefügt. Sinn der Datei: dem Nachwuchs zeigen, wie eine Partnerin Anfängertexte umarbeitet — sachlich, hart, lehrreich.
 
 ---
 
 ## 1 Cap Table und Gesellschafterliste
 
-Ich glaube, Cap Table ist im Grunde die Gesellschafterliste, aber mit englischer Ueberschrift. Muss ich noch pruefen.
+Ich glaube, Cap Table ist im Grunde die Gesellschafterliste, aber mit englischer Ueberschrift. Muss ich noch prüfen.
 
-> **AvW:** Nein. Cap Table ist eine wirtschaftliche Projektion auf Fully-Diluted-Basis und enthaelt Optionen, Wandeldarlehen, Pool. Die Gesellschafterliste nach § 40 GmbHG ist eine **rechtlich verbindliche** Liste der **tatsaechlich** in Geschaeftsanteilen verkoerperten Mitgliedschaftsrechte zum Stichtag. Wer das verwechselt, verwechselt im Mandantengespraech auch die Kategorien "wirtschaftliche Beteiligung" und "Mitgliedschaftsrecht". Bitte das Glossar (Datei 08) lesen. **Wiederlesen, dann umschreiben.**
+> **AvW:** Nein. Cap Table ist eine wirtschaftliche Projektion auf Fully-Diluted-Basis und enthält Optionen, Wandeldarlehen, Pool. Die Gesellschafterliste nach § 40 GmbHG ist eine **rechtlich verbindliche** Liste der **tatsächlich** in Geschäftsanteilen verkörperten Mitgliedschaftsrechte zum Stichtag. Wer das verwechselt, verwechselt im Mandantengespräch auch die Kategorien "wirtschaftliche Beteiligung" und "Mitgliedschaftsrecht". Bitte das Glossar (Datei 08) lesen. **Wiederlesen, dann umschreiben.**
 
 ## 2 Fully Diluted
 
-Fully diluted heisst wohl, dass alle Gruender schon jetzt so behandelt werden, als haetten sie weniger echte Anteile. Unklar, ob VSOP mitzaehlt.
+Fully diluted heißt wohl, dass alle Gründer schon jetzt so behandelt werden, als hätten sie weniger echte Anteile. Unklar, ob VSOP mitzählt.
 
-> **AvW:** "Wohl" ist im Memo verboten. Fully Diluted ist eine **definierte Rechengroesse**: man rechnet alle Anteile, Optionen, Wandeldarlehen, Warrants so, als waeren sie ausgeuebt/gewandelt. Das VSOP zaehlt **nur dann**, wenn es **virtuelle** Anteile sind, die in echte Anteile konvertiert werden koennen; ein reines Phantom-Cash-Plan zaehlt **nicht**. Hier zaehlt das VSOP nur insofern, als der **Option Pool** (nicht das VSOP selbst) auf der Cap Table als reservierte Geschaeftsanteile abgebildet wird. Bitte den Investor Counsel anschreiben und um Klarstellung bitten, ob unser Phantom-VSOP als "Share Equivalent" gilt — das ist verhandelbar.
+> **AvW:** "Wohl" ist im Memo verboten. Fully Diluted ist eine **definierte Rechengröße**: man rechnet alle Anteile, Optionen, Wandeldarlehen, Warrants so, als wären sie ausgeübt/gewandelt. Das VSOP zählt **nur dann**, wenn es **virtuelle** Anteile sind, die in echte Anteile konvertiert werden können; ein reines Phantom-Cash-Plan zählt **nicht**. Hier zählt das VSOP nur insofern, als der **Option Pool** (nicht das VSOP selbst) auf der Cap Table als reservierte Geschäftsanteile abgebildet wird. Bitte den Investor Counsel anschreiben und um Klarstellung bitten, ob unser Phantom-VSOP als "Share Equivalent" gilt — das ist verhandelbar.
 
 ## 3 Liquidation Preference
 
-Liquidation Preference klingt nach Insolvenz/Liquidation, aber im Term Sheet steht auch Verkauf aller Anteile oder Assets. Das ist also wahrscheinlich Exit-Erloesverteilung. Muss sauber erklaert werden.
+Liquidation Preference klingt nach Insolvenz/Liquidation, aber im Term Sheet steht auch Verkauf aller Anteile oder Assets. Das ist also wahrscheinlich Exit-Erlösverteilung. Muss sauber erklärt werden.
 
-> **AvW:** Ja, das ist richtig erkannt, aber bitte **niemals** in dieser unsicheren Sprache an die Mandantin schreiben. Mandantin braucht: (1) Liquidation Preference ist **keine** Insolvenzrangordnung. (2) Sie greift bei **Exit-Erloesverteilung** — Sale oder Liquidation Event nach Term-Sheet-Definition. (3) "1x non-participating" mit "higher of" bedeutet: Investor bekommt **das Hoehere** aus (a) Praeferenzbetrag und (b) anteiliger Beteiligung. Setzen Sie die Mechanik bitte mit drei Rechenbeispielen auf: niedriger Exit, Break-Even-Exit, hoher Exit.
+> **AvW:** Ja, das ist richtig erkannt, aber bitte **niemals** in dieser unsicheren Sprache an die Mandantin schreiben. Mandantin braucht: (1) Liquidation Preference ist **keine** Insolvenzrangordnung. (2) Sie greift bei **Exit-Erlösverteilung** — Sale oder Liquidation Event nach Term-Sheet-Definition. (3) "1x non-participating" mit "higher of" bedeutet: Investor bekommt **das Höhere** aus (a) Präferenzbetrag und (b) anteiliger Beteiligung. Setzen Sie die Mechanik bitte mit drei Rechenbeispielen auf: niedriger Exit, Break-Even-Exit, hoher Exit.
 
 ## 4 Anti-Dilution
 
-Anti-Dilution: Investor sagt broad-based weighted average. Das ist wohl weicher als full ratchet. Die Formel fehlt aber. Ich wuerde nicht freigeben, ohne Formel und Exceptions.
+Anti-Dilution: Investor sagt broad-based weighted average. Das ist wohl weicher als full ratchet. Die Formel fehlt aber. Ich würde nicht freigeben, ohne Formel und Exceptions.
 
-> **AvW:** Korrekt — broad-based weighted average ist **investorenfreundlicher als pari passu, aber gruenderfreundlicher als full ratchet**. Die Formel steht jetzt in Datei 03 Ziff. 4 (NCP = OCP x (A+B) / (A+C)). Ihre Aufgabe: pruefen, ob die **Exclusions** ausreichend sind. Insbesondere: gilt die Anti-Dilution auch fuer **bridge financings**, fuer **Wandeldarlehen** und fuer **strategische Ausgaben**? Wenn nicht, dann formulieren wir die Exclusions im SHA aus. Frist: bis 25.05. Es wird **kein** Markup an Brackenmuir gehen, ohne dass das gesperrt ist.
+> **AvW:** Korrekt — broad-based weighted average ist **investorenfreundlicher als pari passu, aber gründerfreundlicher als full ratchet**. Die Formel steht jetzt in Datei 03 Ziff. 4 (NCP = OCP x (A+B) / (A+C)). Ihre Aufgabe: prüfen, ob die **Exclusions** ausreichend sind. Insbesondere: gilt die Anti-Dilution auch für **bridge financings**, für **Wandeldarlehen** und für **strategische Ausgaben**? Wenn nicht, dann formulieren wir die Exclusions im SHA aus. Frist: bis 25.05. Es wird **kein** Markup an Brackenmuir gehen, ohne dass das gesperrt ist.
 
 ## 5 Vesting
 
-Vesting: Gruender haben altes Vesting seit 2024. Northbridge will neues Vesting ab Closing. Das ist wirtschaftlich ein harter Reset. Frage an Partnerin: akzeptabel oder Anrechnung verhandeln?
+Vesting: Gründer haben altes Vesting seit 2024. Northbridge will neues Vesting ab Closing. Das ist wirtschaftlich ein harter Reset. Frage an Partnerin: akzeptabel oder Anrechnung verhandeln?
 
-> **AvW:** Anrechnung verhandeln. Standard ist eine **Hybridloesung**: die im Seed bereits abgelaufenen 28 Monate werden anteilig angerechnet (d.h. neue Vesting-Dauer ist 48 Monate ab Closing, davon sind 28 Monate ab Closing sofort gevested), **plus** Cliff von 6 Monaten statt 12 als Kompromiss. Northbridge wird das nicht freiwillig akzeptieren; bringen Sie es im Markup als Counter ein.
+> **AvW:** Anrechnung verhandeln. Standard ist eine **Hybridlösung**: die im Seed bereits abgelaufenen 28 Monate werden anteilig angerechnet (d.h. neue Vesting-Dauer ist 48 Monate ab Closing, davon sind 28 Monate ab Closing sofort gevested), **plus** Cliff von 6 Monaten statt 12 als Kompromiss. Northbridge wird das nicht freiwillig akzeptieren; bringen Sie es im Markup als Counter ein.
 
 ## 6 Drag und Tag
 
 Drag/Tag: Term Sheet 60 Prozent plus Series A Majority. Satzung/Seed-SHA sehen andere Schwellen. Muss harmonisiert werden.
 
-> **AvW:** Richtig, aber "harmonisiert" ist Beraterkauderwelsch. Sie haben **drei** Drag-Schwellen aufgeschrieben: 60 % + Series A Majority (Term Sheet), 70 % (Seed-SHA), 75 % (Satzung Vinkulierung). Frage: was gilt nach Closing? Antwort: das **Series-A-SHA**. Aber das hilft nicht, wenn die Satzung gegenlaeuft. Konkret: die Vinkulierung in § 6 Satzung verlangt 75 % fuer **Uebertragung**. Auch ein Drag ist eine Uebertragung. Daher entweder (a) Satzung anpassen oder (b) im SHA eine "Stimmbindungsvereinbarung" einfuegen, dass alle Gesellschafter zur Vinkulierungs-Zustimmung verpflichtet sind. Standard ist (b). Bitte als Klausel ausformulieren.
+> **AvW:** Richtig, aber "harmonisiert" ist Beraterkauderwelsch. Sie haben **drei** Drag-Schwellen aufgeschrieben: 60 % + Series A Majority (Term Sheet), 70 % (Seed-SHA), 75 % (Satzung Vinkulierung). Frage: was gilt nach Closing? Antwort: das **Series-A-SHA**. Aber das hilft nicht, wenn die Satzung gegenläuft. Konkret: die Vinkulierung in § 6 Satzung verlangt 75 % für **Übertragung**. Auch ein Drag ist eine Übertragung. Daher entweder (a) Satzung anpassen oder (b) im SHA eine "Stimmbindungsvereinbarung" einfügen, dass alle Gesellschafter zur Vinkulierungs-Zustimmung verpflichtet sind. Standard ist (b). Bitte als Klausel ausformulieren.
 
 ## 7 Investor Director Approval
 
-Investor Director Approval: Bei GmbH nicht einfach wie Delaware Board behandeln. Beirat nach Satzung bisher nur beratend. Wenn Zustimmungsvorbehalte gewollt sind, muessen Dokumente sauber angepasst werden.
+Investor Director Approval: Bei GmbH nicht einfach wie Delaware Board behandeln. Beirat nach Satzung bisher nur beratend. Wenn Zustimmungsvorbehalte gewollt sind, müssen Dokumente sauber angepasst werden.
 
-> **AvW:** Ja. Drei Ebenen: (1) **Satzung** — Beirat mit Zustimmungsvorbehalten ist zulaessig (Heider, Muenchener Kommentar GmbHG, § 6 Rn. 35 ff. — bitte das aus der Hauspraxisgruppe heraussuchen; **nicht** zitieren ohne Stellenpruefung), aber er bleibt **nicht** ein "Board of Directors" im Delaware-Sinne. (2) **Geschaeftsfuehrungs-Geschaeftsordnung** — die Zustimmungsvorbehalte sind dort als interne Befugnisgrenze zu verankern. (3) **SHA** — schuldrechtliche Stimmbindung. Bitte nicht "Investor Director" in deutsche Dokumente uebernehmen, sondern "Investor-Beiratsmitglied" oder "vom Investor entsandtes Beiratsmitglied" verwenden.
+> **AvW:** Ja. Drei Ebenen: (1) **Satzung** — Beirat mit Zustimmungsvorbehalten ist zulässig (Heider, Münchener Kommentar GmbHG, § 6 Rn. 35 ff. — bitte das aus der Hauspraxisgruppe heraussuchen; **nicht** zitieren ohne Stellenprüfung), aber er bleibt **nicht** ein "Board of Directors" im Delaware-Sinne. (2) **Geschäftsführungs-Geschäftsordnung** — die Zustimmungsvorbehalte sind dort als interne Befugnisgrenze zu verankern. (3) **SHA** — schuldrechtliche Stimmbindung. Bitte nicht "Investor Director" in deutsche Dokumente übernehmen, sondern "Investor-Beiratsmitglied" oder "vom Investor entsandtes Beiratsmitglied" verwenden.
 
 ## 8 Series A Preferred Shares — echte Anteilsklasse oder nur schuldrechtlich?
 
 To do: Investor Counsel fragen, ob Series A Preferred Shares echte Anteilsklasse oder nur schuldrechtliche Rechte sein sollen.
 
-> **AvW:** Falsche Frage. In Deutschland gibt es **keine** Anteilsklassen wie in Delaware. Es gibt aber **Geschaeftsanteile mit Sonderrechten einzelner Gesellschafter**, deren rechtliche Verankerung sich aus der allgemeinen **Satzungsautonomie** ergibt und auf § 14 GmbHG (Sonderrechte und Mitgliedschaft) gestuetzt wird. Hueten Sie sich vor dem Anfaengerfehler, § 5 Abs. 3 GmbHG als Anker zu zitieren — diese Vorschrift regelt **nur**, dass Geschaeftsanteile unterschiedliche **Nennbetraege** haben koennen und in Summe das Stammkapital ergeben muessen; sie betrifft **nicht** die wirtschaftlichen Sonderrechte wie Liquidation Preference oder Anti-Dilution. Die Vorzugsrechte werden in der **Satzung** definiert, mit den jeweiligen Liquidations-, Stimm- und Gewinnrechten. Schuldrechtliche Loesungen ueber den SHA sind moeglich, aber riskant bei Insolvenz und gegenueber Rechtsnachfolgern. Empfehlung: dingliche Loesung in Satzung (mit Aenderungsbeschluss nach § 53 GmbHG), plus schuldrechtliche Spiegelung im SHA. Das bitte als eigenen Memo-Abschnitt fuer die Mandantin.
+> **AvW:** Falsche Frage. In Deutschland gibt es **keine** Anteilsklassen wie in Delaware. Es gibt aber **Geschäftsanteile mit Sonderrechten einzelner Gesellschafter**, deren rechtliche Verankerung sich aus der allgemeinen **Satzungsautonomie** ergibt und nach ständiger Rechtsprechung auf § 35 BGB analog gestützt wird (BGHZ 123, 15; BGH, Urt. v. 14.05.1956 – II ZR 229/54; BGH, Urt. v. 25.06.1979 – II ZR 89/79 = LM BGB § 35 Nr. 4; OLG Nürnberg, Urt. v. 09.02.2000 – 12 U 813/99, GmbHR 2000, 561). **Im GmbHG selbst** gibt es **keine** positive Vorschrift, die Sonderrechte regelt — § 14 GmbHG (Einlagepflicht/Nennbetrag) ist gerade **nicht** der Anker, auch wenn das in der Praxis manchmal nachlässig zitiert wird. Hüten Sie sich erst recht vor dem doppelten Anfängerfehler, § 5 Abs. 3 GmbHG als Anker zu zitieren — diese Vorschrift regelt **nur**, dass Geschäftsanteile unterschiedliche **Nennbeträge** haben können und in Summe das Stammkapital ergeben müssen; sie betrifft **nicht** die wirtschaftlichen Sonderrechte wie Liquidation Preference oder Anti-Dilution. Die Vorzugsrechte werden in der **Satzung** definiert, mit den jeweiligen Liquidations-, Stimm- und Gewinnrechten. Schuldrechtliche Lösungen über den SHA sind möglich, aber riskant bei Insolvenz und gegenüber Rechtsnachfolgern. Empfehlung: dingliche Lösung in Satzung (mit Änderungsbeschluss nach § 53 GmbHG), plus schuldrechtliche Spiegelung im SHA. Das bitte als eigenen Memo-Abschnitt für die Mandantin.
 
 ## 9 English long-form docs unter deutschem Recht
 
-To do: Pruefen, ob English long-form docs mit deutscher Notar- und Registerlogik funktionieren.
+To do: Prüfen, ob English long-form docs mit deutscher Notar- und Registerlogik funktionieren.
 
 > **AvW:** Ja, das funktioniert, aber nur mit Sorgfalt. Drei Punkte:
 
-> 1. **Notarielle Beurkundung** § 15 Abs. 3 GmbHG **verlangt deutsche Sprache** im Notarprotokoll, soweit die Beteiligten der deutschen Sprache maechtig sind (§ 5 BeurkG). Wenn ein Beteiligter nicht deutsch spricht, ist eine **schriftliche Uebersetzung** beizufuegen, die der Notar fuer "richtig und vollstaendig" erklaert (§ 5 Abs. 2 BeurkG).
-> 2. **Handelsregister** — die Anlagen zur Anmeldung muessen in deutscher Sprache eingereicht werden (§ 184 GVG analog, plus Registerverordnung).
-> 3. **SHA, Investment Agreement, Side Letter** koennen in englischer Sprache abgeschlossen werden, da sie **nicht** beurkundungsbeduerftig sind, soweit sie nicht **die Uebertragung von Geschaeftsanteilen verpflichtend regeln** (§ 15 Abs. 4 GmbHG). Achtung: ein "Drag-Along" als schuldrechtliche Verpflichtung kann als verkaufsverpflichtend gelten und dann **beurkundungsbeduerftig** sein. Strittig, aber konservativ: Notar einschalten.
+> 1. **Notarielle Beurkundung** § 15 Abs. 3 GmbHG **verlangt deutsche Sprache** im Notarprotokoll, soweit die Beteiligten der deutschen Sprache mächtig sind (§ 5 BeurkG). Wenn ein Beteiligter nicht deutsch spricht, ist eine **schriftliche Uebersetzung** beizufügen, die der Notar für "richtig und vollständig" erklärt (§ 5 Abs. 2 BeurkG).
+> 2. **Handelsregister** — die Anlagen zur Anmeldung müssen in deutscher Sprache eingereicht werden (§ 184 GVG analog, plus Registerverordnung).
+> 3. **SHA, Investment Agreement, Side Letter** können in englischer Sprache abgeschlossen werden, da sie **nicht** beurkundungsbedürftig sind, soweit sie nicht **die Übertragung von Geschäftsanteilen verpflichtend regeln** (§ 15 Abs. 4 GmbHG). Achtung: ein "Drag-Along" als schuldrechtliche Verpflichtung kann als verkaufsverpflichtend gelten und dann **beurkundungsbedürftig** sein. Strittig, aber konservativ: Notar einschalten.
 
 ## 10 To-Do Liste
 
 To do:
 
 - Cap Table current vs fully diluted rechnen.
-- Begriffserklaerung fuer Kunigunde.
+- Begriffserklärung für Kunigunde.
 - Partnerbriefing.
 - Investor Counsel fragen, ob Series A Preferred Shares echte Anteilsklasse oder nur schuldrechtliche Rechte sein sollen.
-- Pruefen, ob English long-form docs mit deutscher Notar- und Registerlogik funktionieren.
+- Prüfen, ob English long-form docs mit deutscher Notar- und Registerlogik funktionieren.
 
-> **AvW:** Reihenfolge umstellen: **(1) Partnerbriefing zuerst** — kommen Sie morgen 8:00 Uhr in mein Buero. (2) Cap Table mit drei Szenarien (siehe Datei 02). (3) Begriffserklaerung fuer Kunigunde **erst nach** unserem Briefing — wir wollen nicht, dass Sie ihr Halbwissen weitergeben. (4) Notar-Frage klaere ich mit Roswitha Ploeger im Notariat Schwartz direkt. (5) Investor-Counsel-Frage: nicht "Anteilsklasse vs schuldrechtlich" fragen, sondern: "Wir gehen davon aus, dass die Series A Preferred Shares als Geschaeftsanteile mit Sonderrechten einzelner Gesellschafter in der Satzung verankert werden, gestuetzt auf die Satzungsautonomie und § 14 GmbHG. Stimmen Sie zu?" — das ist der professionelle Aufschlag.
+> **AvW:** Reihenfolge umstellen: **(1) Partnerbriefing zuerst** — kommen Sie morgen 8:00 Uhr in mein Büro. (2) Cap Table mit drei Szenarien (siehe Datei 02). (3) Begriffserklärung für Kunigunde **erst nach** unserem Briefing — wir wollen nicht, dass Sie ihr Halbwissen weitergeben. (4) Notar-Frage kläre ich mit Roswitha Plöger im Notariat Schwartz direkt. (5) Investor-Counsel-Frage: nicht "Anteilsklasse vs schuldrechtlich" fragen, sondern: "Wir gehen davon aus, dass die Series A Preferred Shares als Geschäftsanteile mit Sonderrechten einzelner Gesellschafter in der Satzung verankert werden, gestützt auf die Satzungsautonomie und § 35 BGB analog (BGHZ 123, 15). Stimmen Sie zu?" — das ist der professionelle Aufschlag.
 
 ---
 
 ## Hildemars Reaktion am 21.05.2026, 09:47 Uhr
 
-OK. Ich habe heute Morgen schon das Glossar (Datei 08) und den Anfaengerfehler-Katalog (Datei 09) gelesen. Ich verstehe jetzt:
+OK. Ich habe heute Morgen schon das Glossar (Datei 08) und den Anfängerfehler-Katalog (Datei 09) gelesen. Ich verstehe jetzt:
 
 - Cap Table != Gesellschafterliste.
-- Fully Diluted ist definierte Rechengroesse.
+- Fully Diluted ist definierte Rechengröße.
 - Anti-Dilution braucht Formel **und** Exclusions.
 - Vesting-Anrechnung wird verhandelt, nicht akzeptiert.
 - Drag braucht Stimmbindung im SHA, weil Vinkulierung in Satzung 75 % verlangt.
 - Investor "Director" ist kein Board-Director, sondern Beiratsmitglied.
-- Series A Preferred Shares sind Geschaeftsanteile mit Sonderrechten in der Satzung (Satzungsautonomie, § 14 GmbHG); § 5 Abs. 3 GmbHG ist **nicht** die Rechtsgrundlage.
+- Series A Preferred Shares sind Geschäftsanteile mit Sonderrechten in der Satzung (Satzungsautonomie, § 35 BGB analog, st. Rspr.: BGHZ 123, 15; BGH II ZR 89/79); weder § 14 GmbHG (Einlagepflicht) noch § 5 Abs. 3 GmbHG (Nennbeträge) ist die Rechtsgrundlage.
 - English long-form docs gehen, aber Notar verlangt Deutsch.
 
-Ich bringe morgen 8:00 die Cap Table mit drei Szenarien und einen Memo-Entwurf fuer Kunigunde.
+Ich bringe morgen 8:00 die Cap Table mit drei Szenarien und einen Memo-Entwurf für Kunigunde.
 
-> **AvW (gleicher Tag, 10:02 Uhr per Slack):** Gut. Und bitte: weniger Schachtelsaetze in der Mandantenkommunikation. Kunigunde ist Ingenieurin, sie versteht Tabellen besser als Bandwurmsaetze.
+> **AvW (gleicher Tag, 10:02 Uhr per Slack):** Gut. Und bitte: weniger Schachtelsätze in der Mandantenkommunikation. Kunigunde ist Ingenieurin, sie versteht Tabellen besser als Bandwurmsätze.

--- a/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/07-erwarteter-output-ohne-musterloesung.md
+++ b/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/07-erwarteter-output-ohne-musterloesung.md
@@ -1,14 +1,14 @@
-# 07 Erwarteter Output und Pruefraster (ohne Musterloesung)
+# 07 Erwarteter Output und Prüfraster (ohne Musterlösung)
 
 > Fiktive Lehrakte. Aehnlichkeiten zu realen Transaktionen sind nicht beabsichtigt.
 
-Dieses Dokument enthaelt **keine** Musterloesung, sondern **Qualitaetsanforderungen** und ein **Pruefraster**, mit dem die Antworten des Nachwuchses bewertet werden. Es ist bewusst so geschrieben, dass es weder Antworten vorgibt noch Antworten ausschliesst, sondern Maßstaebe setzt.
+Dieses Dokument enthält **keine** Musterlösung, sondern **Qualitätsanforderungen** und ein **Prüfraster**, mit dem die Antworten des Nachwuchses bewertet werden. Es ist bewusst so geschrieben, dass es weder Antworten vorgibt noch Antworten ausschließt, sondern Maßstäbe setzt.
 
 ---
 
 ## A Grundhaltung
 
-Eine gute Bearbeitung dieser Akte erkennt, dass **Corporate Legal English** im deutschen Mandat **keine Uebersetzungsaufgabe** ist, sondern eine **Doppelarbeit**: man muss (1) den englischen Begriff in seiner internationalen Bedeutung erfassen und (2) ihn in deutsche Rechtsstrukturen und Rechtspflichten ueberfuehren. Wer einen englischen Begriff eins-zu-eins als deutsche Klausel uebersetzt, hat seinen Job nicht gemacht.
+Eine gute Bearbeitung dieser Akte erkennt, dass **Corporate Legal English** im deutschen Mandat **keine Übersetzungsaufgabe** ist, sondern eine **Doppelarbeit**: man muss (1) den englischen Begriff in seiner internationalen Bedeutung erfassen und (2) ihn in deutsche Rechtsstrukturen und Rechtspflichten überführen. Wer einen englischen Begriff eins-zu-eins als deutsche Klausel übersetzt, hat seinen Job nicht gemacht.
 
 ---
 
@@ -17,46 +17,46 @@ Eine gute Bearbeitung dieser Akte erkennt, dass **Corporate Legal English** im d
 ### B.1 Begriffsdisziplin
 
 - Cap Table und Gesellschafterliste werden klar getrennt; § 40 GmbHG wird als Rechtsanker erkannt.
-- § 16 GmbHG (gutglaeubiger Erwerb der Mitgliedschaft) wird angesprochen.
-- Fully Diluted wird als **definierte Rechengroesse** mit Annahmen (Pool, Wandeldarlehen, Optionen) erklaert.
+- § 16 GmbHG (gutgläubiger Erwerb der Mitgliedschaft) wird angesprochen.
+- Fully Diluted wird als **definierte Rechengröße** mit Annahmen (Pool, Wandeldarlehen, Optionen) erklärt.
 - Option Pool **pre-money** vs **post-money** wird als wirtschaftlich entscheidender Punkt markiert (siehe Datei 02, V19a/V19b/V19c).
-- Liquidation Preference wird als **Exit-Waterfall** erklaert, **nicht** als Insolvenzrang.
-- Anti-Dilution wird **nicht** mit Bezugsrecht (§ 55 GmbHG) gleichgesetzt; "broad-based weighted average" wird unter Angabe der Formel erklaert.
-- Vesting und Leaver werden in **deutsche** Umsetzungsfragen uebersetzt (Call-Optionen, Einziehung, Bewertung nach § 317 BGB).
-- Beirat, Investor Director und Reserved Matters werden **nicht** blind aus dem Delaware-Vokabular uebernommen.
-- English Contract under German Law wird mit Blick auf Sprachklausel, Notarebene (§ 15 GmbHG, § 5 BeurkG) und Registerebene (§ 184 GVG analog) geprueft.
+- Liquidation Preference wird als **Exit-Waterfall** erklärt, **nicht** als Insolvenzrang.
+- Anti-Dilution wird **nicht** mit Bezugsrecht (§ 55 GmbHG) gleichgesetzt; "broad-based weighted average" wird unter Angabe der Formel erklärt.
+- Vesting und Leaver werden in **deutsche** Umsetzungsfragen übersetzt (Call-Optionen, Einziehung, Bewertung nach § 317 BGB).
+- Beirat, Investor Director und Reserved Matters werden **nicht** blind aus dem Delaware-Vokabular übernommen.
+- English Contract under German Law wird mit Blick auf Sprachklausel, Notarebene (§ 15 GmbHG, § 5 BeurkG) und Registerebene (§ 184 GVG analog) geprüft.
 
 ### B.2 Strukturelle Disziplin
 
 - Senior-Review-Gates werden gesetzt: jede Mandantenkommunikation, jedes Markup, jede Investorenantwort geht durch die Partnerin.
 - Die Disclosure-Schedule-Logik (was wird der Gegenseite offengelegt, was nicht) wird beachtet.
-- Vertragsstaende werden konsistent benannt: Term Sheet (Datei 03), Seed-SHA, Series-A-SHA, Investment Agreement, Side Letter, Geschaeftsordnung der GF, Satzung.
-- Notarielle Form (§ 15 Abs. 3 GmbHG fuer Anteilsuebertragung, § 53 GmbHG fuer Satzungsaenderung, § 55 GmbHG fuer Kapitalerhoehung) wird sauber zugeordnet.
+- Vertragsstände werden konsistent benannt: Term Sheet (Datei 03), Seed-SHA, Series-A-SHA, Investment Agreement, Side Letter, Geschäftsordnung der GF, Satzung.
+- Notarielle Form (§ 15 Abs. 3 GmbHG für Anteilsübertragung, § 53 GmbHG für Satzungsänderung, § 55 GmbHG für Kapitalerhöhung) wird sauber zugeordnet.
 - Pre-Closing-Schritte (CPs) werden von Post-Closing-Schritten getrennt (siehe Datei 15).
 
 ### B.3 Mandantenkommunikation
 
-- Begriffe werden in der Sprache erklaert, in der die Mandantin denkt (Ingenieursprache: Tabellen, Beispielrechnungen).
+- Begriffe werden in der Sprache erklärt, in der die Mandantin denkt (Ingenieursprache: Tabellen, Beispielrechnungen).
 - Drei Rechenbeispiele zur Liquidation Preference (niedriger Exit, Break-Even-Exit, hoher Exit).
 - Eine Cap Table mit drei Szenarien (siehe Datei 02, V19a/V19b/V19c).
-- Klare Empfehlung mit Hinweis auf das Risiko, das die Mandantin uebernimmt.
+- Klare Empfehlung mit Hinweis auf das Risiko, das die Mandantin übernimmt.
 
 ### B.4 Stil
 
-- Aktiv, kurze Saetze, keine Modalpartikel ("wohl", "eigentlich", "wahrscheinlich" gehoeren in der Auseinandersetzung nicht in Memos der Partnerin gegenueber).
+- Aktiv, kurze Sätze, keine Modalpartikel ("wohl", "eigentlich", "wahrscheinlich" gehören in der Auseinandersetzung nicht in Memos der Partnerin gegenüber).
 - Generisches Maskulinum ist akzeptabel.
-- Englische Begriffe werden in Klammern hinter dem deutschen Begriff gefuehrt, nicht umgekehrt.
+- Englische Begriffe werden in Klammern hinter dem deutschen Begriff geführt, nicht umgekehrt.
 
 ---
 
 ## C Was gute Antworten **nicht** tun
 
 - Paywallige Literatur zitieren.
-- BeckRS, juris, anwalt24.de oder Kommentarstellen ungeprueft uebernehmen oder erfinden.
+- BeckRS, juris, anwalt24.de oder Kommentarstellen ungeprüft übernehmen oder erfinden.
 - Englische Begriffe eins-zu-eins eindeutschen ("Investor Director" wird zu "Investorendirektor" — falsch).
-- Den Associate-Arbeitsstand (Datei 06) ungeprueft uebernehmen — die Datei enthaelt absichtlich Anfaengerfehler, die mit dem Rotstift der Partnerin korrigiert sind.
+- Den Associate-Arbeitsstand (Datei 06) ungeprüft übernehmen — die Datei enthält absichtlich Anfängerfehler, die mit dem Rotstift der Partnerin korrigiert sind.
 - Den Cap Table als rechtliche Gesellschafterliste behandeln.
-- "Liquidation Preference" als Insolvenzrang erklaeren.
+- "Liquidation Preference" als Insolvenzrang erklären.
 - "Anti-Dilution" mit "Bezugsrecht" gleichsetzen.
 - Den Beirat einer GmbH als "Board of Directors" einer Delaware-Gesellschaft behandeln.
 - Die englische Fassung des Term Sheets als Notarvorlage vorlegen.
@@ -64,22 +64,22 @@ Eine gute Bearbeitung dieser Akte erkennt, dass **Corporate Legal English** im d
 
 ---
 
-## D Pruefraster (Punktewertung intern, **nicht** an Mandanten weiterzugeben)
+## D Prüfraster (Punktewertung intern, **nicht** an Mandanten weiterzugeben)
 
-Maximalpunktzahl 100. Mindestpunktzahl fuer "Bestanden" 70.
+Maximalpunktzahl 100. Mindestpunktzahl für "Bestanden" 70.
 
-| Pruefpunkt | Punkte | Bemerkungen |
+| Prüfpunkt | Punkte | Bemerkungen |
 |---|---:|---|
 | Cap Table vs Gesellschafterliste sauber getrennt | 10 | Kein Punkt bei "im Grunde dasselbe" |
 | Fully Diluted definiert und durchgerechnet | 10 | Mit Annahmen zu Pool, Wandeldarlehen, VSOP |
-| Pool pre-/post-money erklaert | 5 | Plus wirtschaftliche Auswirkung |
+| Pool pre-/post-money erklärt | 5 | Plus wirtschaftliche Auswirkung |
 | Liquidation Preference als Exit-Waterfall | 10 | Mit drei Rechenbeispielen |
 | Anti-Dilution Formel und Exclusions | 10 | Broad-based weighted average mit Ausnahmenliste |
 | Vesting/Leaver Implementierung | 10 | Call, Einziehung, Bewertung |
 | Drag-/Tag-Schwellen harmonisiert | 5 | Stimmbindung im SHA, Vinkulierung beachtet |
-| Beirat vs Board of Directors | 10 | Geschaeftsordnung erwaehnt |
+| Beirat vs Board of Directors | 10 | Geschäftsordnung erwähnt |
 | English contract under German law | 10 | Sprache, Notar, Register |
-| Vorzugsrechte ueber Satzungsautonomie und Sonderrechte | 5 | Vorzugsrechte werden bei der GmbH als Sonderrechte einzelner Gesellschafter in der Satzung verankert (gestuetzt auf § 14 GmbHG und die allgemeine Satzungsautonomie, Satzungsaenderung nach § 53 GmbHG). § 5 Abs. 3 GmbHG ist **nicht** einschlaegig — er regelt nur, dass Geschaeftsanteile unterschiedliche Nennbetraege haben koennen und in Summe das Stammkapital ergeben muessen. "Series A Preferred Shares" als Pseudoklasse bleibt ein Anfaengerfehler. |
+| Vorzugsrechte über Satzungsautonomie und Sonderrechte | 5 | Vorzugsrechte werden bei der GmbH als Sonderrechte einzelner Gesellschafter in der Satzung verankert. Rechtsgrundlage ist die allgemeine Satzungsautonomie in Verbindung mit § 35 BGB analog nach ständiger Rechtsprechung (BGHZ 123, 15; BGH II ZR 89/79 = LM BGB § 35 Nr. 4; OLG Nürnberg 12 U 813/99); Satzungsänderung nach § 53 GmbHG. Im GmbHG selbst regelt **keine** Vorschrift die Sonderrechte positiv — weder § 14 GmbHG (Einlagepflicht/Nennbetrag) noch § 5 Abs. 3 GmbHG (Nennbeträge). "Series A Preferred Shares" als Pseudoklasse bleibt ein Anfängerfehler. |
 | Disclosure-Schedule-Logik | 5 | DD-Befunde sauber eingeordnet |
 | Senior-Review-Gates gesetzt | 5 | Jede Mandantenantwort durch Partnerin |
 | Notarielle Form korrekt zugeordnet | 5 | § 15, § 53, § 55 GmbHG, § 5 BeurkG |
@@ -88,32 +88,32 @@ Maximalpunktzahl 100. Mindestpunktzahl fuer "Bestanden" 70.
 
 ## E Typische Fehlbewertungen
 
-- **Halbverstandene Floskeln** (Score: -10): "Standardklausel, ist in jedem SHA so" — das ist **keine** Begruendung.
+- **Halbverstandene Floskeln** (Score: -10): "Standardklausel, ist in jedem SHA so" — das ist **keine** Begründung.
 - **Falsche Rechtsverweise** (Score: -10): "§ 31 GmbHG" wenn § 30 GmbHG gemeint ist.
-- **Erfundene Praezedenzfaelle** (Score: Direktausschluss): "BGH II ZR 142/19" als Zitat, wenn das Aktenzeichen nicht existiert.
-- **Aus dem Internet kopierte Definitionen** (Score: -5): Wikipedia oder anwalt24.de als Quelle, ohne Gegenpruefung.
+- **Erfundene Präzedenzfälle** (Score: Direktausschluss): "BGH II ZR 142/19" als Zitat, wenn das Aktenzeichen nicht existiert.
+- **Aus dem Internet kopierte Definitionen** (Score: -5): Wikipedia oder anwalt24.de als Quelle, ohne Gegenprüfung.
 - **Mandanten-Patronisierung** (Score: -5): "Sie als Laie verstehen das vielleicht nicht, aber ..."
-- **Ueberhebliche englische Begriffe** (Score: -3): "Das ist im Term Sheet gehedged" — bitte verstaendlich uebersetzen.
+- **Ueberhebliche englische Begriffe** (Score: -3): "Das ist im Term Sheet gehedged" — bitte verständlich übersetzen.
 
 ---
 
 ## F Bewertung des Senior-Verhaltens (intern)
 
-Die Partnerin bewertet zusaetzlich:
+Die Partnerin bewertet zusätzlich:
 
 - Ist der Associate **vorbereitet** ins Briefing gekommen?
-- Hat er **vorab gelesen** (Datei 08 Glossar, Datei 09 Anfaengerfehler)?
-- Stellt er **Verstaendnisfragen** oder gibt er nur Antworten?
+- Hat er **vorab gelesen** (Datei 08 Glossar, Datei 09 Anfängerfehler)?
+- Stellt er **Verständnisfragen** oder gibt er nur Antworten?
 - Schreibt er **klare** Emails an Investor Counsel?
 - Akzeptiert er **Kritik** ohne defensive Reaktion?
 - Lernt er **aus** der Korrektur?
 
-Das ist nicht "weicher" als die fachliche Bewertung — es ist die andere Haelfte der Big-Law-Existenz.
+Das ist nicht "weicher" als die fachliche Bewertung — es ist die andere Hälfte der Big-Law-Existenz.
 
 ---
 
 ## G Hinweis zur Verwendung des Plugins
 
-Das Plugin `gesellschaftsrecht-legal-english` ist als didaktisches Werkzeug konzipiert. Es ersetzt nicht die Mandatsfuehrung, nicht das Partner-Briefing, nicht die Notarbesprechung und nicht die DD-Pruefung durch Steuer-, IP- und Arbeitsrechtspraxisgruppen. Die Skills sollen Anfaengern die Begriffe, die Stolperfallen und die strukturelle Disziplin beibringen, mit der eine deutsche VC-Series-A-Transaktion mit englischsprachiger Dokumentation gefuehrt wird.
+Das Plugin `gesellschaftsrecht-legal-english` ist als didaktisches Werkzeug konzipiert. Es ersetzt nicht die Mandatsführung, nicht das Partner-Briefing, nicht die Notarbesprechung und nicht die DD-Prüfung durch Steuer-, IP- und Arbeitsrechtspraxisgruppen. Die Skills sollen Anfängern die Begriffe, die Stolperfallen und die strukturelle Disziplin beibringen, mit der eine deutsche VC-Series-A-Transaktion mit englischsprachiger Dokumentation geführt wird.
 
-Verwendung im Training: die Akte (00 bis 15) wird in der genannten Reihenfolge gelesen. Der Anfaengerfehler-Katalog (Datei 09) und das Glossar (Datei 08) sind **vor** der ersten Bearbeitung zu konsultieren. Die Cap Table (Datei 02) wird mit Bleistift und Taschenrechner nachgerechnet, **nicht** copy-paste in Excel.
+Verwendung im Training: die Akte (00 bis 15) wird in der genannten Reihenfolge gelesen. Der Anfängerfehler-Katalog (Datei 09) und das Glossar (Datei 08) sind **vor** der ersten Bearbeitung zu konsultieren. Die Cap Table (Datei 02) wird mit Bleistift und Taschenrechner nachgerechnet, **nicht** copy-paste in Excel.

--- a/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/08-glossar-deutsch-englisch-fallstricke.md
+++ b/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/08-glossar-deutsch-englisch-fallstricke.md
@@ -143,4 +143,4 @@ Lesehinweis: Wer hier scheitert, scheitert später beim Notar.
 - Paragraf 184 GVG (Gerichtssprache): https://www.gesetze-im-internet.de/gvg/__184.html
 - Paragraf 433 ff., 434 BGB (Sachmangel): https://www.gesetze-im-internet.de/bgb/__434.html
 
-Jedes Aktenzeichen vor Verwendung über dejure.org oder Bundesgerichtshof.de selbst pruefen. Kein BeckRS, kein Juris als alleinige Quelle.
+Jedes Aktenzeichen vor Verwendung über dejure.org oder Bundesgerichtshof.de selbst prüfen. Kein BeckRS, kein Juris als alleinige Quelle.

--- a/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/09-anfaengerfehler-katalog-mit-partner-rotstift.md
+++ b/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/09-anfaengerfehler-katalog-mit-partner-rotstift.md
@@ -1,4 +1,4 @@
-# 09 Anfaengerfehler Katalog mit Partner Rotstift
+# 09 Anfängerfehler Katalog mit Partner Rotstift
 
 Lehrmaterial für den ersten Big-Law-Sommer. Auf der linken Seite typische Anfängerformulierungen aus echten Associate-Drafts. Auf der rechten Seite die Korrektur, wie Dr. Adelheid von Westarp sie schreiben würde, mit kurzem Grund.
 
@@ -34,7 +34,7 @@ Lesehinweis: Wer dieselbe Stelle dreimal so verändert bekommt, muss sich die zu
 | „Die Anti-Dilution-Klausel sichert dem Investor ein gesetzliches Bezugsrecht in künftigen Finanzierungsrunden." | „Die Anti-Dilution-Klausel passt das Wandlungsverhältnis (Conversion Ratio) der Vorzugsanteile in einer Down Round an. Sie wirkt rückwirkend auf den wirtschaftlichen Wert der bestehenden Anteile. Das Bezugsrecht ist eine davon zu trennende Frage der Beteiligung an der neuen Kapitalerhöhung und wird typischerweise in einer Pre-Emption-Klausel oder Pro-Rata-Right-Klausel geregelt." |
 | Warum: Anti-Dilution und Bezugsrecht sind komplementär, aber rechtlich unterschiedliche Mechanismen. |
 
-## Fehlerklasse B: Englisch eindeutschen ohne Funktion zu pruefen
+## Fehlerklasse B: Englisch eindeutschen ohne Funktion zu prüfen
 
 ### B1 Reps and Warranties gleich Gewährleistung
 
@@ -64,7 +64,7 @@ Lesehinweis: Wer dieselbe Stelle dreimal so verändert bekommt, muss sich die zu
 | „Die Drag-Along-Klausel räumt den Investoren ein Vorkaufsrecht ein." | „Die Drag-Along-Klausel verpflichtet die Minderheitsgesellschafter, ihre Anteile zu denselben Konditionen wie die ziehende Mehrheit an einen Drittkäufer zu veräußern, sofern die im SHA festgelegten Schwellen erfüllt sind. Es handelt sich um eine Mitverkaufsverpflichtung, nicht um ein Vorkaufsrecht (Right of First Refusal)." |
 | Warum: Vorkaufsrecht regelt die Reihenfolge bei einem geplanten Verkauf, Drag-Along eine Verkaufspflicht an einen identifizierten Dritten. |
 
-## Fehlerklasse C: GmbH-Recht und Notar uebersehen
+## Fehlerklasse C: GmbH-Recht und Notar übersehen
 
 ### C1 SHA-Klausel reicht für Vinkulierung
 
@@ -133,6 +133,6 @@ Lesehinweis: Wer dieselbe Stelle dreimal so verändert bekommt, muss sich die zu
 | „Vor Versand an Investor Counsel würde ich vorschlagen, das interne Briefing freizugeben." | „Vor Versand an Investor Counsel sind die folgenden Senior-Review-Gates verpflichtend: (1) Cap-Table-Rechenmodell durch Counsel verifiziert; (2) Term-Sheet-Übersetzung der Schlüsselbegriffe Partner-freigegeben; (3) Beurkundungspflichten und Notarslot mit Notariat geklärt; (4) steuerliche Folgen mit Steuerberatung abgestimmt; (5) Antworten auf Mandantenfragen im Originalwortlaut der Mandantin verfasst. Erst danach Versand." |
 | Warum: Schreibstil signalisiert die Erwartung an die eigene Sorgfalt. Konjunktive ersetzen keine Gates. |
 
-## Tutoriumseinheit fuer die Praxisrunde
+## Tutoriumseinheit für die Praxisrunde
 
 In der wöchentlichen Praxisrunde der Frankfurter Corporate-Praxis werden zwei der oben gelisteten Fehlerklassen anhand von echten Anonymisierungen durchgegangen. Wer die Aufgabe hat, beim nächsten Termin Lead zu sein, bringt zwei eigene Drafts aus der vergangenen Woche mit, in denen er oder sie eine der Fehlerklassen vermieden hat, und einen Draft, an dem er oder sie noch arbeitet.

--- a/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/10-wandeldarlehen-tante-ermelind.md
+++ b/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/10-wandeldarlehen-tante-ermelind.md
@@ -100,7 +100,7 @@ To do vor Term-Sheet-Antwort:
 - Convertible-Klauseln im Series-A-SHA spiegeln (Pari passu? Senior? Pro-rata bei Down-Round?).
 - Notariatsslot für etwaige Nachbeurkundung im Notariat Schwartz vorab reservieren.
 
-## Wandlungsrechnung (Skizze fuer Senior-Review)
+## Wandlungsrechnung (Skizze für Senior-Review)
 
 Annahme Series A: 5,2 Mio. EUR Investment, Pre-Money 12 Mio. EUR fully diluted, Post-Money 17,2 Mio. EUR (vor Pool-Shuffle). Pool wird auf 12 Prozent post-money equivalent gehoben (pre-money-Shuffle).
 

--- a/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/12-notar-checkliste-und-handelsregisterlogik.md
+++ b/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/12-notar-checkliste-und-handelsregisterlogik.md
@@ -15,7 +15,7 @@ Interne Pre-Closing-Checkliste für die deutsche Notar- und Handelsregisterebene
 | Apostillen | für Vollmacht der luxemburgischen Northbridge SCS, beglaubigt durch luxemburgisches Notariat, mit Apostille nach Haager Übereinkommen, Frist beachten |
 | Beglaubigte Übersetzung Englisch-Deutsch | für Vollmachten, soweit englisch ausgestellt |
 
-## Beurkundungspflichtige Vorgaenge
+## Beurkundungspflichtige Vorgänge
 
 ### Erste Beurkundung — Kapitalerhöhungsbeschluss und Satzungsänderung
 

--- a/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/13-side-letter-und-information-rights.md
+++ b/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/13-side-letter-und-information-rights.md
@@ -28,7 +28,7 @@ If the Company grants to any other investor any rights more favourable than thos
 
 The Investor's 1x non-participating liquidation preference granted under the Seed-SHA dated 01.07.2023 shall be preserved and reflected in any subsequent financing documentation.
 
-## Folgenabschaetzung fuer Series A
+## Folgenabschätzung für Series A
 
 1. **Information Rights Stack**. Northbridge wird im Series-A-SHA umfangreiche Informationsrechte verlangen (monthly, quarterly, annual, budget). Stahlauge hat sie bereits. Aufwand für die Mandantin: jedes Reporting-Format einmal sauber aufbauen, dann gleichmäßig an alle Berechtigten verteilen. Klassischer Anfängerfehler: nur an Northbridge schicken und Stahlauge übersehen.
 
@@ -62,7 +62,7 @@ If the Company grants to any other investor in any subsequent financing any righ
 
 For a period of 24 months following Closing, the Company shall procure that no transfer of shares occurs at a valuation higher than 130 percent of the Series A valuation without first consulting the Investor.
 
-## Spannungspunkte fuer Senior-Review
+## Spannungspunkte für Senior-Review
 
 1. **KPI Dashboard im Investor-Format**. Klingt harmlos, ist es aber nicht. Wenn Northbridge ein „bestimmtes Format" vorschreibt, kann das de facto eine kontinuierliche Reporting-Pflicht aus der Geschäftsführung herausnehmen und an die CFO-Funktion delegieren. Mandantin muss die operative Last verstehen.
 

--- a/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/14-board-und-consent-matters-mapping-de-en.md
+++ b/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/14-board-und-consent-matters-mapping-de-en.md
@@ -16,7 +16,7 @@ Frage 3: Kann die Materie durch Satzungsregelung an einen Beirat delegiert oder 
 
 Frage 4: Welcher Zustimmungsweg ist gegenüber Dritten **wirksam**, welcher nur **schuldrechtlich**?
 
-## Mapping fuer die Reserved Matters Liste aus dem Term Sheet
+## Mapping für die Reserved Matters Liste aus dem Term Sheet
 
 | Reserved Matter (Term Sheet) | Deutsche Umsetzung | Ebene | Rechtsgrundlage / Hinweis |
 | --- | --- | --- | --- |
@@ -31,7 +31,7 @@ Frage 4: Welcher Zustimmungsweg ist gegenüber Dritten **wirksam**, welcher nur 
 | Entering into contracts above EUR 250,000 p.a. | Gesellschafter-Veto oder Beirats-Veto | Gesellschafter oder Beirat | bei wesentlicher Bedeutung Gesellschafterversammlung sinnvoll |
 | Related-party transactions | doppeltes Veto: Gesellschafter und Beirat | beide | Konflikt der Geschäftsführer vermeiden |
 
-## Wirksamkeit gegenueber Dritten
+## Wirksamkeit gegenüber Dritten
 
 Wichtig für Hildemar: ein **Veto, das nur im SHA steht**, wirkt nur **inter partes**. Wenn ein Geschäftsführer trotz SHA-Veto einen Vertrag mit einem Dritten schließt, ist der Vertrag dem Dritten gegenüber **wirksam**. Die Folge ist allenfalls eine Innenhaftung des Geschäftsführers und eine vertragliche Sanktion gegenüber den Vertragsparteien des SHA.
 
@@ -57,7 +57,7 @@ Sauberer Pfad:
 3. Dann die **Geschäftsführungs-Geschäftsordnung** mit den verbleibenden operativen Zustimmungsvorbehalten füllen.
 4. Erst zum Schluss die **SHA-/Side-Letter-Ebene** als verbindliche Verpflichtung der Gesellschafter, ihre Stimmrechte entsprechend auszuüben.
 
-## Cheat Sheet fuer das naechste Briefing
+## Cheat Sheet für das nächste Briefing
 
 - „Reserved Matter" ist immer eine Frage: **Welches Organ?**
 - „Investor Director Approval" ist eine Frage: **Welche Geschäftsordnung?**

--- a/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/15-closing-checkliste-cp.md
+++ b/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/15-closing-checkliste-cp.md
@@ -2,7 +2,7 @@
 
 Interne Closing-Checkliste mit allen Conditions Precedent (CPs) und Closing Deliverables. Datenraum-Auszug. Fiktiv.
 
-## CPs und Deliverables Gesamtuebersicht
+## CPs und Deliverables Gesamtübersicht
 
 | Nr. | Item | Type | Verantwortlich | Status | Dependencies |
 | --- | --- | --- | --- | --- | --- |
@@ -80,7 +80,7 @@ Spielt die Reps and Warranties aus dem SPA-Teil. Hier eintragen:
 - VSOP-Programm Stand.
 - Beiratsbeschlüsse Slack-Stichpunkte.
 
-### CP 22: IP-Bereinigung Entwicklervertraege
+### CP 22: IP-Bereinigung Entwicklerverträge
 
 DD-Red-Flag 05. Bis Closing: ergänzende Abtretungserklärung der Entwickler, beidseitig unterzeichnet, schriftliche Bestätigung der Übertragung nach deutschem Recht (Paragraf 31 ff. UrhG).
 
@@ -92,7 +92,7 @@ Hildemar muss vor Closing prüfen: was steht im Term Sheet als CP, was steht in 
 | --- | --- | --- |
 | „Satisfactory legal due diligence" | CP 10 | breite Klausel, intern in DD-Findings übersetzt |
 | „No material adverse change" | nicht in interner Liste | bewusst ausgelassen, prüfen ob für Mandantin tragbar |
-| „Approval of the Investment Committee" | nicht in interner Liste | Northbridge-internes Approval, ausserhalb unserer Kontrolle |
+| „Approval of the Investment Committee" | nicht in interner Liste | Northbridge-internes Approval, außerhalb unserer Kontrolle |
 | „Customary closing certificates" | CP 11, 27 | erfasst |
 | „Bring-down of representations" | nicht in interner Liste | übersehen, ergänzen |
 

--- a/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/16-whatsapp-partner-associate-thread.md
+++ b/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/16-whatsapp-partner-associate-thread.md
@@ -12,30 +12,30 @@
 
 **07:04 - Hildemar:** Ich baue zwei Szenarien: A Pool pre-money zulasten Bestand, B Pool post-money alle. Wandeldarlehen Tante Ermelind mit Cap/Discount jeweils separat.
 
-**07:06 - Adelheid:** Gut. Und bitte keine "preferred shares" in die Satzung schreiben, als waeren wir Delaware. Wir brauchen deutsche Vorzugsrechte, sauber in Satzung/SHA gespiegelt.
+**07:06 - Adelheid:** Gut. Und bitte keine "preferred shares" in die Satzung schreiben, als wären wir Delaware. Wir brauchen deutsche Vorzugsrechte, sauber in Satzung/SHA gespiegelt.
 
-**07:09 - Hildemar:** Ich mache eine Begriffskarte: Preferred Shares = wirtschaftliche Vorzugsrechte, Umsetzung ueber Geschaeftsanteilsklassen/Satzung/SHA; keine deutsche Scheinuebersetzung.
+**07:09 - Hildemar:** Ich mache eine Begriffskarte: Preferred Shares = wirtschaftliche Vorzugsrechte, Umsetzung über Geschäftsanteilsklassen/Satzung/SHA; keine deutsche Scheinübersetzung.
 
-**07:16 - Adelheid:** Super. Zweiter Punkt: Investor Director. Nicht als Geschaeftsfuehrer behandeln. Es ist Beirat/Consent-Matter-Mechanik.
+**07:16 - Adelheid:** Super. Zweiter Punkt: Investor Director. Nicht als Geschäftsführer behandeln. Es ist Beirat/Consent-Matter-Mechanik.
 
-**07:18 - Hildemar:** Also Consent Matters auf drei Ebenen pruefen: Beirat, Geschaeftsfuehrer-Geschaeftsordnung, Gesellschafterversammlung/Satzung.
+**07:18 - Hildemar:** Also Consent Matters auf drei Ebenen prüfen: Beirat, Geschäftsführer-Geschäftsordnung, Gesellschafterversammlung/Satzung.
 
 **07:20 - Adelheid:** Genau. Und sag im Memo, wo nur SHA reicht und wo Satzung/Notar/HR zwingend werden kann.
 
-**07:43 - Hildemar:** Kurze Rueckfrage: Drag-Along Threshold im Term Sheet 60 Prozent fully diluted plus Series A Majority. Reicht das als schuldrechtliche Pflicht?
+**07:43 - Hildemar:** Kurze Rückfrage: Drag-Along Threshold im Term Sheet 60 Prozent fully diluted plus Series A Majority. Reicht das als schuldrechtliche Pflicht?
 
-**07:46 - Adelheid:** Als Pflicht im SHA ja, aber Vollmacht, Beurkundung, Minderheitenschutz und Preisgleichheit pruefen. Nicht "Vorkaufsrecht" nennen.
+**07:46 - Adelheid:** Als Pflicht im SHA ja, aber Vollmacht, Beurkundung, Minderheitenschutz und Preisgleichheit prüfen. Nicht "Vorkaufsrecht" nennen.
 
 **08:02 - Hildemar:** Ich habe im Associate-Draft den Satz "Liquidation Preference greift bei Insolvenz" gestrichen. Korrektur: Exit-Erlos-Waterfall, auch Share Deal/Asset Deal/Merger.
 
 **08:05 - Adelheid:** Sehr gut. Das ist der Punkt, an dem Leute in Interviews oft stolpern.
 
-**08:21 - Adelheid:** Ergebnis bis 10:30 bitte als 1-Seiter: Top-7 Begriffe, Top-5 deutsche Umsetzungsfragen, Top-3 Rueckfragen an Mandantin, Senior-Gates.
+**08:21 - Adelheid:** Ergebnis bis 10:30 bitte als 1-Seiter: Top-7 Begriffe, Top-5 deutsche Umsetzungsfragen, Top-3 Rückfragen an Mandantin, Senior-Gates.
 
 ## Lernfragen
 
 1. Welche Chatnachricht ist nur Organisationshinweis, welche ist fachliche Arbeitsanweisung?
-2. Welche Begriffe duerfen nicht mechanisch uebersetzt werden?
+2. Welche Begriffe dürfen nicht mechanisch übersetzt werden?
 3. Welche Stelle erzeugt eine Notar-/Registerfrage?
 4. Welche Rechenannahme muss zwingend in Excel sichtbar sein?
 5. Welche Antwort sollte Hildemar nie direkt an Investor Counsel schicken, bevor Adelheid sie gesehen hat?
@@ -43,6 +43,6 @@
 ## Erwarteter Arbeitsmodus
 
 - Erst `anschauungsmaterial-multiformat-auswertung`: Chat als Quelle einordnen.
-- Dann `rookie-modus`: Top-Begriffe erklaeren.
+- Dann `rookie-modus`: Top-Begriffe erklären.
 - Dann `cap-table-gesellschafterliste` und `fully-diluted-esop-option-pool`.
 - Danach `partner-briefing-memo`.

--- a/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/17-anschauungsmaterial-und-formate-index.md
+++ b/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/17-anschauungsmaterial-und-formate-index.md
@@ -1,31 +1,31 @@
 # 17 Anschauungsmaterial und Formate Index
 
-Diese Datei erschliesst die nicht reinen Markdown-Unterlagen der Testakte. Sie sind fiktiv, aber absichtlich so gestaltet, wie Material in einem echten Dealroom auftauchen kann: nicht perfekt, teilweise informell, teilweise visuell, teilweise rechnerisch.
+Diese Datei erschließt die nicht reinen Markdown-Unterlagen der Testakte. Sie sind fiktiv, aber absichtlich so gestaltet, wie Material in einem echten Dealroom auftauchen kann: nicht perfekt, teilweise informell, teilweise visuell, teilweise rechnerisch.
 
 ## Neue Formate
 
-| Datei | Format | Was simuliert wird | Wofuer sie gut ist |
+| Datei | Format | Was simuliert wird | Wofür sie gut ist |
 | --- | --- | --- | --- |
 | `18-cap-table-waterfall-training.xlsx` | Excel | Cap Table, Pool pre-/post-money, Wandeldarlehen, Liquidation-Preference-Waterfall | Zahlenlogik sichtbar machen, Annahmen kontrollieren |
 | `19-notar-scan-beurkundungssprache.pdf` | PDF-Scan | handschriftlich wirkende Notar-/Associate-Notiz zu Sprache, Satzung, Beurkundung | Form- und Sprach-Gate trainieren |
 | `20-whiteboard-foto-deal-map.jpg` | JPEG-Foto | Whiteboard-Skizze mit Dealstruktur, Dokumenten und Spezialskills | schnelle visuelle Orientierung |
-| `21-investor-email-screenshot.jpg` | JPEG-Screenshot | abgeschnittener Email-Screenshot der Gegenseite | Quellenkritik: Screenshot ist keine vollstaendige Vertragsfassung |
+| `21-investor-email-screenshot.jpg` | JPEG-Screenshot | abgeschnittener Email-Screenshot der Gegenseite | Quellenkritik: Screenshot ist keine vollständige Vertragsfassung |
 | `22-whatsapp-screenshot.jpg` | JPEG-Screenshot | Chat-Auszug zu fully diluted, Investor Director, Drag-Along | informelle Anweisung vs. belastbarer Auftrag |
-| `23-rookie-cheatsheet-corporate-legal-english.pdf` | PDF | einseitiges Lernblatt mit Begriffskarten und Senior-Gates | Einstieg fuer Anfaenger und Demo im Plugin |
+| `23-rookie-cheatsheet-corporate-legal-english.pdf` | PDF | einseitiges Lernblatt mit Begriffskarten und Senior-Gates | Einstieg für Anfänger und Demo im Plugin |
 
 ## Didaktischer Einsatz
 
-1. **Nicht sofort loesen.** Zuerst jedes Material als Dokumentkarte erfassen: Wer, wann, wozu, Sprache, Verlaesslichkeit.
+1. **Nicht sofort lösen.** Zuerst jedes Material als Dokumentkarte erfassen: Wer, wann, wozu, Sprache, Verlässlichkeit.
 2. **Sichtbares von Unsichtbarem trennen.** Ein Screenshot zeigt nur einen Ausschnitt. Ein Scan kann Randnotizen enthalten, aber nicht automatisch den finalen Vertrag.
 3. **Zahlen immer in Annahmen zerlegen.** Excel-Modelle sind keine Wahrheit, sondern sichtbar gemachte Annahmen.
-4. **Chat nie als Vertrag behandeln.** WhatsApp-Nachrichten koennen Arbeitsanweisungen, Rueckfragen oder Indizien sein, ersetzen aber nicht die Langformdokumente.
+4. **Chat nie als Vertrag behandeln.** WhatsApp-Nachrichten können Arbeitsanweisungen, Rückfragen oder Indizien sein, ersetzen aber nicht die Langformdokumente.
 5. **Skill-Routing ernst nehmen.** Mehrere Formate bedeuten meist mehrere Spezialskills.
 
 ## Erwartete Ausgabe bei Bearbeitung
 
 Das Plugin soll nach Sichtung der Formate eine Tabelle liefern:
 
-| Quelle | Verlaesslichkeit | Top-Begriffe | deutsches Risiko | naechster Skill |
+| Quelle | Verlässlichkeit | Top-Begriffe | deutsches Risiko | nächster Skill |
 | --- | --- | --- | --- | --- |
 
 Danach soll es einen 30-Minuten-Lernpfad und ein Partnerbriefing-Skelett erzeugen.

--- a/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/24-agio-und-kapitalruecklage-streitfrage.md
+++ b/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/24-agio-und-kapitalruecklage-streitfrage.md
@@ -1,0 +1,141 @@
+# 24 Agio und Kapitalrücklage — Streitfrage Satzungsverankerung bei Kapitalerhöhung
+
+> **Fiktive Lehrakte.** Personen, Mandanten und Zitate sind erfunden. Übereinstimmungen mit realen Personen sind nicht beabsichtigt.
+
+## Kontext im Deal
+
+Bei der Series-A-Runde von Kometenfalter Systems GmbH zahlt Northbridge Growth III SCS für 16.679 neue Geschäftsanteile zu einem Ausgabebetrag von ca. 287,77 EUR pro Anteil. Der Nennbetrag pro Geschäftsanteil ist 1,00 EUR. Die Differenz von 286,77 EUR pro Anteil ist das **Agio** (Aufgeld). Bei 18.069 Series-A-Anteilen sind das in Summe rund 5,182 Mio. EUR Agio — fast die gesamte Investitionssumme. Das Stammkapital steigt nur um 18.069 EUR von 30.000 auf 48.069 EUR.
+
+Diese Konstellation ist nicht etwa eine Besonderheit dieses Deals, sondern das absolute Standardmuster bei VC-finanzierten GmbHs. Damit ist die Frage, **wie das Agio rechtlich korrekt zu konstruieren** ist und ob es **zwingend in den aktualisierten Satzungstext** muss, eine der praktisch wichtigsten Fragen der Transaktion. Adelheid von Westarp hat dem Associate Hildemar K. eine ausführliche Notiz dazu verfasst.
+
+---
+
+## Notiz Adelheid von Westarp an Hildemar K., 21.05.2026, 14:22 Uhr
+
+Lieber Hildemar,
+
+ich sehe in Ihrem Memo-Entwurf den Satz „Das Agio wird in die Kapitalrücklage gebucht, sonst ist nichts zu beachten." Das ist genau die Art von Halbsatz, mit der man bei einer Holding-Strukturierung oder einem qualifizierten Anteilstausch in einen 6-stelligen Steuerschaden hineinläuft. Bitte arbeiten Sie die folgende Differenzierung in Datei 06 und in das Memo für die Mandantin ein.
+
+### 1. Echtes (korporatives) vs. unechtes (schuldrechtliches) Agio
+
+- **Echtes/korporatives Agio:** gesellschaftsrechtlich begründeter Aufpreis auf den Nennbetrag der übernommenen Stammeinlage. Wird durch korporativen Beschluss begründet, ist Teil der mitgliedschaftlichen Pflichtenstellung, fließt in die Kapitalrücklage nach **§ 272 Abs. 2 Nr. 1 HGB** und unterliegt der Kapitalbindung. Standard bei VC-Runden.
+- **Unechtes/schuldrechtliches Agio:** beruht auf einer rein schuldrechtlichen Nebenabrede (zwischen Gesellschaftern oder zwischen Gesellschafter und Gesellschaft). Keine korporative Wirkung. Fließt nach herrschender Meinung in die Kapitalrücklage nach **§ 272 Abs. 2 Nr. 4 HGB** (andere Zuzahlungen). Vgl. Bayer, in: Lutter/Hommelhoff, GmbHG, 21. Aufl. 2023, § 5 Rn. 32 ff.
+
+**Für Kometenfalter brauchen wir das echte Agio.** Northbridge schreibt 4,8 Mio. EUR mit korporativer Wirkung auf die GmbH-Bilanz, nicht eine schuldrechtliche Zuzahlung an Mitgesellschafter. Das ist Vorbedingung für die Buchwertfortführung beim qualifizierten Anteilstausch nach § 21 UmwStG und für die spätere steuerneutrale Rückgewähr aus dem Einlagekonto.
+
+### 2. Gründungsstadium: § 3 Abs. 2 GmbHG zwingend
+
+Bei der **Gründung** ist die Lage unstreitig: Das echte Agio ist eine **Nebenleistungspflicht** im Sinne des § 3 Abs. 2 GmbHG und muss zwingend in den Gesellschaftsvertrag (Satzung) aufgenommen werden. Die fehlende Aufnahme führt zur **Unwirksamkeit der Agioverpflichtung** (vgl. BGH, Urt. v. 15.10.2007 — II ZR 216/06, GmbHR 2008, 147; Roth, in: Roth/Altmeppen, GmbHG, 10. Aufl. 2021, § 3 Rn. 41; J. Vetter, in: MüKoGmbHG, 4. Aufl. 2022, § 3 Rn. 109 ff.). Praktisch besonders relevant bei der Etablierung von Holding-Strukturen, in denen die Tochter-GmbH durch Bargründung mit gleichzeitiger Sachagio-Einbringung von Anteilen entsteht — der klassische § 21 UmwStG-Anteilstausch.
+
+### 3. Kapitalerhöhung: Die eigentliche Streitfrage
+
+Bei der **Kapitalerhöhung** ist die Lage diffiziler. § 3 Abs. 2 GmbHG gilt sachlich nicht nur bei Gründung, sondern dauerhaft (Strukturnorm). Daraus könnte folgen, dass jedes echte Agio zwingend in den aktualisierten Satzungstext muss. Das ist nicht ohne Weiteres so. Die richtige Differenzierung — die in der Neuauflage des Scholz, GmbHG, § 3 (14. Aufl. 2027, Verlag Dr. Otto Schmidt) vertieft werden wird — lautet:
+
+**Parallele zur Sachkapitalerhöhung:** Obwohl § 5 Abs. 4 GmbHG bei der Gründung die Festsetzung des Sacheinlagegegenstandes als Wirksamkeitsvoraussetzung verlangt, ist nach allgemeiner Meinung bei der Sachkapitalerhöhung die Aufnahme in den **Kapitalerhöhungsbeschluss und die Übernahmeerklärung** ausreichend — eine Wiedergabe im aktualisierten Satzungswortlaut ist nicht erforderlich, weil der Kapitalerhöhungsbeschluss selbst **satzungsändernde Wirkung** entfaltet (vgl. BGH, Urt. v. 16.02.1981 — II ZR 168/79, BGHZ 80, 129; Lieder, in: MüKoGmbHG, 4. Aufl. 2022, § 55 Rn. 71 ff.).
+
+**Differenzierung nach Fälligkeit (h.M. für das echte Agio bei KapErh):**
+
+- **Fall (1) — Agio bis zur Eintragung fällig und geleistet:** Eine Aufnahme in den Satzungstext wäre nur noch rechtshistorische Reminiszenz ohne normativen Mehrwert. Die Nebenleistungspflicht ist erloschen — kein Regelungsgegenstand mehr für die Satzung. **Keine Aufnahme in den Satzungstext erforderlich.**
+- **Fall (2) — Agio erst nach Eintragung fällig:** Die Nebenleistungspflicht besteht über die Eintragung hinaus fort. § 3 Abs. 2 GmbHG greift ratione materiae. **Aufnahme in den aktualisierten Satzungstext systematisch geboten.**
+
+### 4. Rechtsfolge bei Nichtaufnahme im Fall (2)
+
+Anders als im Gründungsfall führt die fehlende Aufnahme **nicht zur Unwirksamkeit** der Agioverpflichtung, sondern lediglich zu einem **Eintragungshindernis** beim Handelsregister. Begründung:
+
+- Der Kapitalerhöhungsbeschluss entfaltet inklusive Agio-Begründung satzungsändernde Wirkung kraft eigener Rechtsnatur (§ 53 Abs. 2 GmbHG).
+- Der Beschluss ist im Registerordner einsehbar — dem Publizitätsgedanken ist Genüge getan.
+- Eine Nichtigkeitsfolge wäre unverhältnismäßig, da ein formwirksamer, notariell beurkundeter Beschluss vorliegt.
+
+**Steuerlich** dürfte die fehlende Aufnahme in den Satzungstext unschädlich sein — die Finanzverwaltung knüpft an die materielle gesellschaftsrechtliche Wirksamkeit an, nicht an die formale Satzungsredaktion (vgl. UmwSt-Erlass v. 11.11.2011, BStBl. I 2011, 1314, Rn. 21.09 ff.).
+
+### 5. Praxisempfehlung Adelheid
+
+Auch wenn die fehlende Aufnahme im Fall (2) nur ein Eintragungshindernis begründet — Sie wollen den Notartermin nicht zweimal machen und Sie wollen Roswitha Plöger nicht erklären müssen, warum die Eintragung scheitert. **Aufnahme in den Satzungstext vorsorglich immer dann, wenn das Agio nach Eintragung fällig wird.**
+
+Für Kometenfalter bedeutet das: Wenn Northbridge das Agio bei Closing in voller Höhe leistet (Fall 1), muss das Agio nicht in den Satzungstext aufgenommen werden — es genügt der Kapitalerhöhungsbeschluss mit Übernahmeerklärung. Wenn das Agio (oder Teile davon, etwa bei staged closings) erst nach Eintragung fällig wird (Fall 2), muss es in den neuen § 3 oder § 4 der Satzung aufgenommen werden.
+
+---
+
+## US-Term-Sheet-Bezug: Original Purchase Price, Liquidation Preference und Agio
+
+Die US-amerikanischen Term Sheets sprechen nicht von „Agio", sondern von **„Original Issue Price"** oder **„Original Purchase Price"** (OPP). Das ist begrifflich nicht dasselbe, funktional aber sehr ähnlich. Hildemar, achten Sie auf die folgenden Übersetzungsfallen.
+
+| US-Begriff | Was es technisch ist | Deutsche Entsprechung |
+|---|---|---|
+| Original Purchase Price (OPP) | Gesamtpreis pro Series-A-Share = Nennbetrag (Par Value) plus Aufgeld | Ausgabebetrag pro Geschäftsanteil = Nennbetrag plus Agio |
+| Par Value | Nennbetrag des Shares (oft sogar 0,001 USD oder 0,0001 USD bei Delaware-Corp) | Nennbetrag des Geschäftsanteils (mindestens 1 EUR, § 5 Abs. 2 GmbHG) |
+| Additional Paid-In Capital (APIC) | Bilanz-Posten unter Equity: Differenz zwischen OPP und Par Value über alle Shares | Kapitalrücklage nach § 272 Abs. 2 Nr. 1 HGB |
+| Liquidation Preference | Vorrecht im Exit/Wind-down, gemessen an OPP (z.B. „1x non-participating preferred") | Vorrecht im Liquidationsfall, gemessen am Ausgabebetrag (Nennbetrag plus Agio) |
+
+**Häufige Übersetzungsfehler des Associates:**
+
+1. „Original Purchase Price" wird mit „Kaufpreis" übersetzt — falsch. Es ist der **Ausgabebetrag**, weil bei einer Series-A-Runde neue Anteile **emittiert** werden, nicht alte verkauft. „Kaufpreis" wäre nur bei einer Secondary-Komponente korrekt.
+2. „Par Value" wird mit „Nennwert" übersetzt — terminologisch akzeptabel, juristisch besser „Nennbetrag" (so § 5 GmbHG, § 8 AktG).
+3. „APIC" wird mit „zusätzliches eingezahltes Kapital" wörtlich übersetzt — bilanziell falsch. Im deutschen HGB heißt der Posten **„Kapitalrücklage"**.
+4. „Liquidation Preference of 1x OPP" wird oft als „1x Kaufpreis" formuliert — und damit ist unklar, ob nur das Agio, nur der Nennbetrag, oder beide gemeint sind. Adelheid will hier immer: **„1x Ausgabebetrag (Nennbetrag plus Agio)"** zur Vermeidung von Auslegungsstreit.
+
+**Mathe-Check im Kometenfalter-Deal:**
+
+Liquidation Preference 1x OPP für Northbridge bedeutet im Liquidationsfall:
+- Northbridge erhält vor den Stammgesellschaftern: 16.679 Series-A-Anteile × 287,77 EUR = ca. 4,8 Mio. EUR.
+- Davon entfallen 16.679 EUR auf den Nennbetrag, ca. 4,783 Mio. EUR auf das Agio.
+- Der Agio-Anteil ist also rund 99,7 % der Liquidation Preference. Wer das Agio nicht im Liquidationskonzept hat, verliert dem Investor 99,7 % seiner Sicherheit.
+
+**Konsequenz für die Satzung der Kometenfalter:** Die Liquidationspräferenz nach § 11a der neu zu fassenden Satzung muss ausdrücklich auf den **Ausgabebetrag (Nennbetrag plus Agio)** Bezug nehmen, nicht nur auf den Nennbetrag. Eine in deutschen Satzungen häufig anzutreffende Formulierung „1-fache Liquidationspräferenz auf den Nennbetrag" wäre für Northbridge eine Katastrophe und wird in jeder VC-Runde sofort korrigiert.
+
+---
+
+## Wirtschaftliche Funktion des Agios — warum Northbridge das so macht
+
+Damit Hildemar die Mandantin Kunigunde Reiter (Geschäftsführerin Kometenfalter) erklären kann, warum das Agio nicht ein bloß bilanzieller Kunstgriff ist:
+
+1. **Bewertungsdifferenz Verkehrswert vs. Nennwert.** Das Stammkapital von 30.000 EUR (vor Series A) ist eine registerlich publizierte Größe, die mit dem Verkehrswert von 12 Mio. EUR pre-money nichts zu tun hat. Das Agio bildet die Differenz ab.
+2. **Verwässerungssteuerung.** Northbridge zahlt 4,8 Mio. EUR, bekommt aber nur 16.679 EUR Nennbetrag (entspricht 16.679 Geschäftsanteilen à 1 EUR) plus ca. 4,783 Mio. EUR Agio. Die quotale Mehrheit der Gründer bleibt rechnerisch erhalten.
+3. **Vermeidung der „Stammkapital-Inflation".** Würde Northbridge 4,8 Mio. EUR als Stammkapital zeichnen, hätte die GmbH ein Stammkapital von ca. 4,83 Mio. EUR — dauerhaft der Kapitalbindung nach § 30 GmbHG unterworfen, nur mit Sperrjahr und Gläubigeraufruf nach §§ 58 ff. GmbHG zurückführbar. Das Agio fließt dagegen in die Kapitalrücklage, die flexibler aufgelöst werden kann.
+4. **Steuerliche Erfassung im Einlagekonto.** Das Agio erhöht das steuerliche Einlagekonto nach **§ 27 KStG**. Spätere Rückzahlungen aus der Kapitalrücklage gelten als steuerneutrale Einlagenrückgewähr (nicht als Dividende). Beim Gesellschafter erhöht das Agio die Anschaffungskosten der Beteiligung (st. Rspr.: BFH, Urt. v. 27.05.2009 — I R 53/08, BFHE 226, 500, BStBl II 2010, 1004; bestätigt durch BFH, Urt. v. 03.05.2023 — IX R 12/22).
+5. **Bezugsrechtsschutz.** Bei einer Kapitalerhöhung unter Bezugsrechtsausschluss ist ein angemessenes Agio regelmäßig zwingend, weil andernfalls die vom Bezug ausgeschlossenen Altgesellschafter wirtschaftlich nicht geschützt sind. Der für die AG entwickelte „Kali+Salz"-Grundsatz (BGH, Urt. v. 13.03.1978 — II ZR 142/76, BGHZ 71, 40) ist auf die GmbH übertragbar.
+6. **Signalfunktion.** Die Höhe des Agios dokumentiert die Pre-Money-Bewertung. Bezugspunkt für ESOP-Ausgabepreise, Anti-Dilution-Berechnungen und Folgerunden.
+
+---
+
+## Anfängerfehler-Catalogue: typische Stolperer beim Agio
+
+| Fehler | Was richtig wäre |
+|---|---|
+| „Agio braucht keine Satzungsregelung, das ist nur Buchhaltung." | Bei Gründung zwingend nach § 3 Abs. 2 GmbHG. Bei KapErh mit nachgelagerter Fälligkeit ebenfalls. |
+| „Agio = Kapitalrücklage nach § 272 Abs. 2 Nr. 4 HGB." | Echtes Agio = Nr. 1. Schuldrechtliches Agio = Nr. 4. Differenzierung beibehalten. |
+| „Das Sachagio wird einfach im Kapitalerhöhungsbeschluss erwähnt, die Satzung bleibt unverändert." | Bei Sachagio mit nachgelagerter Fälligkeit (selten, aber möglich) ist Satzungsaufnahme angezeigt. Bei sofortiger Leistung mit Eintragung ist die Aufnahme nicht erforderlich. |
+| „Liquidation Preference 1x bedeutet 1x Nennbetrag." | Falsch. Bezugsgröße ist der **Ausgabebetrag (Nennbetrag plus Agio)**. Andernfalls 99 %-Verlust für den Investor. |
+| „Original Purchase Price = Kaufpreis." | Falsch. Ausgabebetrag. Bei Kapitalerhöhung werden Anteile **ausgegeben**, nicht verkauft. |
+| „APIC wird in der GmbH-Bilanz unter ‚Gezeichnetes Kapital' geführt." | Nein. Kapitalrücklage, § 272 Abs. 2 Nr. 1 HGB. Gezeichnetes Kapital = nur Nennbeträge. |
+| „Beim qualifizierten Anteilstausch nach § 21 UmwStG muss das gesamte Einbringungsvolumen ins Stammkapital." | Nein. Sachagio ist die Standardgestaltung — Stammkapital schlank halten, Sachagio in die Kapitalrücklage. |
+| „Wenn das Agio bei Closing fließt, brauche ich keine Wirksamkeitsvorausetzungen mehr zu prüfen." | Doch. Der Kapitalerhöhungsbeschluss muss das Agio korrekt benennen, sonst wird der Notar nicht beurkunden und das Registergericht nicht eintragen. |
+
+---
+
+## Aufgabe für Hildemar
+
+1. Bauen Sie in das Memo für die Mandantin einen Abschnitt „Agio und Liquidationspräferenz" ein, der die Punkte 1 bis 6 oben für Kunigunde Reiter verständlich auflöst.
+2. Prüfen Sie den vorliegenden Satzungsentwurf des Notariats Schwartz daraufhin, ob die Liquidationspräferenz auf **Ausgabebetrag** oder fälschlich auf **Nennbetrag** Bezug nimmt. Falls letzteres: Markup an Brackenmuir & Quint vorbereiten.
+3. Klären Sie mit Olaf Eichholtz (CFO), wann das Agio fließt — bei Closing oder gestaffelt? Falls gestaffelt: Aufnahme in den neuen Satzungstext vorsorglich machen, sonst Eintragungshindernis.
+4. Bereiten Sie für die nächste Steuerabstimmung mit der Mandantin eine Notiz vor, dass das Agio in das steuerliche Einlagekonto nach § 27 KStG fließt und damit später steuerneutral zurückgezahlt werden kann — das ist ein nicht zu unterschätzendes Argument gegenüber den Gründern, die Liquiditätssorgen für die Zukunft haben.
+
+> **AvW:** Hildemar, das ist eine der wenigen Fragen, die der Investor Counsel Brackenmuir & Quint nicht besser kann als wir. Brackenmuir denkt in Delaware-Kategorien (Par Value 0,0001 USD, APIC als bilanzielle Selbstverständlichkeit). Die deutsche § 3 Abs. 2 GmbHG-Dogmatik mit der Differenzierung nach Fälligkeit ist eine **deutsche Spezialität**, die wir hier auf der Seite der Mandantin haben müssen. Wenn Sie das in einem Call mit Brackenmuir sauber erklären können, haben Sie Punkte bei Frieda Brackenmuir gesammelt. Wenn nicht: bitte vor dem Call mit mir durchgehen.
+
+---
+
+## Weiterführende Quellen für Hildemar (Studien-Stoff)
+
+- BGH, Urt. v. 15.10.2007 — II ZR 216/06, GmbHR 2008, 147 (Sachagio bei Gründung, § 3 Abs. 2 GmbHG zwingend)
+- BGH, Urt. v. 16.02.1981 — II ZR 168/79, BGHZ 80, 129 (Sachkapitalerhöhung, Beschluss mit satzungsändernder Wirkung)
+- BGH, Urt. v. 13.03.1978 — II ZR 142/76, BGHZ 71, 40 — „Kali+Salz" (Bezugsrechtsausschluss, sachliche Rechtfertigung)
+- BFH, Urt. v. 27.05.2009 — I R 53/08, BFHE 226, 500, BStBl II 2010, 1004 (Agio als Anschaffungskosten des neu erworbenen Anteils)
+- BFH, Urt. v. 03.05.2023 — IX R 12/22 (Überpari-Emission, Bestätigung I R 53/08, kein § 42 AO-Missbrauch)
+- UmwSt-Erlass v. 11.11.2011, BStBl. I 2011, 1314, Rn. 21.09 ff. (qualifizierter Anteilstausch und Sachagio)
+- Bayer, in: Lutter/Hommelhoff, GmbHG, 21. Aufl. 2023, § 5 Rn. 32 ff.
+- J. Vetter, in: MüKoGmbHG, 4. Aufl. 2022, § 3 Rn. 109 ff.
+- Lieder, in: MüKoGmbHG, 4. Aufl. 2022, § 55 Rn. 71 ff.
+- Roth, in: Roth/Altmeppen, GmbHG, 10. Aufl. 2021, § 3 Rn. 41
+- Scholz, GmbHG, § 3 (14. Aufl. 2027, Verlag Dr. Otto Schmidt, im Erscheinen — wird die Differenzierung nach Fälligkeit vertiefen)
+- Schwandtner, Das Agio im GmbH- und Aktienrecht, 2006 (Duncker & Humblot)
+- Baums, Agio und sonstige Zuzahlungen im Aktienrecht, ILF Working Paper No. 124

--- a/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/README.md
+++ b/testakten/gesellschaftsrecht-legal-english-frankfurt-startup/README.md
@@ -1,8 +1,8 @@
 # Testakte: Frankfurt Startup Round — Corporate Legal English
 
-Fiktive Schulungsakte fuer das Plugin `gesellschaftsrecht-legal-english`. Ziel: Big-Law-Nachwuchs (1st-/2nd-Year-Associates) in einer Corporate-Praxis lehrt zu lernen, wie eine deutsche GmbH eine Series-A-Finanzierung mit englischsprachigem Term Sheet und deutscher Notar-/Registerlogik durchfuehrt. Aehnlichkeiten zu realen Transaktionen sind nicht beabsichtigt.
+Fiktive Schulungsakte für das Plugin `gesellschaftsrecht-legal-english`. Ziel: Big-Law-Nachwuchs (1st-/2nd-Year-Associates) in einer Corporate-Praxis lehrt zu lernen, wie eine deutsche GmbH eine Series-A-Finanzierung mit englischsprachigem Term Sheet und deutscher Notar-/Registerlogik durchführt. Aehnlichkeiten zu realen Transaktionen sind nicht beabsichtigt.
 
-Die Akte simuliert einen hektischen Donnerstag in einer internationalen Corporate-Praxis in Frankfurt am Main. Die Partnerin Adelheid von Westarp uebergibt einem Associate eine angefangene Mandatsbearbeitung mit Cap Table, fully diluted, Anti-Dilution, Vesting, Drag/Tag, Liquidation Preference, Consent Matters und einer Reihe deutscher Umsetzungsfragen. Die Akte enthaelt absichtlich Stolperfallen und Anfaengerfehler. Seit dem v34-Ausbau enthaelt sie auch Multi-Format-Unterlagen: Excel, PDF-Scan, PDF-Cheatsheet, JPEG-Foto, Email-Screenshot und WhatsApp-Screenshot.
+Die Akte simuliert einen hektischen Donnerstag in einer internationalen Corporate-Praxis in Frankfurt am Main. Die Partnerin Adelheid von Westarp übergibt einem Associate eine angefangene Mandatsbearbeitung mit Cap Table, fully diluted, Anti-Dilution, Vesting, Drag/Tag, Liquidation Preference, Consent Matters und einer Reihe deutscher Umsetzungsfragen. Die Akte enthält absichtlich Stolperfallen und Anfängerfehler. Seit dem v34-Ausbau enthält sie auch Multi-Format-Unterlagen: Excel, PDF-Scan, PDF-Cheatsheet, JPEG-Foto, Email-Screenshot und WhatsApp-Screenshot.
 
 ## Dateien
 
@@ -11,21 +11,21 @@ Die Akte simuliert einen hektischen Donnerstag in einer internationalen Corporat
 | `00-deal-personen-und-zeitleiste.md` | Cast, Zeitleiste 14.02.2022 bis 15.09.2026, fiktive Eckdaten |
 | `01-partnerauftrag-email.md` | Partnerauftrag mit knapper, jargonreicher Aufgabenbeschreibung, zweite Email und Slack-Thread |
 | `02-cap-table-und-gesellschafterliste.md` | Cap Table V19a (current) und Projektion V19b/V19c (Pool pre-/post-money) plus Berechnungsskizzen |
-| `03-term-sheet-auszug.md` | Englischer Term Sheet Auszug mit ausfuehrlichem Definitions-Set und vielen Klauseln |
+| `03-term-sheet-auszug.md` | Englischer Term Sheet Auszug mit ausführlichem Definitions-Set und vielen Klauseln |
 | `04-sha-satzung-und-vesting-notizen.md` | Synopse Seed-SHA / Satzung / Series-A-Term-Sheet mit CFO-Kommentaren |
 | `05-dd-red-flags-und-client-fragen.md` | Datenraum-Index, DD-Funde Corporate/IP/Employment/Commercial/Tax und Mandantenfragen |
 | `06-associate-arbeitsstand.md` | Unfertige Associate-Notiz mit rotem Stift der Partnerin |
-| `07-erwarteter-output-ohne-musterloesung.md` | Pruefraster fuer Bearbeiter, ohne Musterloesung |
-| `08-glossar-deutsch-englisch-fallstricke.md` | Begriffsglossar mit typischen Missverstaendnissen Deutsch/Englisch |
-| `09-anfaengerfehler-katalog-mit-partner-rotstift.md` | Anfaengerfehler-Katalog mit Kommentaren der Partnerin |
-| `10-wandeldarlehen-tante-ermelind.md` | Vollstaendiger Convertible Loan Agreement plus Associate-Vermerk und Wandlungsrechnung |
+| `07-erwarteter-output-ohne-musterlösung.md` | Prüfraster für Bearbeiter, ohne Musterlösung |
+| `08-glossar-deutsch-englisch-fallstricke.md` | Begriffsglossar mit typischen Missverständnissen Deutsch/Englisch |
+| `09-anfängerfehler-katalog-mit-partner-rotstift.md` | Anfängerfehler-Katalog mit Kommentaren der Partnerin |
+| `10-wandeldarlehen-tante-ermelind.md` | Vollständiger Convertible Loan Agreement plus Associate-Vermerk und Wandlungsrechnung |
 | `11-investor-counsel-markup-roundtrip.md` | Markup-Email der Gegenseite, interne Sortierung und 2:14-Uhr-Antwort des Associates |
 | `12-notar-checkliste-und-handelsregisterlogik.md` | Notarverfahren, Sprachfragen § 5 BeurkG, Einheitsdoktrin, Handelsregister, Fristen |
 | `13-side-letter-und-information-rights.md` | Seed-Side-Letter, Series-A-Side-Letter und Konsistenz-Stack |
-| `14-board-und-consent-matters-mapping-de-en.md` | Reserved-Matters-Mapping englisch zu deutsch (Beirat, Geschaeftsordnung, Gesellschafterversammlung) |
+| `14-board-und-consent-matters-mapping-de-en.md` | Reserved-Matters-Mapping englisch zu deutsch (Beirat, Geschäftsordnung, Gesellschafterversammlung) |
 | `15-closing-checkliste-cp.md` | Closing-Checkliste mit 30 CPs, Term-Sheet-Gap-Analyse und Post-Closing-Punkten |
 | `16-whatsapp-partner-associate-thread.md` | Fiktiver Chat-Thread mit Arbeitsanweisungen zu fully diluted, Pool, Investor Director, Drag-Along und Senior-Gates |
-| `17-anschauungsmaterial-und-formate-index.md` | Index fuer Excel, PDF, Scan, Foto, Screenshot und Chat-Unterlagen |
+| `17-anschauungsmaterial-und-formate-index.md` | Index für Excel, PDF, Scan, Foto, Screenshot und Chat-Unterlagen |
 | `18-cap-table-waterfall-training.xlsx` | Excel-Trainingsmodell mit Cap Table, Pool-Szenarien, Convertible, Waterfall und Rookie-Quiz |
 | `19-notar-scan-beurkundungssprache.pdf` | PDF-Scan einer internen Notar-/Beurkundungssprache-Notiz |
 | `20-whiteboard-foto-deal-map.jpg` | Whiteboard-Foto mit Deal Map und Rookie-Regel |
@@ -38,8 +38,8 @@ Die Akte simuliert einen hektischen Donnerstag in einer internationalen Corporat
 ### Pfad A — Begriffsdisziplin (Erstlesung, 2 Stunden)
 
 1. README (diese Datei).
-2. `08-glossar-deutsch-englisch-fallstricke.md` zuerst — die zwoelf Begriffspaare entscheiden ueber Verstaendnis aller anderen Dateien.
-3. `09-anfaengerfehler-katalog-mit-partner-rotstift.md` als Inokulation gegen die fuenf Fehlerklassen A bis E.
+2. `08-glossar-deutsch-englisch-fallstricke.md` zuerst — die zwölf Begriffspaare entscheiden über Verständnis aller anderen Dateien.
+3. `09-anfängerfehler-katalog-mit-partner-rotstift.md` als Inokulation gegen die fünf Fehlerklassen A bis E.
 4. `00-deal-personen-und-zeitleiste.md` als Orientierung.
 
 ### Pfad B — Mandatsanalyse (Hauptlesung, 4 Stunden)
@@ -50,7 +50,7 @@ Die Akte simuliert einen hektischen Donnerstag in einer internationalen Corporat
 4. `04-sha-satzung-und-vesting-notizen.md` — Synopse Seed-SHA / Satzung / Term Sheet.
 5. `05-dd-red-flags-und-client-fragen.md` — Datenraum-Befunde und Mandantenfragen.
 6. `06-associate-arbeitsstand.md` — Associate-Stand mit Rotstift.
-7. `07-erwarteter-output-ohne-musterloesung.md` — Pruefraster.
+7. `07-erwarteter-output-ohne-musterlösung.md` — Prüfraster.
 
 ### Pfad C — Vertiefung (4 bis 6 Stunden)
 
@@ -58,42 +58,42 @@ Die Akte simuliert einen hektischen Donnerstag in einer internationalen Corporat
 2. `11-investor-counsel-markup-roundtrip.md` — typische Markup-Roundtrip-Dynamik.
 3. `12-notar-checkliste-und-handelsregisterlogik.md` — § 5 BeurkG, § 15 GmbHG, Einheitsdoktrin, § 40 GmbHG.
 4. `13-side-letter-und-information-rights.md` — MFN, Pro-Rata, Anti-Embarrassment, Most Favoured Investor.
-5. `14-board-und-consent-matters-mapping-de-en.md` — Reserved-Matters in Beirat, GF-Geschaeftsordnung, Gesellschafterversammlung uebersetzen.
+5. `14-board-und-consent-matters-mapping-de-en.md` — Reserved-Matters in Beirat, GF-Geschäftsordnung, Gesellschafterversammlung übersetzen.
 6. `15-closing-checkliste-cp.md` — die 30 CPs durchgehen.
 
 ### Pfad D — Mandantenkommunikation (1 bis 2 Stunden)
 
 1. `05-dd-red-flags-und-client-fragen.md` Abschnitt J — Mandantenfragen.
-2. `07-erwarteter-output-ohne-musterloesung.md` Abschnitt B.3 — Stilvorgabe.
-3. `08-glossar-deutsch-englisch-fallstricke.md` — fuer das Mandantenmemo verwenden.
+2. `07-erwarteter-output-ohne-musterlösung.md` Abschnitt B.3 — Stilvorgabe.
+3. `08-glossar-deutsch-englisch-fallstricke.md` — für das Mandantenmemo verwenden.
 
 ### Pfad E — Multi-Format-Dealroom (60 bis 90 Minuten)
 
-1. `17-anschauungsmaterial-und-formate-index.md` — Materialarten und Verlaesslichkeit klaeren.
-2. `18-cap-table-waterfall-training.xlsx` — Zahlenlogik pruefen, nicht nur lesen.
+1. `17-anschauungsmaterial-und-formate-index.md` — Materialarten und Verlässlichkeit klären.
+2. `18-cap-table-waterfall-training.xlsx` — Zahlenlogik prüfen, nicht nur lesen.
 3. `19-notar-scan-beurkundungssprache.pdf` — Form-/Sprach-Gates markieren.
-4. `20-whiteboard-foto-deal-map.jpg` — Deal Map in eigene Dokumentkarte uebertragen.
+4. `20-whiteboard-foto-deal-map.jpg` — Deal Map in eigene Dokumentkarte übertragen.
 5. `21-investor-email-screenshot.jpg` und `22-whatsapp-screenshot.jpg` — Screenshot/Chat als Quelle kritisch einordnen.
 6. `23-rookie-cheatsheet-corporate-legal-english.pdf` — Abschlusskontrolle vor Partnerbriefing.
 
 ## Testziele
 
-- Begriffe Deutsch/Englisch erklaeren, ohne Scheinsynonyme zu produzieren.
+- Begriffe Deutsch/Englisch erklären, ohne Scheinsynonyme zu produzieren.
 - Cap Table, Gesellschafterliste und fully diluted basis trennen.
-- Term Sheet in deutsche Umsetzungsfragen uebersetzen.
-- Anfaenger-/First-Year-Modus sinnvoll aktivieren.
-- Partnerbriefing, Mandantenmemo und Rueckfragenliste erzeugen.
+- Term Sheet in deutsche Umsetzungsfragen übersetzen.
+- Anfänger-/First-Year-Modus sinnvoll aktivieren.
+- Partnerbriefing, Mandantenmemo und Rückfragenliste erzeugen.
 - Markup-Roundtrips professionell fahren (Datei 11).
 - Notar-, Register- und Sprachfragen korrekt einordnen (Datei 12).
-- Reserved-Matters in deutsche Gesellschaftsstruktur uebersetzen (Datei 14).
+- Reserved-Matters in deutsche Gesellschaftsstruktur übersetzen (Datei 14).
 - CP-Liste und Long-Stop einhalten (Datei 15).
 - Multi-Format-Unterlagen quellenkritisch auswerten: Screenshot, Scan, Chat, Excel und PDF nicht gleich behandeln.
-- Keine Paywall-Fundstellen oder Blindzitate verwenden. Quellen ausschliesslich dejure.org, openjur.de, bundesgerichtshof.de, bundesarbeitsgericht.de, bundessozialgericht.de, bundesfinanzhof.de, curia.europa.eu, Landesjustizportale.
+- Keine Paywall-Fundstellen oder Blindzitate verwenden. Quellen ausschließlich dejure.org, openjur.de, bundesgerichtshof.de, bundesarbeitsgericht.de, bundessozialgericht.de, bundesfinanzhof.de, curia.europa.eu, Landesjustizportale.
 
 ## Quellenhinweis
 
-Die Testakte zitiert keine Rechtsprechung als Belegmaterial. Soweit Aktenzeichen oder Normen in den Lehrmaterialien auftauchen, sind sie in den Plugin-Skills selbst (`gesellschaftsrecht-legal-english/skills/...`) sauber belegt. Die Testakte ist ausschliesslich didaktisch.
+Die Testakte zitiert keine Rechtsprechung als Belegmaterial. Soweit Aktenzeichen oder Normen in den Lehrmaterialien auftauchen, sind sie in den Plugin-Skills selbst (`gesellschaftsrecht-legal-english/skills/...`) sauber belegt. Die Testakte ist ausschließlich didaktisch.
 
 ## Hinweis zur Bearbeitung
 
-Diese Akte ist im Trockenlauf zu bearbeiten. Jede Mandantenantwort, jedes Markup und jede Investorenantwort geht durch die Partnerin. Senior-Review-Gates sind in `07-erwarteter-output-ohne-musterloesung.md` Abschnitt B.2 dokumentiert.
+Diese Akte ist im Trockenlauf zu bearbeiten. Jede Mandantenantwort, jedes Markup und jede Investorenantwort geht durch die Partnerin. Senior-Review-Gates sind in `07-erwarteter-output-ohne-musterlösung.md` Abschnitt B.2 dokumentiert.


### PR DESCRIPTION
## v35.0.0

### Codex-Round-2-Fixes
- § 14 GmbHG-Anker in Datei 06 + 07 auf **Satzungsautonomie + § 35 BGB analog** umgestellt (BGHZ 123, 15; BGH II ZR 89/79 = LM BGB § 35 Nr. 4; OLG Nürnberg GmbHR 2000, 561)
- Datei 02: Subscription-Listen-Verweis auf CFO-Slack-Thread korrigiert
- Umlaut-Hygiene: 17 Testakten-Dateien (ä/ö/ü/ß), englische Termini (gross proceeds, business, issued, Voss, Stein) unangetastet

### Agio-Dogmatik (neu, in 3 Plugins)
- **Testakte:** `24-agio-und-kapitalruecklage-streitfrage.md` (Frankfurt-Startup, US-Term-Sheet-Bezug: Liquidation Preference vs. korporatives Agio)
- **Skill gesellschaftsrecht:** `agio-und-kapitalruecklage` (dogmatischer Fokus: § 3 II GmbHG, § 272 II Nr. 1 HGB, § 27 KStG, § 21 UmwStG)
- **Skill corporate-kanzlei:** `corporate-kanzlei-agio-und-kapitalerhoehungsstruktur` (Deal-Mechanik, Fälligkeitsdifferenzierung)

### Belegte Rechtsgrundlagen
- BGH 15.10.2007 — II ZR 216/06 (Sachagio § 3 II GmbHG)
- BGH 13.03.1978 — Kali+Salz, BGHZ 71, 40
- BFH 27.05.2009 — I R 53/08 (Aufgeld als AK des neuen Anteils)
- BFH 03.05.2023 — IX R 12/22; BFH 14.03.2007 — I R 35/05

### Version-Bumps
- gesellschaftsrecht: 29.0.0 → 30.0.0
- corporate-kanzlei: 29.0.0 → 30.0.0
- gesellschaftsrecht-legal-english: 34.0.0 → 35.0.0

### Validatoren
- plugin-structure ✓ / yaml-frontmatter ✓ / welle5-Komma ✓ / forbidden-frontmatter ✓