### PR TITLE
fix(v47.1.1): Codex-Feedback zu bgb-at-schuldrecht-at-im-ma

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -445,7 +445,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "47.1.0"
+      "version": "47.1.1"
     },
     {
       "name": "gewerblicher-rechtsschutz",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v47.1.1 — Plugin gesellschaftsrecht-legal-english: Codex-Feedback zu bgb-at-schuldrecht-at-im-ma
+
+Reaktion auf zwei P2-Badges aus dem Codex-Review zu PR #142:
+
+- **§ 343 BGB qualifiziert auf Kaufleute (§ 348 HGB):** Die fruehere Aussage "Im B2B kein § 343 BGB-Schutz" war zu pauschal. Der Ausschluss der richterlichen Herabsetzung greift nach § 348 HGB nur, wenn ein Kaufmann die Vertragsstrafe im Betrieb seines Handelsgewerbes verspricht. Fuer Freiberufler, nicht-gewerbliche GbRs und Unternehmer ohne Kaufmannseigenschaft bleibt § 343 BGB anwendbar. Wurde sauber qualifiziert.
+- **Falsche BGH-Zitate ersetzt:** BGH I ZR 17/05 (Pralinenform II) ist Markenrecht und keine Best-Efforts-/§ 242-Entscheidung. BGH VIII ZR 244/97 betrifft Leasing-AGB und nicht die Einheitstheorie. Beide entfernt. Neu: BGH II ZR 155/85 (14.04.1986) und BGH VIII ZR 329/99 (27.06.2001, NJW 2002, 142) zur Reichweite des Beurkundungserfordernisses nach § 15 Abs. 4 GmbHG. Die Best-Efforts-Auslegung wird nun dogmatisch ueber § 242 BGB hergeleitet, ohne unpassende Einzelfallzitate. AGB-B2B-Quelle ersetzt durch BGH VII ZR 58/14 (22.10.2015).
+
+## Plugin-Version
+
+- `gesellschaftsrecht-legal-english/.claude-plugin/plugin.json` und `.claude-plugin/marketplace.json` auf `47.1.1` gebumpt. Description und Slug unveraendert. Skill-Anzahl unveraendert (32).
+
 # v47.1.0 — Plugin gesellschaftsrecht-legal-english: zwei neue Grundlagen-Skills
 
 Reaktion auf den Hinweis aus der Praxis (LinkedIn-Diskussion vom 29.05.2026), dass M&A-Anwaelte regelmaessig Basics aus BGB AT, Schuldrecht AT und Kapitalaufbringungsrecht uebersehen, weil sie M&A fuer reines Vertragsrecht halten. Gerade in Zeiten breiter KI-Nutzung bleibt das Grundlagenwissen entscheidend, damit Ergebnisse richtig interpretiert werden.

--- a/gesellschaftsrecht-legal-english/.claude-plugin/plugin.json
+++ b/gesellschaftsrecht-legal-english/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gesellschaftsrecht-legal-english",
-  "version": "47.1.0",
+  "version": "47.1.1",
   "description": "Didaktisches Gesellschaftsrecht — English Business Terms: Corporate Legal English fuer Big-Law-Anfaenger. Dealroom: Cap Table vs Gesellschafterliste; Term Sheet; SHA; Vesting; Drag/Tag; Liquidation Preference; Anti-Dilution; SPA; DD; Notar/HR; Multi-Format-Auswertung; Frankfurt-Startup-Akte.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gesellschaftsrecht-legal-english/skills/bgb-at-schuldrecht-at-im-ma/SKILL.md
+++ b/gesellschaftsrecht-legal-english/skills/bgb-at-schuldrecht-at-im-ma/SKILL.md
@@ -29,7 +29,7 @@ Englischsprachige M&A- und Finanzierungsvertraege unter deutschem Recht (Rechtsw
 - **"Best efforts" ohne Definition:** Auslegung ueber § 242 BGB; das Ergebnis ist in der Regel sachlicher und niedriger als das, was die englische Rechtspraxis darunter versteht.
 - **CP-Vereitelung:** Der Verkaeufer unterlaesst Handlungen, die zum CP-Eintritt fuehren wuerden. § 162 BGB fingiert den Eintritt. Wirkt zwingend, jedes "exclusive remedy"-Wording dagegen ist unwirksam.
 - **MAC-Klausel als AGB:** Wenn die MAC-Klausel von einer Seite gestellt und nicht ausgehandelt ist, droht § 307 BGB-Inhaltskontrolle.
-- **Vertragsstrafe und Liquidated Damages:** Sind als pauschalierter Schadensersatz nach §§ 339 ff. BGB zu pruefen. Im B2B kein § 343 BGB-Schutz, aber AGB-Kontrolle ueber § 307 BGB.
+- **Vertragsstrafe und Liquidated Damages:** Sind als pauschalierter Schadensersatz nach §§ 339 ff. BGB zu pruefen. § 343 BGB (richterliche Herabsetzung) ist nur bei kaufmaennischer Vertragsstrafe gemaess § 348 HGB ausgeschlossen; das setzt eine Vertragsstrafe voraus, die ein Kaufmann im Betrieb seines Handelsgewerbes versprochen hat. Bei B2B-Sachverhalten ausserhalb dieses Rahmens (Freiberufler, nicht-gewerbliche GbR, Unternehmer ohne Kaufmannseigenschaft nach §§ 1 ff. HGB) bleibt § 343 BGB anwendbar. Zusaetzlich greift bei einseitig gestellten Klauseln die AGB-Kontrolle ueber § 307 BGB.
 - **Konzernsachverhalte und § 181 BGB:** Bei Konzernverflechtungen oft Insichgeschaeft. Befreiung in der Satzung pruefen, sonst genehmigungsbeduerftig.
 
 ## Antwortvorgaben
@@ -44,9 +44,9 @@ Englischsprachige M&A- und Finanzierungsvertraege unter deutschem Recht (Rechtsw
 
 - § 125 BGB, § 138 BGB, § 158 BGB, § 162 BGB, § 164 BGB, § 181 BGB, § 242 BGB, § 305 BGB, § 307 BGB, § 311b BGB, § 444 BGB.
 - § 15 Abs. 3 und Abs. 4 GmbHG (Beurkundung Geschaeftsanteilskauf, Einheitstheorie).
-- BGH, Urt. v. 26.11.1998 - VII ZR 218/97 zur AGB-Kontrolle im unternehmerischen Verkehr.
-- BGH, Urt. v. 22.04.2010 - I ZR 17/05 zur Konkretisierung von "best efforts" nach § 242 BGB.
-- BGH, Urt. v. 25.03.1998 - VIII ZR 244/97 zur Einheitstheorie.
+- BGH, Urt. v. 14.04.1986 - II ZR 155/85 zur Beurkundungspflicht der Nebenabreden nach § 15 Abs. 4 GmbHG (Vollstaendigkeitsgrundsatz/Einheitstheorie).
+- BGH, Urt. v. 27.06.2001 - VIII ZR 329/99 (NJW 2002, 142) zur Reichweite der Beurkundungspflicht auf alle Nebenabreden, die nach dem Willen der Parteien Bestandteil der Verpflichtung zur Anteilsuebertragung sein sollen.
+- BGH, Urt. v. 22.10.2015 - VII ZR 58/14 zur AGB-Kontrolle im unternehmerischen Verkehr (§§ 305 ff., § 307 BGB auch zwischen Unternehmern).
 
 ## Verwandte Skills
 


### PR DESCRIPTION
## v47.1.1 — Codex-Review zu PR #142

Adressiert zwei P2-Badges aus dem Codex-Review der bgb-at-schuldrecht-at-im-ma-Quellen:

### 1. Paragraph 343 BGB auf kaufmaennische Transaktionen qualifiziert
Frueher pauschal "Im B2B kein Paragraph 343 BGB-Schutz". Codex zu Recht: Der Ausschluss der richterlichen Herabsetzung greift nach Paragraph 348 HGB nur, wenn ein Kaufmann die Vertragsstrafe im Betrieb seines Handelsgewerbes verspricht. Fuer Freiberufler, nicht-gewerbliche GbRs und Unternehmer ohne Kaufmannseigenschaft (Paragraph Paragraph 1 ff. HGB) bleibt Paragraph 343 BGB anwendbar. Wurde im Skill sauber qualifiziert.

### 2. Falsche BGH-Zitate ersetzt
- **Raus:** BGH I ZR 17/05 (Pralinenform II) — ist Markenrecht, keine Best-Efforts-/Paragraph 242-Entscheidung.
- **Raus:** BGH VIII ZR 244/97 — betrifft Leasing-AGB, nicht die Einheitstheorie zu Paragraph 15 Abs. 4 GmbHG.
- **Raus:** BGH VII ZR 218/97 — kein passender Treffer fuer AGB-B2B.
- **Neu:** BGH II ZR 155/85 (14.04.1986) zur Beurkundungspflicht aller Nebenabreden nach Paragraph 15 Abs. 4 GmbHG (Vollstaendigkeitsgrundsatz/Einheitstheorie, Senat fuer Gesellschaftsrecht).
- **Neu:** BGH VIII ZR 329/99 (27.06.2001, NJW 2002, 142) zur Reichweite der Beurkundungspflicht.
- **Neu:** BGH VII ZR 58/14 (22.10.2015) zur AGB-Kontrolle zwischen Unternehmern.

Die Best-Efforts-Auslegung wird nun dogmatisch ueber Paragraph 242 BGB hergeleitet, ohne unpassende Einzelfallzitate.

### Versionen
- plugin.json: 47.1.0 zu 47.1.1
- marketplace.json: 47.1.0 zu 47.1.1
- CHANGELOG.md: v47.1.1-Eintrag

### Validatoren
Alle gruen.