### PR TITLE
v40.0.0: README-Spotlight - Meinungspruefer entfernt, Corporate Legal English oben

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
-# v40.0.0 — Sanity-Check-Release nach v39
+# v40.0.0 — Sanity-Check-Release nach v39 + README-Spotlight Corporate Legal English
 
-Sammelrelease ohne neue Fachlogik: Der aktuelle `main`-Stand nach `v38.0.0` (Steuerrechts-Sanity-Fix) und `v39.0.0` (CO2KostAufG-Präzisierung) wurde noch einmal gegen die Repo-Validatoren und den Release-ZIP-Bau geprüft und als nächster stabiler Download-Stand markiert.
+Sammelrelease: Der aktuelle `main`-Stand nach `v38.0.0` (Steuerrechts-Sanity-Fix) und `v39.0.0` (CO2KostAufG-Präzisierung) wurde gegen die Repo-Validatoren und den Release-ZIP-Bau geprüft und als nächster stabiler Download-Stand markiert. Zusätzlich wurde das README-Spotlight redaktionell geändert.
+
+## README-Spotlight
+
+- Meinungspruefer-Block ganz oben aus README entfernt.
+- Spotlight-Abschnitt umbenannt zu "Ganz oben: Corporate Legal English" und auf `gesellschaftsrecht-legal-english` mit Testakte `gesellschaftsrecht-legal-english-frankfurt-startup` fokussiert (Kaltstart, Dealroom-Lernpfad, Cap Table, Gesellschafterliste, Term Sheet, SHA, Liquidation Preference, Anti-Dilution, Vesting, Drag/Tag, SPA/DD-Begriffe, englische Vertragssprache unter deutschem Recht).
+- Keine Plugin-Aenderungen; rein redaktioneller README-Schnitt zusätzlich zum Sanity-Release.
 
 ## Qualitätssicherung
 
@@ -8,6 +14,7 @@ Sammelrelease ohne neue Fachlogik: Der aktuelle `main`-Stand nach `v38.0.0` (Ste
 - `python3 scripts/validate-yaml-frontmatter.py` — 0 Fehler, 0 Warnungen
 - `node scripts/validate-plugin-structure.mjs` — OK
 - `python3 scripts/validate-release-zips.py /tmp/codex-release-sanity .claude-plugin/marketplace.json` — OK
+- `python3 /tmp/welle5_komma_check.py` — 0 Treffer
 - Release-Asset-Sanity: 105 Plugin-ZIPs, 63 Testakten-ZIPs, 1 `marketplace.json`, insgesamt 169 Assets
 
 ## Dokumentation

--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 > **Experimentelles Skill-Set** für die anwaltliche Praxis im deutschen Recht – Skills, Sub-Agenten, Workflows etc. als Anregung für Kanzlei-Arbeitsabläufe. Orientiert sich an der **deutschen Rechtspraxis**, an Gesetzestexten, amtlichen Materialien und frei überprüfbarer Rechtsprechung. Enthält keinerlei Fachgutachten oder Rechtsberatung, alle Angaben ohne Gewähr – jede Nutzerin und jeder Nutzer kalibriert die Skills selbst für die eigene Praxis.
 
-## Ganz oben: Meinungsprüfer
+## Ganz oben: Corporate Legal English
 
-Neu im Repo ist der [`meinungspruefer`](./meinungspruefer): ein großes Äußerungsrechts-Plugin für Meinung/Tatsache, Beleidigung, üble Nachrede, Verleumdung, § 188 StGB, Art. 5 GG, Art. 10 EMRK, Art. 11 GRCh, EGMR-/EuGH-Rechtsprechung, OLG-/KG-Praxis, Plattformfälle und US-Supreme-Court-Vergleich. Dazu gibt es die Testakte [`meinungspruefer-grenzfaelle-alltag`](./testakten/meinungspruefer-grenzfaelle-alltag/) mit X-Post, LinkedIn-Pinocchio, Kantinenfall, Elternchat, Bürgermeister-"Lackaffe", Abmahnung, Anhörung, Belegmappe und USA-Vergleichsnotiz.
-
-Ebenfalls besonders ausgebaut ist [`gesellschaftsrecht-legal-english`](./gesellschaftsrecht-legal-english): ein didaktisches Gesellschaftsrechts-Plugin für Corporate Legal English, das Kaltstart, Dealroom-Lernpfad, Multi-Format-Auswertung, Cap Table, Gesellschafterliste, Term Sheet, SHA, Liquidation Preference, Anti-Dilution, Vesting, Drag/Tag, SPA/DD-Begriffe und englische Vertragssprache unter deutschem Recht erklärt und in Big-Law-Workflows für Anfänger übersetzt. Dazu gehört die Testakte [`gesellschaftsrecht-legal-english-frankfurt-startup`](./testakten/gesellschaftsrecht-legal-english-frankfurt-startup/) mit Markdown, Excel, PDF-Scan, PDF-Cheatsheet, JPEG-Foto, Email-Screenshot und WhatsApp-Screenshot.
+Besonders ausgebaut ist [`gesellschaftsrecht-legal-english`](./gesellschaftsrecht-legal-english): ein didaktisches Gesellschaftsrechts-Plugin für Corporate Legal English, das Kaltstart, Dealroom-Lernpfad, Multi-Format-Auswertung, Cap Table, Gesellschafterliste, Term Sheet, SHA, Liquidation Preference, Anti-Dilution, Vesting, Drag/Tag, SPA/DD-Begriffe und englische Vertragssprache unter deutschem Recht erklärt und in Big-Law-Workflows für Anfänger übersetzt. Dazu gehört die Testakte [`gesellschaftsrecht-legal-english-frankfurt-startup`](./testakten/gesellschaftsrecht-legal-english-frankfurt-startup/) mit Markdown, Excel, PDF-Scan, PDF-Cheatsheet, JPEG-Foto, Email-Screenshot und WhatsApp-Screenshot.
 
 ## Über dieses Repository
 


### PR DESCRIPTION
## README-Schnitt

- 'Ganz oben: Meinungspruefer'-Block entfernt
- Spotlight umbenannt zu 'Ganz oben: Corporate Legal English'
- Fokus auf gesellschaftsrecht-legal-english + Testakte gesellschaftsrecht-legal-english-frankfurt-startup (Kaltstart, Dealroom-Lernpfad, Cap Table, Gesellschafterliste, Term Sheet, SHA, Liquidation Preference, Anti-Dilution, Vesting, Drag/Tag, SPA/DD-Begriffe)

## Aenderungen

- README.md: Hero-Block ersetzt
- CHANGELOG.md: bestehender v40-Eintrag (Sanity-Release) um README-Spotlight ergaenzt

## Validatoren

- validate-plugin-structure: OK
- validate-yaml-frontmatter: 0 Fehler 0 Warnungen
- welle5_komma_check: 0 Treffer

Keine Plugin-Aenderungen.