### PR TITLE
v38.0.0: Sanity-Check Tax + Bug-Fix § 1 Abs. 3 GrEStG statt AO

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -822,7 +822,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "36.1.0"
+      "version": "37.0.0"
     },
     {
       "name": "strafbefehl-verteidiger",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+# v38.0.0 — Sanity-Check Tax + Bug-Fix § 1 Abs. 3 GrEStG statt AO
+
+Sanity-Check des Tax-Commits `4ab560c2` (16 neue GrESt- und Grundsteuer-Skills, zwei neue Testakten). Validatoren alle grün, Rechtsstand-Anker verifiziert (§ 6a GrEStG noch 95 %, BFH II B 13/25, II B 23/25, II B 47/25, BFH II R 25/24 zum Bundesmodell, BVerfG 1 BvL 11/14). Ein Bug gefunden und behoben.
+
+## Bug-Fix
+
+- **`anw-grunderwerbsteuer-share-deal-90-prozent` description**: Die YAML-`description` hatte den falschen Normverweis `§ 1 Abs. 3 AO` (Abgabenordnung) statt `§ 1 Abs. 3 GrEStG`. Im Body war die Norm korrekt zitiert; nur das Suchmetadatum-Feld war vertauscht. Korrigiert.
+
+## Plugin-Versionsbumps
+
+- `steuerrecht-anwalt-und-berater` 36.1.0 → 37.0.0
+- `.claude-plugin/marketplace.json` synchronisiert
+
+## Qualitätssicherung
+
+- `node scripts/validate-plugin-structure.mjs` — OK
+- `python3 scripts/validate-yaml-frontmatter.py` — 0 Fehler 0 Warnungen
+- `python3 /tmp/welle5_komma_check.py` — 0 Treffer
+- Forbidden-Frontmatter-Check — leer
+
+---
+
 # v37.0.0 — Codex-Round-4-Fixes: CO2KostAufG-Datenpflichten richtig zuordnen
 
 Drei Codex-Findings zur Testakte `11-co2kostaufg-aufteilungspruefung.md` aus dem v36-PR behoben:

--- a/steuerrecht-anwalt-und-berater/.claude-plugin/plugin.json
+++ b/steuerrecht-anwalt-und-berater/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "steuerrecht-anwalt-und-berater",
-  "version": "36.1.0",
+  "version": "37.0.0",
   "description": "Steuerrecht für Anwalt (anw- FAO § 9) und Steuerberater (stb-): Einspruch Klage FG Aussenprüfung Selbstanzeige, Grundsteuer, Grunderwerbsteuer, Share Deals, Signing Closing, BWA SuSa Lohnbuchhaltung Jahresabschluss.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/steuerrecht-anwalt-und-berater/skills/anw-grunderwerbsteuer-share-deal-90-prozent/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/anw-grunderwerbsteuer-share-deal-90-prozent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: anw-grunderwerbsteuer-share-deal-90-prozent
-description: "Grunderwerbsteuer GrEStG bei Share-Deal-Transaktionen mit grundbesitzhaltenden Gesellschaften berechnen und gestalten. Anwendungsfall M-und-A-Transaktion mit Immobilien-Hintergrund Anteilsuebertragung droht GrESt-Pflicht. 90-Prozent-Schwelle ab 01.07.2021 statt zuvor 95 Prozent. § 1 Abs. 2a GrEStG Personengesellschaft § 1 Abs. 2b GrEStG Kapitalgesellschaft § 1 Abs. 3 AO unmittelbare Vereinigung § 1 Abs. 3a wirtschaftliche Beteiligung. 10-Jahres-Frist RETT-Blocker-Strukturen Anzeigepflicht § 19 GrEStG. Output GrESt-Prüfprotokoll Strukturierungs-Empfehlung Anzeige-Vorlage."
+description: "Grunderwerbsteuer GrEStG bei Share-Deal-Transaktionen mit grundbesitzhaltenden Gesellschaften berechnen und gestalten. Anwendungsfall M-und-A-Transaktion mit Immobilien-Hintergrund Anteilsuebertragung droht GrESt-Pflicht. 90-Prozent-Schwelle ab 01.07.2021 statt zuvor 95 Prozent. § 1 Abs. 2a GrEStG Personengesellschaft § 1 Abs. 2b GrEStG Kapitalgesellschaft § 1 Abs. 3 GrEStG unmittelbare Vereinigung § 1 Abs. 3a wirtschaftliche Beteiligung. 10-Jahres-Frist RETT-Blocker-Strukturen Anzeigepflicht § 19 GrEStG. Output GrESt-Prüfprotokoll Strukturierungs-Empfehlung Anzeige-Vorlage."
 ---
 
 # Grunderwerbsteuer bei Share Deals — 90-%-Schwelle, Anzeigepflicht, Gestaltung


### PR DESCRIPTION
## Sanity-Check Tax-Commit 4ab560c2

Sanity-Check des Tax-Commits `4ab560c2 feat(tax): add grundsteuer and grest workflows` (16 neue GrESt-/Grundsteuer-Skills, zwei neue Testakten). 

## Verifizierte Rechtsstaende

- § 6a GrEStG: weiterhin **95 %** + 5-Jahres-Vor-/Nachbehaltensfrist (gesetze-im-internet)
- BFH 09.07.2025 II B 13/25, 16.09.2025 II B 23/25, 27.10.2025 II B 47/25 (Signing/Closing-AdV-Linie)
- BFH 12.11.2025 II R 25/24 zum Bundesmodell
- BVerfG 10.04.2018 1 BvL 11/14 (alte Einheitsbewertung)

## Bug-Fix

**`anw-grunderwerbsteuer-share-deal-90-prozent` SKILL.md description:**
- alt: `§ 1 Abs. 3 AO unmittelbare Vereinigung` (Abgabenordnung — falsches Gesetz)
- neu: `§ 1 Abs. 3 GrEStG unmittelbare Vereinigung`

Im Body war die Norm korrekt zitiert; nur das description-Suchmetadatum war vertauscht.

## Plugin-Versionsbumps

- `steuerrecht-anwalt-und-berater` 36.1.0 → 37.0.0
- `.claude-plugin/marketplace.json` synchronisiert
- CHANGELOG.md v38.0.0-Eintrag

## Validatoren

- `validate-plugin-structure` — OK
- `validate-yaml-frontmatter` — 0 Fehler 0 Warnungen
- `welle5_komma_check` — 0 Treffer
- Forbidden-Frontmatter — leer