### PR TITLE
v36.0.0: Codex-Round-3 sechs Findings (WEG + Agio)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -121,7 +121,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "30.0.0"
+      "version": "31.0.0"
     },
     {
       "name": "datenschutzrecht",
@@ -445,7 +445,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "35.0.0"
+      "version": "36.0.0"
     },
     {
       "name": "gewerblicher-rechtsschutz",
@@ -490,7 +490,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "35.0.0"
+      "version": "36.0.0"
     },
     {
       "name": "insolvenzforderungsanmeldungspruefung",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+# v36.0.0 — Codex-Round-3-Fixes: HeizkostenV-Bandbreite, § 18 vs. § 28 WEG, CO2KostAufG WEG-Grenzen, Gewährleistungs-Werkart, § 55a GmbHG, negatives Agio
+
+Sechs Codex-Review-Findings aus dem v35-PR systematisch behoben:
+
+- **HeizkostenV-Bandbreite korrekt formuliert** (`weg-hausverwaltung/skills/betriebskosten-nebenkostenabrechnung/SKILL.md`). Die irreführende Formulierung `mindestens 50/30/70 Prozent nach Verbrauch` wurde durch die richtige Regel ersetzt: verbrauchsabhängiger Anteil mindestens 50 Prozent und höchstens 70 Prozent, restlicher Anteil (30 bis 50 Prozent) nach Wohnfläche oder umbautem Raum (§§ 7, 8 HeizkostenV). Der häufige Schlüssel 70/30 ist ausdrücklich als eine zulässige Ausgestaltung innerhalb der Bandbreite gekennzeichnet.
+- **§ 55a GmbHG ergänzt** (`corporate-kanzlei/skills/corporate-kanzlei-agio-und-kapitalerhoehungsstruktur/SKILL.md`). Die Authorized-Capital-Zeile in der US-Term-Sheet-Übersetzungstabelle behauptete fälschlich, die GmbH kenne kein genehmigtes Kapital. Korrigiert auf: bei der AG § 202 AktG, bei der GmbH seit MoMiG ausdrücklich § 55a GmbHG (mit Verweis auf den bestehenden Skill `gesellschaftsgruender-genehmigtes-kapital`).
+- **Negatives Agio als rechtlich ausgeschlossen klargestellt** (`corporate-kanzlei/skills/corporate-kanzlei-agio-und-kapitalerhoehungsstruktur/SKILL.md`). Die Down-Round-Passage hatte die wirtschaftliche Verwässerung mit einem "negativen Agio" beschrieben. Das ist juristisch falsch: Ausgabe unter pari verstößt gegen § 9 Abs. 1 GmbHG / § 5 Abs. 2 GmbHG (Verbot der Unter-pari-Emission, nichtige Kapitalerhöhung). Korrigiert auf die drei zulässigen Down-Round-Instrumente: Null-Agio, größere Stückzahl zum reduzierten Preis pro Anteil, flankierende Wandeldarlehen oder Anti-Dilution-Anpassungen.
+- **CO2KostAufG nicht auf WEG-Innenverhältnis anwenden** (`testakten/weg-hausverwaltung-hohenzollernhof/11-co2kostaufg-aufteilungspruefung.md`). Die Testakte hatte den Eindruck vermittelt, das CO2KostAufG-Stufenmodell sei auf die WEG-Jahresabrechnung anzuwenden. Korrigiert: das CO2KostAufG regelt nur das Vermieter-Mieter-Verhältnis (§§ 1, 2 CO2KostAufG); die WEG-interne Hausgeldumlage bleibt bei § 16 Abs. 2 WEG und HeizkostenV. Praxisrelevanz für die WEG: vermietende Eigentümer brauchen aus der Jahresabrechnung Datengrundlagen (Brennstoffmenge, CO2-Emission, Energieträger, gebäudespezifischer CO2-Wert) gemäß § 2 Abs. 2 CO2KostAufG. Beanstandung und Anfechtungsrisiko entsprechend umformuliert.
+- **Gewährleistungsfrist nach Werkart differenziert** (`weg-hausverwaltung/skills/handwerker-beauftragung-vergabe/SKILL.md`). Die pauschale Auswahl `5 / 4 Jahre` ist nur für Bauwerk-Arbeiten korrekt. Ergänzt um die richtige Trias: BGB Bauwerk 5 Jahre (§ 634a Abs. 1 BGB), VOB/B Bauwerk 4 Jahre bei wirksamer Einbeziehung (§ 13 Abs. 4 VOB/B), sonstige Werkleistungen und Wartung 2 Jahre. Im Auftragsbestaetigungs-Muster und in der Vergleichstabelle.
+- **Belegeinsicht § 18 Abs. 4 WEG statt § 28 Abs. 4 WEG** (`weg-hausverwaltung/skills/datenschutz-dokumentenfreigabe/SKILL.md`). Die Belegeinsicht in Verwaltungsunterlagen folgt § 18 Abs. 4 WEG; § 28 Abs. 4 WEG regelt nur den Vermögensbericht. Description und Body entsprechend getrennt; beide Rechtsgrundlagen verlinkt.
+
+## Plugin-Versionsbumps
+
+- `corporate-kanzlei` 30.0.0 → 31.0.0
+- `weg-hausverwaltung` 35.0.0 → 36.0.0
+- `gesellschaftsrecht-legal-english` 35.0.0 → 36.0.0
+- `.claude-plugin/marketplace.json` synchronisiert
+
+## Qualitätssicherung
+
+- `node scripts/validate-plugin-structure.mjs` — OK
+- `python3 scripts/validate-yaml-frontmatter.py` — 0 Fehler 0 Warnungen
+- `python3 /tmp/welle5_komma_check.py` — 0 Treffer
+
+---
+
 # v35.0.0 — Agio-Dogmatik in drei Plugins, Codex-Round-2-Fixes, Umlaut-Hygiene Testakte
 
 - **Codex-Round-2-Fixes in `testakten/gesellschaftsrecht-legal-english-frankfurt-startup/`.** Der `§ 14 GmbHG`-Anker für Sonderrechte/Vorzugsanteile wurde in den Dateien `06-associate-arbeitsstand.md` und `07-erwarteter-output-ohne-musterloesung.md` durch den korrekten Anker `Satzungsautonomie + § 35 BGB analog` ersetzt; gestützt auf ständige Rechtsprechung (BGHZ 123, 15; BGH II ZR 89/79 = LM BGB § 35 Nr. 4; OLG Nürnberg 12 U 813/99). § 14 GmbHG (Einlagepflicht/Nennbetrag) wird explizit als Nicht-Anker markiert. In `02-cap-table-und-gesellschafterliste.md` wurde der irreführende Verweis auf eine angebliche Subscription-Liste in Datei 03 Ziff. 2 berichtigt — die 4,8/0,4-Aufteilung steht in Datei 02 selbst (CFO-Slack-Thread vom 28.05.2026); Datei 03 Ziff. 2 verlangt nur eine Lead-Mindestquote von 75 Prozent.

--- a/corporate-kanzlei/.claude-plugin/plugin.json
+++ b/corporate-kanzlei/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corporate-kanzlei",
-  "version": "30.0.0",
+  "version": "31.0.0",
   "description": "Corporate-Kanzlei-Plugin: Deal-Kommandocenter, Datenraum, Due Diligence, SPA/APA, Umwandlung, StaRUG, Insolvenzplan, W&I, Signing/Closing, PMI.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/corporate-kanzlei/skills/corporate-kanzlei-agio-und-kapitalerhoehungsstruktur/SKILL.md
+++ b/corporate-kanzlei/skills/corporate-kanzlei-agio-und-kapitalerhoehungsstruktur/SKILL.md
@@ -52,7 +52,7 @@ Das ist nicht atypisch sondern Standard. Wer mit einem Lead Investor verhandelt 
 | Stated Capital | Gezeichnetes Kapital Stammkapital | manchmal mit Grundkapital verwechselt (das ist AG-Begriff § 6 AktG) |
 | Issued Shares | Ausgegebene Geschäftsanteile | bei der GmbH gibt es keine Shares im US-Sinne |
 | Outstanding Shares | Ausgegebene und nicht eingezogene Geschäftsanteile | dasselbe wie Issued Shares minus Treasury Shares (in DE selten relevant) |
-| Authorized Capital | Genehmigtes Kapital (in der AG § 202 AktG in der GmbH gibt es das so nicht) | gelegentlich mit Stammkapital verwechselt |
+| Authorized Capital | Genehmigtes Kapital — bei der AG § 202 AktG, bei der GmbH seit MoMiG ausdrücklich § 55a GmbHG (für VC-Runden zunehmend genutzt; eigener Skill gesellschaftsgruender-genehmigtes-kapital im Repo) | gelegentlich mit Stammkapital verwechselt; früher verbreiteter Irrtum, GmbH kenne kein genehmigtes Kapital |
 | Pre-Money Valuation | Pre-Money-Bewertung Vor-Investitionsbewertung | unkritisch |
 | Post-Money Valuation | Post-Money-Bewertung | unkritisch |
 | Liquidation Preference 1x OPP | Einfache Liquidationspräferenz auf den Ausgabebetrag | wird oft als 1x Nennbetrag interpretiert — katastrophal für den Investor |
@@ -140,7 +140,7 @@ In Series-B-Runden stellt sich die Frage ob die Series-B-Liquidation-Preference 
 
 ### Bezugsrechtsausschluss bei Down-Rounds
 
-Bei Down-Rounds (Pre-Money unter letztem Post-Money) ist ein Bezugsrechtsausschluss zugunsten des Lead Investors oft notwendig. Sachliche Rechtfertigung nach Kali+Salz-Grundsatz (BGHZ 71, 40) erforderlich. Das Agio in der Down-Round ist niedriger oder negativ — was wirtschaftlich heißt: Verwässerung der Altgesellschafter mit höherer Hebelwirkung.
+Bei Down-Rounds (Pre-Money unter letztem Post-Money) ist ein Bezugsrechtsausschluss zugunsten des Lead Investors oft notwendig. Sachliche Rechtfertigung nach Kali+Salz-Grundsatz (BGHZ 71, 40) erforderlich. Das Agio in der Down-Round ist niedriger als in der Vorrunde oder Null — ein **negatives Agio ist rechtlich ausgeschlossen**, weil eine Ausgabe unter pari (Ausgabebetrag unter Nennbetrag) gegen § 9 Abs. 1 GmbHG / § 5 Abs. 2 GmbHG verstößt (Verbot der Unter-pari-Emission). Wirtschaftlich erreicht man die Verwässerung in einer Down-Round durch (i) sehr niedriges oder Null-Agio bei gleichem Nennbetrag, (ii) Ausgabe einer größeren Stückzahl neuer Geschäftsanteile zum reduzierten Preis je Anteil oder (iii) flankierende Instrumente (Wandeldarlehen, Anti-Dilution-Anpassung der bestehenden Series). Wer einem Mandanten ein negatives Agio vorschlägt, beschließt eine nichtige Kapitalerhöhung.
 
 ## Anfängerfehler im Corporate-Kontext
 

--- a/gesellschaftsrecht-legal-english/.claude-plugin/plugin.json
+++ b/gesellschaftsrecht-legal-english/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gesellschaftsrecht-legal-english",
-  "version": "35.0.0",
+  "version": "36.0.0",
   "description": "Didaktisches Gesellschaftsrechts-Plugin fuer Corporate Legal English: Kaltstart, Dealroom-Lernpfad, Multi-Format-Auswertung, Cap Table, Term Sheet, SHA, Vesting, Drag/Tag, Liquidation Preference, Anti-Dilution, SPA, DD und Big-Law-Anfaengertraining.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/testakten/weg-hausverwaltung-hohenzollernhof/11-co2kostaufg-aufteilungspruefung.md
+++ b/testakten/weg-hausverwaltung-hohenzollernhof/11-co2kostaufg-aufteilungspruefung.md
@@ -11,7 +11,7 @@ status: Beanstandung der Jahresabrechnung 2023, 2024, 2025 angekuendigt
 
 **CO2KostAufG** (Kohlendioxidkostenaufteilungsgesetz) vom 05.08.2022 (BGBl. 2022 I S. 1390), in Kraft 01.01.2023.
 
-Gilt fuer **Vermieter-Mieter** und **WEG (intern Hausgeld)** sowie **Gewerbeeinheiten**.
+Gilt fuer das **Vermieter-Mieter-Verhaeltnis** (§§ 1, 2 CO2KostAufG) sowie fuer **Gewerbeeinheiten** im selben Pass-Through. Die **WEG-interne Hausgeldumlage** richtet sich dagegen nach WEG-Recht (§ 16 Abs. 2 WEG, Teilungserklaerung, ggf. Verteilerschluessel-Beschluss); das CO2KostAufG ordnet die CO2-Kosten **nicht** zwischen den Wohnungseigentuemern um. Praxisrelevanz fuer die WEG: vermietende Eigentuemer brauchen aus der WEG-Jahresabrechnung **Datengrundlagen** (Brennstoffmenge, CO2-Emission, Energietraeger, Gebaeude-spezifischer CO2-Ausstoss in kg CO2/m2/a), um in der eigenen Betriebskostenabrechnung gegenueber ihren Mietern die Stufenmodell-Aufteilung umsetzen zu koennen (§ 2 Abs. 2 CO2KostAufG). Selbstnutzer und vermietende Eigentuemer tragen ihren Eigentuemeranteil der Heizkosten unveraendert nach WEG/HeizkostenV; die Stufenmodell-Aufteilung greift erst in der Vermieter-Mieter-Ebene.
 
 Quelle (offen): https://www.gesetze-im-internet.de/co2kostaufg/
 
@@ -61,7 +61,7 @@ Beim Hohenzollernhof handelt es sich um ein Wohnobjekt mit **Anteil Nichtwohnnut
 
 ### Was die Verwalterin Berlin-Domus gemacht hat
 
-Die Jahresabrechnung 2025 (Stand 14.04.2026) **verteilt die gesamten Heizkosten inkl. CO2-Anteil pauschal nach HeizkostenV (70/30)** auf alle Einheiten. Das CO2KostAufG-Stufenmodell ist **nicht angewendet**.
+Die Jahresabrechnung 2025 (Stand 14.04.2026) **verteilt die gesamten Heizkosten inkl. CO2-Anteil pauschal nach HeizkostenV (70/30)** auf alle Einheiten. Die fuer die vermietenden Eigentuemer erforderlichen **Datengrundlagen nach § 2 Abs. 2 CO2KostAufG** (Energietraeger, eingesetzte Brennstoffmenge, daraus abgeleitete CO2-Emission, gebaeudespezifischer Wert in kg CO2/m2/a, Einstufung in die Stufentabelle) sind in der Abrechnung **nicht ausgewiesen**. Das Stufenmodell selbst ist auf WEG-Ebene **nicht anzuwenden** — Beanstandung richtet sich also auf die fehlende Informationsaufbereitung, nicht auf eine "falsche" interne Verteilung.
 
 **Konsequenz:**
 - **Mieter** zahlen mehr als sie muessten (Mieter-Anteil 60 % aus 5.060 = 3.036 EUR; tatsaechlich abgerechnet etwa 5.060 EUR auf Mieter umgelegt).
@@ -69,12 +69,12 @@ Die Jahresabrechnung 2025 (Stand 14.04.2026) **verteilt die gesamten Heizkosten 
 
 ### Beanstandung
 
-Beiratsvorsitz beanstandet die Jahresabrechnung 2025 wegen Verstosses gegen § 7 II Heizkostenverordnung in Verbindung mit CO2KostAufG.
+Beiratsvorsitz beanstandet die Jahresabrechnung 2025 **nicht** wegen einer fehlerhaften internen WEG-Verteilung, sondern wegen **fehlender Datengrundlagen nach § 2 Abs. 2 CO2KostAufG**, die die vermietenden Eigentuemer fuer ihre eigene Betriebskostenabrechnung gegenueber den Mietern benoetigen.
 
 **Mit Schreiben vom 12.05.2026:**
 > Sehr geehrte Frau Kornfeld,
 >
-> die Jahresabrechnung 2025 vom 14.04.2026 weist die CO2-Kosten nicht nach dem Stufenmodell § 5 ff. CO2KostAufG aus. Das Gas-Heizungsobjekt fällt unter Stufe 5 (27,35 kg CO2/m²; Aufteilung 60 %/40 %). Wir beanstanden die Abrechnung und bitten um Korrektur **vor** Verschickung an die Eigentuemer.
+> die Jahresabrechnung 2025 vom 14.04.2026 enthaelt nicht die nach § 2 Abs. 2 CO2KostAufG fuer die vermietenden Eigentuemer erforderlichen Angaben (Energietraeger, eingesetzte Brennstoffmenge, abgeleitete CO2-Emission, gebaeudespezifischer Wert in kg CO2/m2/a, Einstufung). Das Gas-Heizungsobjekt liegt nach unserer Berechnung bei 27,35 kg CO2/m2 (Stufe 5: 60 % Vermieter / 40 % Mieter). Die WEG-interne Verteilung der Heizkosten nach HeizkostenV bleibt unveraendert; wir bitten aber um Aufnahme der genannten Datenfelder **vor** Verschickung an die Eigentuemer, damit die vermietenden Eigentuemer ihrer Pflicht aus CO2KostAufG nachkommen koennen.
 >
 > Gleiche Beanstandung gilt nachtraeglich fuer 2023 und 2024. Wir behalten uns Rueckforderungs- und Beschlussanfechtungs-Rechte vor.
 >
@@ -83,7 +83,7 @@ Beiratsvorsitz beanstandet die Jahresabrechnung 2025 wegen Verstosses gegen § 7
 
 ## Anfechtungs-Risiko bei nicht-Korrektur
 
-Die Jahresabrechnung 2025 koennte nach § 44 WEG i.V.m. § 28 WEG anfechtbar sein, wenn die Beschlussfassung zur Genehmigung Mehrheit findet, aber das CO2KostAufG ignoriert.
+Anfechtungsrisiko: Eine Anfechtung des Genehmigungsbeschlusses nach § 44 WEG i.V.m. § 28 WEG **nur wegen fehlender CO2-Datenfelder** ist zweifelhaft, weil das CO2KostAufG die WEG-interne Verteilung nicht regelt. Mit hoeherer Erfolgsaussicht angreifbar ist der Abrechnungsbeschluss, wenn die fehlenden Datenangaben zu einer **unzureichenden Information der vermietenden Eigentuemer** fuehren und diese gegenueber ihren Mietern in Haftung geraten (§ 6 Abs. 1 CO2KostAufG: Pflichtverletzung des Vermieters bei fehlender Aufteilung). Praxisempfehlung: Korrektur vor Beschlussfassung; falls Beschluss bereits gefasst, separate Datenuebersicht nachreichen statt Anfechtung.
 
 **Fristen:**
 - Anfechtung: 1 Monat ab Beschlussfassung (§ 45 I WEG)

--- a/weg-hausverwaltung/.claude-plugin/plugin.json
+++ b/weg-hausverwaltung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "weg-hausverwaltung",
-  "version": "35.0.0",
+  "version": "36.0.0",
   "description": "Operatives WEG- und Hausverwaltungs-Plugin fuer Beschluesse, Eigentuemerversammlung, Protokoll, Beschlusssammlung, Wirtschaftsplan, Jahresabrechnung, Hausgeld, Sonderumlage, Betriebskosten, Handwerker, bauliche Veraenderungen, Steckersolar, Wallbox, Verwalter, Beirat und Anwalt-Eskalation.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/weg-hausverwaltung/skills/betriebskosten-nebenkostenabrechnung/SKILL.md
+++ b/weg-hausverwaltung/skills/betriebskosten-nebenkostenabrechnung/SKILL.md
@@ -16,7 +16,7 @@ Die Schnittstelle zwischen WEG-Jahresabrechnung und mietrechtlicher Betriebskost
 - **Umlagefähigkeit** nach Mietvertrag (Klausel auf BetrKV verweisend) und BetrKV (https://www.gesetze-im-internet.de/betrkv/).
 - **Abrechnungszeitraum**: in der Regel Kalenderjahr; muss im Mietvertrag oder konsequent praktiziert sein.
 - **Zugangsfrist**: Vermieter muss innerhalb von **12 Monaten** ab Ende des Abrechnungszeitraums abrechnen (§ 556 Abs. 3 BGB — https://www.gesetze-im-internet.de/bgb/__556.html). Nach Ablauf nur noch zugunsten des Mieters Korrekturen möglich.
-- **Verteilerschlüssel** nach Mietvertrag, Wohnfläche, Verbrauch oder Einheiten; Heizung/Warmwasser zwingend mindestens 50/30/70 Prozent nach Verbrauch (HeizkostenV).
+- **Verteilerschlüssel** nach Mietvertrag, Wohnfläche, Verbrauch oder Einheiten; bei Heizung/Warmwasser zwingend nach HeizkostenV: verbrauchsabhängiger Anteil mindestens 50 % und höchstens 70 %, der restliche Anteil (30 % bis 50 %) nach Wohnfläche oder umbautem Raum (§§ 7, 8 HeizkostenV — https://www.gesetze-im-internet.de/heizkostenv/). Der häufige Schlüssel 70/30 (70 % Verbrauch, 30 % Fläche) ist eine zulässige Ausgestaltung innerhalb dieser Bandbreite, nicht die einzige.
 - **HeizkostenV**: Erfassung, Verteilung, Ablesung, Zwischenablesung bei Mieterwechsel.
 - **Nicht umlagefähig**: Verwaltungskosten, Instandsetzung/Erhaltung (vs. Wartung), Bankgebühren ohne Vertragsgrundlage, Reparaturen, Erhaltungsrücklage.
 - **Belegeinsicht** nach Aufforderung; Vermieter muss Einsicht ermöglichen, ggf. gegen Kostenerstattung Kopien.

--- a/weg-hausverwaltung/skills/datenschutz-dokumentenfreigabe/SKILL.md
+++ b/weg-hausverwaltung/skills/datenschutz-dokumentenfreigabe/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: datenschutz-dokumentenfreigabe
-description: "Prüft Datenschutz und Dokumentenfreigaben in der Hausverwaltung (Stand 05/2026): Eigentümerlisten, Belegeinsicht, Handwerkerdaten, Mieterbeschwerden, Cloud-Ordner, Schwärzungen und Versandkreis. Schnittstelle zum Datenschutzrecht-Plugin bei hohem Risiko, Verweis auf § 28 Abs. 4 WEG (Vermögensbericht) und Belegeinsicht-Logik."
+description: "Prüft Datenschutz und Dokumentenfreigaben in der Hausverwaltung (Stand 05/2026): Eigentümerlisten, Belegeinsicht, Handwerkerdaten, Mieterbeschwerden, Cloud-Ordner, Schwärzungen und Versandkreis. Schnittstelle zum Datenschutzrecht-Plugin bei hohem Risiko; Belegeinsicht nach § 18 Abs. 4 WEG (Verwaltungsunterlagen); § 28 Abs. 4 WEG nur für den Vermögensbericht."
 ---
 
 # Datenschutz und Dokumentenfreigabe
@@ -32,7 +32,9 @@ Transparenz in der GdWE ermöglichen, ohne personenbezogene Daten unnötig breit
 
 ## Belegeinsicht / Vermögensbericht
 
-- § 28 Abs. 4 WEG: Vermögensbericht zur Information der Eigentümer; Belege auf Verlangen einsehbar.
+- **§ 18 Abs. 4 WEG**: Anspruch jedes Wohnungseigentümers auf Einsicht in die Verwaltungsunterlagen — das ist die Rechtsgrundlage für die Belegeinsicht (Rechnungen, Verträge, Kontoauszüge, Abrechnungsunterlagen). Anspruch besteht gegen die GdWE, in der Praxis erfüllt durch den Verwalter (https://www.gesetze-im-internet.de/woeigg/__18.html).
+- **§ 28 Abs. 4 WEG**: Anspruch auf Vorlage des Vermögensberichts (Aufstellung des Gemeinschaftsvermögens, Erhaltungsrücklage, Forderungen/Verbindlichkeiten) — nicht die Anspruchsgrundlage für die Belegeinsicht, sondern eigene Informationspflicht (https://www.gesetze-im-internet.de/woeigg/__28.html).
+- Praxis: Belegeinsicht auf Verlangen, Ort und Zeit billigerweise festlegen, kein Verbot der Anfertigung von Kopien/Fotos, soweit nicht durch Datenschutz Dritter (z. B. Mieter-Belege, Gehaltsabrechnungen Hauspersonal) eingeschränkt.
 - Empfehlenswert: kontrollierter Einsichtstermin oder geschütztes Portal mit Audit-Log.
 
 ## Mustertext Freigabeentscheidung
@@ -68,4 +70,4 @@ Transparenz in der GdWE ermöglichen, ohne personenbezogene Daten unnötig breit
 
 ## Quellenpflicht
 
-`rechtsstand-mai-2026-faktenbank` laden. § 28 Abs. 4 WEG: https://www.gesetze-im-internet.de/woeigg/__28.html ; DSGVO siehe Datenschutzrecht-Plugin.
+`rechtsstand-mai-2026-faktenbank` laden. § 18 Abs. 4 WEG: https://www.gesetze-im-internet.de/woeigg/__18.html ; § 28 Abs. 4 WEG: https://www.gesetze-im-internet.de/woeigg/__28.html ; DSGVO siehe Datenschutzrecht-Plugin.

--- a/weg-hausverwaltung/skills/handwerker-beauftragung-vergabe/SKILL.md
+++ b/weg-hausverwaltung/skills/handwerker-beauftragung-vergabe/SKILL.md
@@ -17,7 +17,7 @@ Aus einem technischen Problem wird ein sauber dokumentierter Verwaltungs- und Be
 2. **Leistungsbeschreibung** erstellen: gewünschtes Ergebnis, vorhandene Bausubstanz, Ausführungszeitfenster, einzuhaltende Normen.
 3. **Angebote vergleichbar machen**:
    - **Mindestens 2–3 Vergleichsangebote** bei substantiellen Maßnahmen (Schwellwerte im Verwaltervertrag/GO oder Beschluss verankert).
-   - Vergleichstabelle: Preis (Netto/Brutto), Leistungsumfang, Material, Ausführungszeit, Gewährleistungsfrist, Pauschal-/Stundenanteil, Nebenkosten, Ausschlüsse, Referenzen, Versicherung, Bonität.
+   - Vergleichstabelle: Preis (Netto/Brutto), Leistungsumfang, Material, Ausführungszeit, Gewährleistungsfrist (abhängig von Werkart und VOB/B-Vereinbarung — siehe Mustertabelle), Pauschal-/Stundenanteil, Nebenkosten, Ausschlüsse, Referenzen, Versicherung, Bonität.
 4. **Beschlussbedarf prüfen** (siehe Tabelle).
 5. **Beauftragung** mit klarer Vollmacht, Auftragsbestätigung, ggf. VOB/B-Vereinbarung, Versicherungsnachweis.
 6. **Nachträge** schriftlich vereinbaren (Mehrkostenrisiko sichtbar machen), Beirat ggf. einbinden.
@@ -41,7 +41,7 @@ Aus einem technischen Problem wird ein sauber dokumentierter Verwaltungs- und Be
 | --- | --- | --- | --- |
 | Brutto Festpreis | ... | ... | ... |
 | Ausführungszeit | ... | ... | ... |
-| Gewährleistungsfrist (Werkvertrag 5 J, VOB 4 J) | ... | ... | ... |
+| Gewährleistungsfrist (BGB: Bauwerk 5 J, sonstige Werkleistungen/Wartung 2 J — § 634a Abs. 1 BGB; VOB/B § 13 Abs. 4: Bauwerk 4 J, andere Arbeiten und Wartungsarbeiten 2 J, soweit VOB/B wirksam vereinbart) | ... | ... | ... |
 | Materialqualität / Typ | ... | ... | ... |
 | Ausgeschlossene Leistungen | ... | ... | ... |
 | Versicherung / Sachkunde | ... | ... | ... |
@@ -56,7 +56,7 @@ Aus einem technischen Problem wird ein sauber dokumentierter Verwaltungs- und Be
 > 2. Pauschalpreis brutto [Betrag] EUR (inkl. USt.).
 > 3. Ausführungszeitraum: [Beginn]–[Ende].
 > 4. Abnahme: gemeinsam vor Ort am [Datum].
-> 5. Gewährleistungsfrist: [5 / 4] Jahre ab Abnahme.
+> 5. Gewährleistungsfrist: [Bauwerk-Arbeit BGB 5 Jahre / Bauwerk-Arbeit mit wirksam vereinbarter VOB/B 4 Jahre / sonstige Werkleistung oder Wartung 2 Jahre — passend zur Auftragsart streichen] ab Abnahme.
 > 6. Versicherungsnachweis bitte bis [Datum] vorlegen.
 > 7. Nachträge nur schriftlich nach vorheriger Freigabe der Verwaltung.
 


### PR DESCRIPTION
## v36.0.0 — Codex-Round-3-Fixes

Sechs Findings aus dem Codex-Review zu PR #124 behoben:

### WEG-Plugin
1. **HeizkostenV-Bandbreite** (`betriebskosten-nebenkostenabrechnung`): irrefuehrendes `50/30/70` ersetzt durch korrekte Regel: Verbrauch mind. 50 / max. 70 Prozent, Rest (30-50 Prozent) nach Flaeche ($$ 7, 8 HeizkostenV).
2. **Belegeinsicht** (`datenschutz-dokumentenfreigabe`): Anspruchsgrundlage $ 18 Abs. 4 WEG (Verwaltungsunterlagen) statt $ 28 Abs. 4 WEG (nur Vermoegensbericht).
3. **Gewaehrleistungsfrist** (`handwerker-beauftragung-vergabe`): nach Werkart differenziert — BGB Bauwerk 5J ($ 634a I BGB), VOB/B Bauwerk 4J ($ 13 IV VOB/B bei wirksamer Einbeziehung), sonstige Werkleistungen/Wartung 2J.
4. **CO2KostAufG WEG-Grenzen** (Testakte `11-co2kostaufg-aufteilungspruefung.md`): Stufenmodell wirkt nur Vermieter-Mieter ($$ 1, 2 CO2KostAufG); WEG-intern bleibt $ 16 II WEG / HeizkostenV. Beanstandung umformuliert auf fehlende Datengrundlagen nach $ 2 II CO2KostAufG.

### corporate-kanzlei
5. **$ 55a GmbHG** in US-Term-Sheet-Tabelle (Authorized Capital): GmbH-genehmigtes Kapital existiert seit MoMiG, Verweis auf bestehenden Skill `gesellschaftsgruender-genehmigtes-kapital`.
6. **Negatives Agio**: rechtlich ausgeschlossen (Verbot Unter-pari-Emission $ 9 I / $ 5 II GmbHG); ersetzt durch drei zulaessige Down-Round-Instrumente.

### Belegte Rechtsgrundlagen
- HeizkostenV $$ 7, 8
- WEG $ 18 Abs. 4 (Belegeinsicht), $ 28 Abs. 4 (Vermoegensbericht), $ 16 Abs. 2
- BGB $ 634a Abs. 1, VOB/B $ 13 Abs. 4
- CO2KostAufG $$ 1, 2, 6
- GmbHG $$ 5 Abs. 2, 9 Abs. 1, 55a

### Versionsbumps
- corporate-kanzlei 30.0.0 \u2192 31.0.0
- weg-hausverwaltung 35.0.0 \u2192 36.0.0
- gesellschaftsrecht-legal-english 35.0.0 \u2192 36.0.0

### Validatoren
- plugin-structure OK / yaml-frontmatter 0/0 / welle5-Komma 0 Treffer