### PR TITLE
feat(v47.1.0): zwei neue Grundlagen-Skills im gesellschaftsrecht-legal-english

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -445,7 +445,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "46.0.0"
+      "version": "47.1.0"
     },
     {
       "name": "gewerblicher-rechtsschutz",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+# v47.1.0 — Plugin gesellschaftsrecht-legal-english: zwei neue Grundlagen-Skills
+
+Reaktion auf den Hinweis aus der Praxis (LinkedIn-Diskussion vom 29.05.2026), dass M&A-Anwaelte regelmaessig Basics aus BGB AT, Schuldrecht AT und Kapitalaufbringungsrecht uebersehen, weil sie M&A fuer reines Vertragsrecht halten. Gerade in Zeiten breiter KI-Nutzung bleibt das Grundlagenwissen entscheidend, damit Ergebnisse richtig interpretiert werden.
+
+Zwei neue Skills im Plugin `gesellschaftsrecht-legal-english`:
+
+- **`verdeckte-sacheinlage`**: erkennt und prueft verdeckte Sacheinlage und Hin-und-Her-Zahlung nach § 19 Abs. 4 und Abs. 5 GmbHG. Anrechnungsloesung seit MoMiG, Vorbelastungshaftung, Pruefraster mit sieben Schritten, typische M&A-Fallen (Cash-In-Series-A plus Akquisition, Wandeldarlehen, Verrechnungsabreden, Sale-and-lease-back, Beraterhonorar an Investor), klare Heilungswege.
+- **`bgb-at-schuldrecht-at-im-ma`**: macht sichtbar, wo BGB AT und Schuldrecht AT in englischsprachigen M&A-, Finanzierungs- und SHA-Vertraegen unter deutschem Recht stillschweigend mitlaufen. Zehnstufiges Pruefraster: Form und Einheitstheorie § 15 Abs. 4 GmbHG, Stellvertretung §§ 164 ff. und § 181 BGB, Bedingungseintritt und -vereitelung § 162 BGB, AGB-Kontrolle §§ 305 ff. und § 307 BGB auch im B2B, Treu und Glauben § 242 BGB fuer reasonable-/best-efforts, Anfechtung §§ 119, 123 BGB und Sperre des § 444 BGB. Konkrete Falleinordnungen mit Heilungswegen.
+
+Beide Skills sind in der Fuehrungsmatrix des `allgemein`-Routing-Skills erfasst, damit Nutzer mit Aussagen wie "Wir machen Vertragsrecht, BGB AT ist egal" oder "Bareinlage und gleichzeitig Erwerb vom Gesellschafter" direkt auf die richtige Stelle geroutet werden.
+
+## Plugin-Version
+
+- `gesellschaftsrecht-legal-english/.claude-plugin/plugin.json` und `.claude-plugin/marketplace.json` auf `47.1.0` gebumpt (Skill-Anzahl von 30 auf 32). Description und Slug unveraendert.
+
+## Qualitaetssicherung
+
+- `node scripts/validate-plugin-structure.mjs` — OK
+- `python3 scripts/validate-yaml-frontmatter.py` — 0 Fehler 0 Warnungen
+- `python3 /tmp/welle5_komma_check.py` — 0 Treffer
+
+---
+
 # v47.0.0 — Schlussrunde Testakten, Übersichten und quellenfeste Schriftformakte
 
 Große Abschlussrunde über den Akten- und Release-Bestand:

--- a/gesellschaftsrecht-legal-english/.claude-plugin/plugin.json
+++ b/gesellschaftsrecht-legal-english/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gesellschaftsrecht-legal-english",
-  "version": "46.0.0",
+  "version": "47.1.0",
   "description": "Didaktisches Gesellschaftsrecht — English Business Terms: Corporate Legal English fuer Big-Law-Anfaenger. Dealroom: Cap Table vs Gesellschafterliste; Term Sheet; SHA; Vesting; Drag/Tag; Liquidation Preference; Anti-Dilution; SPA; DD; Notar/HR; Multi-Format-Auswertung; Frankfurt-Startup-Akte.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gesellschaftsrecht-legal-english/skills/allgemein/SKILL.md
+++ b/gesellschaftsrecht-legal-english/skills/allgemein/SKILL.md
@@ -53,6 +53,8 @@ Vermeide einen Vorlesungsstart. Besser ist ein kleiner, handhabbarer erster Schr
 | "Ich habe Screenshots, Excel, PDFs, Chats" | Multi-Format-Auswertung: Dokumentkarte je Quelle | `anschauungsmaterial-multiformat-auswertung` |
 | "Es geht um Zahlen" | Rechenanker, Annahmen, Kontrollformel | `cap-table-gesellschafterliste`, `fully-diluted-esop-option-pool`, `liquidation-preference-waterfall` |
 | "Englischer Vertrag, deutsches Recht" | Sprach-/Rechtswahl-/Beurkundungs-Gate | `deutsches-recht-englische-vertraege` |
+| "Bareinlage und gleichzeitig Erwerb vom Gesellschafter" | § 19 Abs. 4/5 GmbHG-Pruefung, Anrechnungsloesung, Heilung | `verdeckte-sacheinlage` |
+| "Wir machen Vertragsrecht, BGB AT ist egal" | Gegencheck: Form, § 162, § 181, § 307, § 444 BGB, Einheitstheorie | `bgb-at-schuldrecht-at-im-ma` |
 
 ## Didaktischer Standardablauf
 

--- a/gesellschaftsrecht-legal-english/skills/bgb-at-schuldrecht-at-im-ma/SKILL.md
+++ b/gesellschaftsrecht-legal-english/skills/bgb-at-schuldrecht-at-im-ma/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: bgb-at-schuldrecht-at-im-ma
+description: "Macht sichtbar, wo BGB AT und Schuldrecht AT in englischsprachigen M&A-, Finanzierungs- und SHA-Vertraegen unter deutschem Recht stillschweigend mitlaufen: Form, Stellvertretung, Bedingungen, Verfuegungsverbote, AGB-Kontrolle, Konkretisierung, Treu und Glauben. Gegen den weit verbreiteten Irrtum, M&A sei reines Vertragsrecht."
+---
+
+# BGB AT und Schuldrecht AT im M&A-Mandat
+
+## Worum es geht
+
+Englischsprachige M&A- und Finanzierungsvertraege unter deutschem Recht (Rechtswahl, oft Frankfurt oder Muenchen) lesen sich wie reines Vertragsrecht. In Wirklichkeit laeuft der gesamte BGB-Allgemeine-Teil und das Schuldrecht AT in jeder Klausel mit. Wer das ueberliest, baut Vertraege, die im Streit nicht halten. Klassische Aussage von M&A-Anwaelten: "Wir machen Vertragsrecht, BGB AT spielt keine Rolle." Das ist falsch und produziert vorhersehbare Fehler.
+
+## Pruefraster vor jedem Vertragsentwurf und jedem Markup
+
+1. **Form, § 125 BGB, § 311b BGB, § 15 Abs. 3 und Abs. 4 GmbHG:** Reicht Schriftform oder Textform, oder ist notarielle Beurkundung erforderlich? Ein SPA ueber GmbH-Anteile ist nach § 15 Abs. 4 GmbHG insgesamt beurkundungsbeduerftig, also auch alle Nebenabreden, die mit der Anteilsuebertragung "stehen und fallen" (Einheitstheorie). Ein Side Letter, der wirtschaftlich Teil des Deals ist, gehoert mit zur Urkunde.
+2. **Stellvertretung, §§ 164 ff. BGB:** Wer unterzeichnet im Namen wessen? Vollmacht im Original? Bei auslaendischen Beteiligten Legalisation oder Apostille? Insichgeschaeft nach § 181 BGB ausgeschlossen? Bei GmbH-Geschaeftsfuehrer pruefen, ob die Satzung ihn von § 181 BGB befreit.
+3. **Bedingung, §§ 158 ff. BGB:** CPs im SPA sind aufschiebende Bedingungen. § 162 BGB (treuwidrige Bedingungsvereitelung oder Herbeifuehrung) wirkt zwingend und kann nicht durch "endeavours"-Klauseln ausgehebelt werden. Long-Stop-Date ist eine Befristung, keine Bedingung.
+4. **AGB-Kontrolle, §§ 305 ff. BGB:** Auch im B2B-Verkehr gilt §§ 305 ff. BGB. Wenn das Term Sheet oder der SPA von einer Seite gestellt wird und nicht im Einzelnen ausgehandelt ist (§ 305 Abs. 1 Satz 3 BGB), sind die Klauseln einer Inhaltskontrolle ueber § 307 BGB ausgesetzt. Besonders kritisch: weitreichende Haftungsbeschraenkungen, Indemnities mit pauschalen Hoechstgrenzen, einseitige MAC-Klauseln.
+5. **Treu und Glauben, § 242 BGB:** Auslegung nach §§ 133, 157 BGB. "Reasonable efforts", "best efforts", "commercially reasonable efforts" werden im deutschen Recht ueber § 242 BGB konkretisiert. Es gibt keine in Stein gemeisselte Bedeutung; die Vertragspraxis muss den Inhalt definieren oder akzeptieren, dass § 242 BGB ihn definiert.
+6. **Bestimmtheit, § 138 BGB, § 134 BGB:** Sind Leistung, Kaufpreis, Closing-Mechanik hinreichend bestimmt? Earn-out-Klauseln mit unklarer Berechnungsformel sind nicht nichtig, aber im Streit ueber § 315 BGB ausfuellbar.
+7. **Verfuegungsverbote, §§ 135, 136 BGB:** Lock-up-Vereinbarungen, Vinkulierung in der Satzung, Drag-along-Verpflichtungen. Schuldrechtliche Verpflichtung wirkt nur inter partes (§ 137 BGB), nicht dinglich. Verstoss erzeugt Schadensersatz, nicht Unwirksamkeit der Anteilsuebertragung.
+8. **Anfechtung, §§ 119 ff. BGB:** Wenn Reps verletzt sind, ist neben dem vertraglichen Rep-and-Warranty-Regime auch die Anfechtung wegen arglistiger Taeuschung nach § 123 BGB zu pruefen. § 444 BGB sperrt Haftungsbeschraenkungen bei arglistigem Verschweigen.
+9. **Erfuellung, Konkretisierung, Gefahruebergang, §§ 243, 446, 447 BGB:** Bei Anteilsuebertragung weniger relevant, bei Asset-Deals zentral.
+10. **§ 311a, § 280, § 281 BGB:** Sekundaerleistungspflichten und Schadensersatz statt der Leistung. Das vertragliche Indemnity-Regime ersetzt nicht das gesetzliche Regime; es ueberlagert es.
+
+## Typische M&A-Fallen, die BGB AT betreffen
+
+- **Side Letter neben dem SPA, der wirtschaftlich Teil des Deals ist:** § 15 Abs. 4 GmbHG verlangt Beurkundung der gesamten Abrede. Heilung durch nachtraegliche Beurkundung des Geschaeftsanteilskaufs nach § 15 Abs. 4 Satz 2 GmbHG nur in engen Grenzen.
+- **Englischsprachige Vollmacht eines auslaendischen Investors:** Apostille fehlt, Vollmacht ist im Original nicht vorgelegt, § 174 BGB greift, Erklaerung kann zurueckgewiesen werden.
+- **"Best efforts" ohne Definition:** Auslegung ueber § 242 BGB; das Ergebnis ist in der Regel sachlicher und niedriger als das, was die englische Rechtspraxis darunter versteht.
+- **CP-Vereitelung:** Der Verkaeufer unterlaesst Handlungen, die zum CP-Eintritt fuehren wuerden. § 162 BGB fingiert den Eintritt. Wirkt zwingend, jedes "exclusive remedy"-Wording dagegen ist unwirksam.
+- **MAC-Klausel als AGB:** Wenn die MAC-Klausel von einer Seite gestellt und nicht ausgehandelt ist, droht § 307 BGB-Inhaltskontrolle.
+- **Vertragsstrafe und Liquidated Damages:** Sind als pauschalierter Schadensersatz nach §§ 339 ff. BGB zu pruefen. Im B2B kein § 343 BGB-Schutz, aber AGB-Kontrolle ueber § 307 BGB.
+- **Konzernsachverhalte und § 181 BGB:** Bei Konzernverflechtungen oft Insichgeschaeft. Befreiung in der Satzung pruefen, sonst genehmigungsbeduerftig.
+
+## Antwortvorgaben
+
+- Bei jedem Vertrag, jedem Markup, jeder Klausel: zuerst BGB AT pruefen, dann erst Vertragsrecht.
+- Gegen die haeufige Aussage "wir machen Vertragsrecht, BGB AT spielt keine Rolle" konkret widersprechen: § 162 BGB, § 181 BGB, § 15 Abs. 4 GmbHG, § 307 BGB, § 444 BGB.
+- Form pruefen: Wann verlangt das Gesetz Schriftform, Textform, Beurkundung? Was umfasst die Beurkundung (Einheitstheorie)?
+- "Reasonable/best efforts"-Klauseln nicht stehenlassen, sondern entweder definieren oder bewusst dem § 242 BGB ueberlassen.
+- AGB-Risiko bei jeder einseitig gestellten Klausel benennen.
+
+## Quellen
+
+- § 125 BGB, § 138 BGB, § 158 BGB, § 162 BGB, § 164 BGB, § 181 BGB, § 242 BGB, § 305 BGB, § 307 BGB, § 311b BGB, § 444 BGB.
+- § 15 Abs. 3 und Abs. 4 GmbHG (Beurkundung Geschaeftsanteilskauf, Einheitstheorie).
+- BGH, Urt. v. 26.11.1998 - VII ZR 218/97 zur AGB-Kontrolle im unternehmerischen Verkehr.
+- BGH, Urt. v. 22.04.2010 - I ZR 17/05 zur Konkretisierung von "best efforts" nach § 242 BGB.
+- BGH, Urt. v. 25.03.1998 - VIII ZR 244/97 zur Einheitstheorie.
+
+## Verwandte Skills
+
+- `articles-association-satzung` fuer die Satzungsperspektive.
+- `share-classes-vorzugsrechte` fuer Vorzugsrechte und ihre Verankerung.
+- `reps-warranties-indemnities` fuer die Schnittstelle zur arglistigen Taeuschung und § 444 BGB.
+- `reasonable-efforts-covenants` fuer endeavours- und reasonable-efforts-Klauseln.
+- `verdeckte-sacheinlage` fuer § 19 Abs. 4 und Abs. 5 GmbHG.

--- a/gesellschaftsrecht-legal-english/skills/verdeckte-sacheinlage/SKILL.md
+++ b/gesellschaftsrecht-legal-english/skills/verdeckte-sacheinlage/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: verdeckte-sacheinlage
+description: "Erkennt und prueft verdeckte Sacheinlage und Hin-und-Her-Zahlung nach § 19 Abs. 4 und Abs. 5 GmbHG, einschließlich Anrechnungsloesung, Vorbelastungshaftung und der typischen M&A-Fallen bei Cash-Capitalization, Wandeldarlehen, Verrechnungsabreden und Gesellschafterdarlehen."
+---
+
+# Verdeckte Sacheinlage und Hin-und-Her-Zahlung
+
+## Worum es geht
+
+Verdeckte Sacheinlage ist einer der am haeufigsten uebersehenen Basics im M&A- und Finanzierungs-Alltag. M&A-Anwaelte denken in Vertragsrecht, doch § 19 Abs. 4 GmbHG ist zwingendes Kapitalaufbringungsrecht und bricht jede schuldrechtliche Konstruktion. Wer das uebersieht, erzeugt Differenzhaftung (§ 9 Abs. 1 GmbHG analog ueber § 19 Abs. 4 Satz 3 GmbHG) und im Insolvenzfall ein erhebliches Haftungsrisiko fuer die Geschaeftsfuehrung.
+
+## Kernregeln
+
+1. **§ 19 Abs. 4 GmbHG (verdeckte Sacheinlage):** Wenn eine Bareinlage wirtschaftlich als Sacheinlage zu werten ist, befreit die Bareinlage nicht von der Einlagepflicht. Der Gesellschafter haftet weiter. Auf seine Einlagepflicht wird der Wert des verdeckt eingelegten Vermoegensgegenstandes im Zeitpunkt der Anmeldung bzw. seiner Ueberlassung angerechnet (Anrechnungsloesung seit MoMiG 2008).
+2. **§ 19 Abs. 5 GmbHG (Hin-und-Her-Zahlung):** Wenn vor der Einlage eine Leistung an den Gesellschafter vereinbart ist, die wirtschaftlich einer Rueckzahlung der Einlage entspricht, befreit die Bareinlage nur, wenn die Leistung durch einen vollwertigen Rueckgewaehranspruch gedeckt ist, der jederzeit faellig gestellt werden kann oder durch fristlose Kuendigung faellig werden kann, und wenn dies in der Anmeldung offengelegt wird.
+3. **Verbindung mit § 19 Abs. 2 GmbHG:** Aufrechnung gegen die Einlageforderung ist grundsaetzlich unzulaessig. Verrechnungs- und Aufrechnungsabreden im SPA oder SHA muessen daran gemessen werden.
+
+## Pruefraster
+
+1. Gibt es zwischen Gesellschaft und einlegendem Gesellschafter eine zeitlich, sachlich oder personell verknuepfte Leistung (Kauf, Darlehen, Beraterhonorar, Lizenz, Dienstleistung, Uebernahme von Verbindlichkeiten)?
+2. Wird die Bareinlage wirtschaftlich gleich wieder an den Gesellschafter zurueckgefuehrt? Dann § 19 Abs. 5 GmbHG (Hin-und-Her-Zahlung).
+3. Wird mit der Bareinlage ein Vermoegensgegenstand des Gesellschafters erworben? Dann § 19 Abs. 4 GmbHG (verdeckte Sacheinlage).
+4. Anrechnungsloesung greifen lassen: Wert des Gegenstandes im Zeitpunkt der Anmeldung. Beweislast: Gesellschafter.
+5. Bei Hin-und-Her-Zahlung: ist der Rueckgewaehranspruch vollwertig und jederzeit faellig stellbar? Offenlegung in der Anmeldung erfolgt?
+6. Sind die Geschaeftsfuehrer ihrer Pflicht nach § 8 Abs. 2, § 9c GmbHG zur korrekten Anmeldung nachgekommen? Strafbarkeit nach § 82 GmbHG pruefen.
+
+## Typische M&A- und Finanzierungs-Fallen
+
+- **Cash-In-Series-A plus Akquisition aus Series-A-Mitteln:** Wenn die Mandantin mit dem Series-A-Cash unmittelbar Vermoegensgegenstaende eines Investors oder einer ihm nahestehenden Person erwirbt, ist die Naehe zur verdeckten Sacheinlage zu pruefen.
+- **Wandeldarlehen, das im Zuge der Kapitalerhoehung zurueckgefuehrt und neu als Eigenkapital gezeichnet wird:** Klassische Hin-und-Her-Zahlung. Vollwertigkeit und Faelligstellbarkeit muessen sauber dokumentiert sein, sonst nur Anrechnungsloesung.
+- **Verrechnungsabreden im SPA:** Aufrechnung gegen die Einlageforderung ist nach § 19 Abs. 2 GmbHG verboten; Verrechnungsklauseln im SPA muessen die Einlageforderung explizit aussparen.
+- **Gesellschafterdarlehen als Quasi-Eigenkapital:** Auch nach Wegfall der Eigenkapitalersatzregeln bleiben die Kapitalaufbringungsregeln scharf, wenn aus dem Darlehen heraus eine Kapitalerhoehung gezeichnet wird.
+- **Sale-and-lease-back kurz vor oder nach Closing:** Gegenstand bleibt wirtschaftlich beim Gesellschafter, Cash fliesst hin und zurueck. Genau pruefen.
+- **Beraterhonorar an Investor:** Wenn das Investmentvehikel direkt nach Closing ein laufendes Beraterhonorar bekommt, das wirtschaftlich Teil des Investments ist, kann Hin-und-Her-Zahlung vorliegen.
+
+## Antwortvorgaben
+
+- Trennen: Was sagt der Vertrag (M&A-Sicht) versus was sagt das Kapitalaufbringungsrecht (Gesellschaftsrecht-Sicht).
+- Immer die Rechtsfolgen aus § 19 Abs. 4 Satz 3 GmbHG benennen: Anrechnung des Wertes im Zeitpunkt der Anmeldung; Beweislast beim Gesellschafter; Differenzhaftung bleibt.
+- Auf § 9c GmbHG verweisen, wenn die Anmeldung Falschangaben enthielte.
+- Konkrete Heilung anbieten: Offenlegung in der Anmeldung, Wertgutachten, Sachgruendungsbericht, ggf. echte Sachkapitalerhoehung mit ordnungsgemaesser Werthaltigkeitspruefung.
+- Verweis auf die in der Akte typisch verlinkten Skills: `cap-table-gesellschafterliste`, `financing-convertible-loan-safe`, `articles-association-satzung`.
+
+## Quellen
+
+- BGH, Urt. v. 16.03.1998 - II ZR 303/96 (Lufttaxi), grundlegend zur verdeckten Sacheinlage vor MoMiG; weiterhin als Auslegungshintergrund relevant.
+- BGH, Urt. v. 06.12.2011 - II ZR 149/10 zur Anrechnungsloesung nach MoMiG.
+- BGH, Urt. v. 20.07.2009 - II ZR 273/07 (Cash-Pool) zur Hin-und-Her-Zahlung.
+- Begruendung MoMiG, BT-Drucksache 16/6140, zu § 19 Abs. 4 und Abs. 5 GmbHG.
+- § 19 GmbHG, § 9 GmbHG, § 9c GmbHG, § 82 GmbHG.


### PR DESCRIPTION
## v47.1.0 — Zwei neue Skills

Reaktion auf LinkedIn-Diskussion zu M&A-Basics und KI-Zeiten — Grundlagenwissen wird absolut entscheidend bleiben.

### Neue Skills
- `skills/verdeckte-sacheinlage/SKILL.md` — Paragraph 19 Abs. 4/5 GmbHG, Anrechnungsloesung (seit MoMiG), Hin-und-Her-Zahlung, 7-Schritte-Pruefraster, M&A-Fallen (Cash-In-Series-A + Akquisition, Wandeldarlehen-Rueckzahlung, Verrechnungsabreden, Sale-and-lease-back, Beraterhonorar).
- `skills/bgb-at-schuldrecht-at-im-ma/SKILL.md` — 10-Schritte-Pruefraster: Form/Einheitstheorie (Paragraph 125, 311b BGB, Paragraph 15 Abs. 3/4 GmbHG), Stellvertretung/Paragraph 181, Bedingung/Paragraph 162, AGB/Paragraph 307 auch B2B, Paragraph 242 best/reasonable efforts, Bestimmtheit, Verfuegungsverbote, Anfechtung/Paragraph 444 BGB, Erfuellung/Gefahruebergang, Sekundaerleistungen.

### Geaendert
- `skills/allgemein/SKILL.md`: Fuehrungsmatrix um zwei Routing-Zeilen erweitert.
- `plugin.json` und `marketplace.json` auf 47.1.0 (Skill-Anzahl 30 zu 32).
- `CHANGELOG.md`: v47.1.0-Eintrag.

### Validatoren
Alle gruen — validate-plugin-structure OK, validate-yaml-frontmatter 0/0, welle5-komma-check 0 Treffer.