### PR TITLE
feat(v47.2.0): methodenlehre-buergerliches-recht README und Skills geschaerft

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -687,7 +687,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "42.0.0"
+      "version": "42.1.0"
     },
     {
       "name": "mietrecht",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+# v47.2.0 — Plugin methodenlehre-buergerliches-recht: README und Skills geschaerft
+
+Das Plugin `methodenlehre-buergerliches-recht` wurde an drei Stellen verbessert; die alte Breaking-Change-Sektion in der README ist entfernt, weil sie seit dem Plugin-Rename in v3.0 ihren Zweck erfuellt hat und nun nur noch Laerm war.
+
+## README
+
+- Sektion `Breaking Change in v3.0` entfernt.
+- Neue Sektion `Was dieses Plugin konkret macht`: praezise Beschreibung der Plugin-Leistung mit allen Komponenten (Anspruchsgrundlagen-Reihenfolge, vier Kanones plus zwei Querschnittskanones, Lueckenfuellung, Generalklauseln, Querschnittsthemen, Verbotsliste, Memo-Standardstruktur, Selbstpruefungs-Checkliste).
+- Skill-Tabelle um den `allgemein`-Skill erweitert (war bisher untertabelliert).
+- Neuer Abschnitt `Verknuepfung mit anderen Plugins`.
+
+## Skill `methodenlehre-anwenden`
+
+- Neue Begruendung der Anspruchsgrundlagen-Reihenfolge (Speziellere vor Allgemeineren, rechtsgeschaeftliche Bindung vor gesetzlichen Schuldverhaeltnissen, etc.).
+- Drei konkrete Praxisbeispiele zur Gewichtung der Auslegungskanones (§ 199 Abs. 1 BGB, § 138 Abs. 2 BGB, §§ 651a ff. BGB Pauschalreise).
+- Erweiterter Abschnitt zu Rechtsfortbildung mit vier klassischen BGH-Argumentationsmustern (Vertrag mit Schutzwirkung, Drittschadensliquidation, c.i.c. vor 2002, Verwirkung/Treuwidrigkeit ueber § 242 BGB).
+- Neuer Hinweis zu typischen Fehlanwendungen von Generalklauseln als Erstargument.
+- Verbotsliste um Punkt "keine ergebnisorientierte Rueckwaerts-Subsumtion" erweitert.
+- Selbstpruefungs-Checkliste um Rechtsfortbildungs-Frage erweitert.
+- Verlinkung zu `bgb-at-pruefer` ergaenzt.
+
+## Skill `allgemein`
+
+- Sektion `Spezial-Skills in diesem Plugin`: aussagekraeftige Beschreibung statt Trunkierung; neue Spalte `Erwarteter Output`.
+- Neuer Block `Routing-Faustregel` mit vier konkreten Weiterleitungen (BGB-AT-Detailpruefung zu `bgb-at-pruefer`, Zitierfragen zu `zitierweise-deutsches-recht`, Fachgebiete zu Fachplugins).
+
+## Plugin-Version
+
+- `methodenlehre-buergerliches-recht/.claude-plugin/plugin.json` und `.claude-plugin/marketplace.json` auf `42.1.0`. Description und Slug unveraendert.
+
 # v47.1.1 — Plugin gesellschaftsrecht-legal-english: Codex-Feedback zu bgb-at-schuldrecht-at-im-ma
 
 Reaktion auf zwei P2-Badges aus dem Codex-Review zu PR #142:

--- a/methodenlehre-buergerliches-recht/.claude-plugin/plugin.json
+++ b/methodenlehre-buergerliches-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "methodenlehre-buergerliches-recht",
-  "version": "42.0.0",
+  "version": "42.1.0",
   "description": "Methodenlehre und Rechtsanwendung im deutschen buergerlichen Recht aus Anwaltsperspektive. Gutachtenstil. Anspruchsgrundlagen-Reihenfolge. Auslegung Wortlaut System Historie Telos pragmatisch ohne starren Vorrang. Verfassungs- und unionsrechtskonforme Auslegung. Lueckenfuellung. Verjährung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/methodenlehre-buergerliches-recht/README.md
+++ b/methodenlehre-buergerliches-recht/README.md
@@ -4,6 +4,22 @@ Deutsche juristische Methodenlehre und Falllösung aus anwaltlicher Perspektive.
 
 Für konkrete Prüfungen im BGB Allgemeiner Teil kann `bgb-at-pruefer` hinzugeladen werden; dieses Plugin bleibt die methodische Grundierung, der BGB-AT-Prüfer übernimmt dann Vertragsschluss, Zugang, Anfechtung, Stellvertretung, Geschäftsfähigkeit, Form, Fristen und Verjährung.
 
+## Was dieses Plugin konkret macht
+
+Das Plugin liefert die **methodische Klammer** für jede zivilrechtliche Bewertung im Repo — also den Rahmen, in dem alle Rechtsgebiet-Plugins (`fachanwalt-erbrecht`, `fachanwalt-arbeitsrecht`, `fachanwalt-familienrecht`, `arbeitsrecht`, `gesellschaftsrecht-legal-english`, `kanzlei-allgemein` etc.) arbeiten sollen. Konkret leistet es Folgendes:
+
+- **Anspruchsgrundlagen-Reihenfolge** strukturiert: Vertrag → c.i.c. → GoA → dingliche Ansprüche → Delikt → Gefährdungshaftung → Bereicherung. Sammelbegriffe wie „vertragsähnlich" oder „quasivertraglich" werden vermieden, weil sie in der Lehre uneinheitlich besetzt sind.
+- **Vier Auslegungskanones** pragmatisch geführt: grammatikalisch (Wortlautgrenze), systematisch, historisch, teleologisch. **Keine starre Rangfolge** — in der anwaltlichen Praxis dominiert die Teleologie, weil Gerichte über die ratio legis Einzelfallgerechtigkeit begründen. Wer im Schriftsatz nur historisch argumentiert, redet am Senat vorbei.
+- **Querschnittskanones**: verfassungskonforme und unionsrechtskonforme Auslegung. Bei Normen unionsrechtlichen Ursprungs autonome Auslegung; Erwägungsgründe als Auslegungshilfe, nicht als Auslegungssubstitut; keine horizontale Direktwirkung von Richtlinien zwischen Privaten.
+- **Lückenfüllung als reales Werkzeug**: Analogie (planwidrige Regelungslücke + vergleichbare Interessenlage), teleologische Reduktion, Erst-Recht-Schluss, Umkehrschluss. Mit konkreten Praxisbeispielen aus der BGH-Rechtsfortbildung (Vertrag mit Schutzwirkung zugunsten Dritter, Drittschadensliquidation, c.i.c. vor Schuldrechtsreform).
+- **Generalklauseln** als Auffangargument, nicht als Hauptargument: § 138, § 242, § 826 BGB greifen erst, wenn keine speziellere Norm passt. Konkretisierung über Grundrechte und Unionsrecht, nicht über gefühlte „Wertvorstellungen der Gemeinschaft".
+- **Querschnittsthemen**, die jede anwaltliche Falllösung mitprüft: Verjährung (§§ 195, 199, 196, 197, 438, 634a BGB, Hemmung §§ 203 ff. BGB), prozessuale Fristen (§ 276, § 517, § 520, § 548, § 569 ZPO, § 339 ZPO, § 4 KSchG), Beweislast (Rosenbergsche Formel, § 280 Abs. 1 S. 2 BGB, § 1 Abs. 4 ProdHaftG, Anscheinsbeweis), Sachverhaltsaufklärung (Auskunftsansprüche § 242 BGB, § 666 BGB, § 810 BGB, Art. 15 DSGVO, §§ 142, 144 ZPO, § 254 ZPO).
+- **Verbotsliste — methodische Selbstdisziplin**: keine scheinbaren Auslegungsregeln als tragende Begründung („Ausnahmen sind eng auszulegen", „im Zweifel für den Schuldner"), kein „h. M." als Selbstbeleg, keine Generalklausel als Erstargument.
+- **Memo-Standardstruktur**: Sachverhalt → Frage(n) → Kurzantwort → rechtliche Bewertung → Gesamtergebnis → Risiken → Quellenverzeichnis nach Hauszitierweise.
+- **Selbstprüfungs-Checkliste vor jeder Ausgabe**: acht Fragen, mit denen jede zivilrechtliche Antwort durchläuft, bevor sie ausgeliefert wird.
+
+Das Plugin verzichtet bewusst darauf, eine methodendebatten-getriebene Position zu beziehen (Rüthers-Warnung vor zu freier Teleologie, Friedrich Müller, Strukturierende Rechtslehre etc.). Es bildet ab, was Senate des BGH und Berufungsinstanzen **tatsächlich** tun, nicht was die Methodenlehre als Idealtypus fordert.
+
 ## ⬇️ Direkt-Download (einzelnes ZIP)
 
 | Plugin | Direkt-Download |
@@ -18,17 +34,20 @@ Die URL ist stabil und zeigt immer auf die neueste Version. Alle weiteren Plugin
 2. Claude Code → **Customize Plugins** → **Install from .zip** → Datei wählen.
 3. Fertig. Skills sind sofort verfügbar.
 
-> **Hinweis:** Für den ZIP-Upload muss das Archiv direkt `.claude-plugin/plugin.json`, `skills/`, `assets/` und `references/` im ZIP-Root enthalten. **Nicht** das komplette Repository-ZIP aus "Code → Download ZIP" verwenden.
+> **Hinweis:** Für den ZIP-Upload muss das Archiv direkt `.claude-plugin/plugin.json`, `skills/`, `assets/` und `references/` im ZIP-Root enthalten. **Nicht** das komplette Repository-ZIP aus „Code → Download ZIP" verwenden.
 
 ## Enthaltene Skills
 
 | Skill | Zweck |
 | --- | --- |
+| `allgemein` | Einstieg, Triage und Workflow-Routing im Plugin. Bei stummem Upload (Dokument ohne Begleittext) reagiert der Skill eigenständig: ordnet das Material, prüft Eil- und Fristenhinweise, schlägt den passenden Spezial-Skill vor oder stellt genau eine gezielte Rückfrage. |
 | `methodenlehre-anwenden` | Wende deutsche juristische Methodenlehre auf zivilrechtliche Bewertungen an. Anspruchsgrundlagen-Reihenfolge, Auslegung Wortlaut Systematik Historie Telos ohne starre Rangfolge. Pragmatische BGH-Praxis: Teleologie dominiert in Begründungen. Rechtsfortbildung als reales Werkzeug. Aus Anwaltsperspektive — was Gerichte wirklich tun, nicht was Lehrbücher fordern. |
 
-## Breaking Change in v3.0
+## Verknüpfung mit anderen Plugins
 
-Plugin umbenannt von `methodenlehre-deutsches-recht` zu `methodenlehre-buergerliches-recht`. Reference-Datei umbenannt von `methodik-deutsches-recht.md` zu `methodik-buergerliches-recht.md`. Inhaltlich neu aufgesetzt aus anwaltlicher Praxis: keine starre Kanones-Rangfolge, Teleologie als dominantes Praxisargument, Rüthers-Warnung entfernt (nicht herrschende Methodendebatte).
+- **`zitierweise-deutsches-recht`** — Jede Aussage wird nach der Hauszitierweise belegt; BGH-Zitate mit `Az.`-Marker, Pinpoint mit Rn., Hierarchie der Gerichte.
+- **`bgb-at-pruefer`** — Konkrete BGB-AT-Prüfungen (Vertragsschluss, Anfechtung, Stellvertretung, Form, Verjährung) — dieses Plugin bleibt die methodische Grundierung.
+- Alle Rechtsgebiet-Plugins setzen die Methodenlehre dieses Plugins voraus und greifen über relative Pfade auf [`references/methodik-buergerliches-recht.md`](references/methodik-buergerliches-recht.md) zu.
 
 ## Lizenz
 

--- a/methodenlehre-buergerliches-recht/skills/allgemein/SKILL.md
+++ b/methodenlehre-buergerliches-recht/skills/allgemein/SKILL.md
@@ -112,9 +112,16 @@ Nutze als erste Antwort nach Aktivierung möglichst dieses kompakte Format:
 
 ### 5. Spezial-Skills in diesem Plugin
 
-| Skill | Wann vorschlagen? |
-|---|---|
-| `methodenlehre-anwenden` | Anwalt oder Rechtsstudent wendet deutsche Methodenlehre im buergerlichen Recht an: Anspruchsgrundlagen-Reihenfolge Vertrag c.i.c. GoA dinglich Delikt Gefaehrdungshaftung Bereicherung. Auslegung §§ 133 157 BGB… |
+| Skill | Wann vorschlagen? | Erwarteter Output |
+|---|---|---|
+| `methodenlehre-anwenden` | Immer dann, wenn eine zivilrechtliche Frage methodisch sauber gepruft werden soll: Anspruchsgrundlagen-Reihenfolge, Auslegung der einschlaegigen Norm nach Wortlaut/System/Historie/Telos, Lueckenfuellung durch Analogie oder teleologische Reduktion, Pruefung von Generalklauseln nur als Auffangargument. Auch fuer Memo-Strukturierung, Schriftsatzentwurf und die Selbstkontrolle der eigenen Argumentation. | Strukturierte Rechtsbewertung im Gutachtenstil mit Anspruchsgrundlagen-Pruefung, Auslegungsbegruendung, Verjaehrungs- und Beweislast-Check, sauber belegt nach Hauszitierweise. |
+
+**Routing-Faustregel:**
+
+- *Schnelle Erstbewertung einer zivilrechtlichen Frage* → `methodenlehre-anwenden` direkt aktivieren.
+- *BGB-AT-Detailpruefung (Vertragsschluss, Anfechtung, Stellvertretung, Form, Verjaehrung)* → Plugin `bgb-at-pruefer` zusaetzlich hinzuladen; dieses Plugin bleibt die methodische Klammer.
+- *Zitierfragen* → Plugin `zitierweise-deutsches-recht`.
+- *Konkrete Rechtsgebiete* (Erbrecht, Arbeitsrecht, Familienrecht, Gesellschaftsrecht etc.) → das jeweilige Fachplugin; die Methodenlehre dieses Plugins gilt als Grundierung.
 
 ## Qualitätsversprechen
 

--- a/methodenlehre-buergerliches-recht/skills/methodenlehre-anwenden/SKILL.md
+++ b/methodenlehre-buergerliches-recht/skills/methodenlehre-anwenden/SKILL.md
@@ -11,8 +11,9 @@ Dieser Skill verkörpert die Methodenlehre und Falllösung im deutschen bürgerl
 
 - Du bewertest eine bürgerlich-rechtliche Frage und musst eine Anspruchsgrundlage prüfen.
 - Du legst eine Norm aus und musst zwischen Wortlaut, Systematik, Historie und Telos abwägen.
-- Du argumentierst mit einer Generalklausel (§ 138 BGB, § 242 BGB, § 826 BGB, "wichtiger Grund", "Treu und Glauben") und musst ihre Auffangstellung begründen.
+- Du argumentierst mit einer Generalklausel (§ 138 BGB, § 242 BGB, § 826 BGB, „wichtiger Grund", „Treu und Glauben") und musst ihre Auffangstellung begründen.
 - Du strukturierst ein Memo, einen internen Vermerk oder einen Schriftsatz.
+- Du musst eine Lücke schließen (Analogie, teleologische Reduktion, Erst-Recht-Schluss, Umkehrschluss).
 
 ## Anspruchsgrundlagen — Prüfungsreihenfolge
 
@@ -26,15 +27,17 @@ Standardreihenfolge im Gutachten und in der anwaltlichen Vorprüfung:
 6. **Gefährdungshaftung — verschuldensunabhängig** (§ 7 StVG; § 1 ProdHaftG; § 1 HaftpflG; § 33 LuftVG; § 25 AtG; § 89 Abs. 2 WHG; § 84 AMG; § 32 GenTG; § 1 UmweltHG; § 833 S. 1 BGB)
 7. **Bereicherungsansprüche** (§§ 812 ff. BGB)
 
-Die Sammelbegriffe "vertragsähnlich" und "quasivertraglich" werden vermieden — sie sind in der Lehre uneinheitlich besetzt. Sauberer ist die direkte Benennung: c.i.c. ist vorvertragliches Schuldverhältnis (§ 311 Abs. 2 BGB), GoA ist gesetzliches Schuldverhältnis. Gefährdungshaftung ist **eigenständige** verschuldensunabhängige Haftungsspur, **kein** Unterfall des § 823 BGB.
+Die Sammelbegriffe „vertragsähnlich" und „quasivertraglich" werden vermieden — sie sind in der Lehre uneinheitlich besetzt. Sauberer ist die direkte Benennung: c.i.c. ist vorvertragliches Schuldverhältnis (§ 311 Abs. 2 BGB), GoA ist gesetzliches Schuldverhältnis. Gefährdungshaftung ist **eigenständige** verschuldensunabhängige Haftungsspur, **kein** Unterfall des § 823 BGB.
+
+**Warum diese Reihenfolge?** Speziellere Anspruchsgrundlagen vor allgemeineren; rechtsgeschäftliche Bindung vor gesetzlichen Schuldverhältnissen; sachenrechtliche Zuordnung vor unerlaubter Handlung; Verschuldenshaftung vor Gefährdungshaftung; Bereicherungsrecht zuletzt als Auffangordnung.
 
 ## Auslegungskanones — pragmatisch geführt
 
 Vier klassische Kanones plus zwei Querschnittskanones. **Eine starre Rangfolge gibt es in der Praxis nicht**; die Kanones werden gleichgewichtig herangezogen und je nach Norm und Sachlage unterschiedlich gewichtet.
 
 1. **Grammatikalisch** — Wortlaut nach allgemeinem oder fachlichem Sprachgebrauch. **Äußere Grenze** der Auslegung; jenseits davon beginnt Rechtsfortbildung.
-2. **Systematisch** — Stellung im Gesetz, Verhältnis zu Nachbarnormen, Gesamtzusammenhang.
-3. **Historisch** — Entstehungsgeschichte, Materialien (BT-Drucks., Ausschussberichte). In der Praxis oft nachgeordnet, weil Materialien lückenhaft oder schwer zugänglich sind; bei jüngeren Reformgesetzen aber regelmäßig tragfähig.
+2. **Systematisch** — Stellung im Gesetz, Verhältnis zu Nachbarnormen, Gesamtzusammenhang. Beispiel: § 280 Abs. 1 BGB im System der Schuldverhältnisse, abgegrenzt zu § 311 Abs. 2 BGB und § 823 BGB.
+3. **Historisch** — Entstehungsgeschichte, Materialien (BT-Drucks., Ausschussberichte). In der Praxis oft nachgeordnet, weil Materialien lückenhaft oder schwer zugänglich sind; bei jüngeren Reformgesetzen (Schuldrechtsmodernisierung 2002, MoMiG, KapMuG, Verbraucherrechte-RL-Umsetzung) aber regelmäßig tragfähig.
 4. **Teleologisch** — Sinn und Zweck (ratio legis). In der **anwaltlichen Praxis** häufig das **stärkste** Auslegungsargument: Gerichte argumentieren ganz überwiegend teleologisch, weil sich damit gerechte Einzelfallergebnisse begründen lassen. Wer in der Praxis ausschließlich historisch argumentiert, läuft am Gericht vorbei.
 
 **Querschnittskanones:**
@@ -42,7 +45,13 @@ Vier klassische Kanones plus zwei Querschnittskanones. **Eine starre Rangfolge g
 5. **Verfassungskonforme Auslegung** — Von zwei vertretbaren Auslegungen ist die mit dem Grundgesetz vereinbare zu wählen. Wirksames Argument in der Praxis.
 6. **Unionsrechtskonforme Auslegung** — Bei Normen unionsrechtlichen Ursprungs (DSGVO, KI-VO, Verbraucher-RL, Kartellrecht u. a.) autonom auszulegen; siehe Sektion unten.
 
-**Anwaltliche Faustregel:** Im Schriftsatz alle einschlägigen Kanones nennen, nicht eine starre Reihenfolge predigen. Wenn drei Kanones in eine Richtung weisen und einer in die andere, ist die Begründungslast für die abweichende Auslegung höher. Wenn alle vier Kanones zum gleichen Ergebnis führen, ist die Auslegung "eindeutig" — dann steht der Schriftsatz.
+**Anwaltliche Faustregel:** Im Schriftsatz alle einschlägigen Kanones nennen, nicht eine starre Reihenfolge predigen. Wenn drei Kanones in eine Richtung weisen und einer in die andere, ist die Begründungslast für die abweichende Auslegung höher. Wenn alle vier Kanones zum gleichen Ergebnis führen, ist die Auslegung „eindeutig" — dann steht der Schriftsatz.
+
+**Praxisbeispiele zur Gewichtung:**
+
+- *§ 199 Abs. 1 BGB — „Kenntnis"*: Wortlaut sagt nur „Kenntnis", aber teleologisch (Verjährung als Rechtsfriedensinstrument) wird grob fahrlässige Unkenntnis gleichgestellt — und genau das hat der Gesetzgeber im Wortlaut ausdrücklich aufgenommen. Historie und Telos decken sich, das Argument trägt.
+- *§ 138 Abs. 2 BGB — „auffälliges Missverhältnis"*: Wortlaut offen, Systematik (Wucherrechtsprechung) und Telos (Schutz vor Ausbeutung) prägen die Konkretisierung; historisch ist die Norm seit dem RGBl. 1900 unverändert, hilft also wenig.
+- *§ 651a BGB ff. (Pauschalreise) nach RL-Umsetzung 2018*: Wortlaut allein trägt nicht; richtlinienkonforme (= unionsrechtskonforme) Auslegung ist Pflicht, weil die Norm Unionsrecht umsetzt.
 
 ## Verfassungskonforme und unionsrechtskonforme Auslegung
 
@@ -54,7 +63,7 @@ Rechtsprechung: keine Entscheidung aus Modellwissen zitieren; vor Ausgabe über 
 - Bei Richtlinien zusätzlich: keine horizontale Direktwirkung zwischen Privaten (EuGH, Marshall, 152/84). Wer sich gegen einen Privaten auf eine Richtlinie beruft, muss über die richtlinienkonforme Auslegung des nationalen Umsetzungsrechts argumentieren.
 
 **Auslegung des Unionsrechts (autonome Auslegung):**
-- Begriffe des Unionsrechts werden unabhängig vom nationalen Begriffsverständnis ausgelegt. "Schaden" in Art. 82 DSGVO ist nicht der Schadensbegriff der §§ 249 ff. BGB.
+- Begriffe des Unionsrechts werden unabhängig vom nationalen Begriffsverständnis ausgelegt. „Schaden" in Art. 82 DSGVO ist nicht der Schadensbegriff der §§ 249 ff. BGB.
 - Erwägungsgründe sind **Auslegungshilfe**, nicht **Auslegungssubstitut**. Sie dürfen nicht **entgegen** dem klaren Wortlaut des verfügenden Teils herangezogen werden.
 - Bei zweifelhaftem Wortlaut Sprachfassungen vergleichen; alle Amtssprachen sind verbindlich.
 - Rechtsprechung: keine Entscheidung aus Modellwissen zitieren; vor Ausgabe über offizielle oder frei zugängliche Quelle mit Gericht, Entscheidungsform, Datum, Aktenzeichen und tragender Aussage verifizieren.
@@ -68,21 +77,31 @@ Rechtsprechung: keine Entscheidung aus Modellwissen zitieren; vor Ausgabe über 
 
 Rechtsfortbildung ist in der bürgerlich-rechtlichen Praxis ein **reales Werkzeug**, nicht nur eine theoretische Möglichkeit — vom BGH durchgehend angewandt (z. B. Vertrag mit Schutzwirkung zugunsten Dritter, Drittschadensliquidation, culpa in contrahendo vor § 311 Abs. 2 BGB). Wer Rechtsfortbildung benötigt, sollte sie offen kennzeichnen und die methodischen Voraussetzungen (Lücke, vergleichbare Interessenlage, fehlende abweichende gesetzgeberische Entscheidung) sauber prüfen.
 
+**Klassische Fälle aus der BGH-Rechtsfortbildung — als Argumentationsmuster nutzbar:**
+
+- **Vertrag mit Schutzwirkung zugunsten Dritter** — analoge Anwendung der vertraglichen Schutzpflichten auf Personen, die bestimmungsgemäß mit der Leistung in Berührung kommen.
+- **Drittschadensliquidation** — Korrektur einer zufälligen Schadensverlagerung; klassischer Fall planwidriger Regelungslücke vor der Schuldrechtsreform.
+- **Vertragliche Schutzpflichten bei gestörtem Vertragsanbahnungsverhältnis** — vor § 311 Abs. 2 BGB rein richterrechtlich (c.i.c.); seit 2002 kodifiziert, aber die Argumentationsstruktur bleibt brauchbar für Konstellationen, die das Gesetz nicht erfasst.
+- **§ 242 BGB als Konkretisierungsplattform** — Verwirkung (Zeitmoment + Umstandsmoment), Treuwidrige Berufung auf Formfehler, Wegfall der Geschäftsgrundlage (jetzt § 313 BGB, vor 2002 richterrechtlich).
+
 ## Generalklauseln — Auffang, nicht Hauptargument
 
 Vor jedem Argument aus § 138 BGB, § 242 BGB oder § 826 BGB ist zu prüfen, ob speziellere Normen einschlägig sind. Wer eine Generalklausel als ersten Belegtyp anführt, muss erklären, warum die spezielle Norm nicht greift.
 
-Die Konkretisierung einer Generalklausel ist an Grundrechten, Verfassungsprinzipien und Unionsrecht zu messen — nicht an gefühlten "Wertvorstellungen der Gemeinschaft".
+Die Konkretisierung einer Generalklausel ist an Grundrechten, Verfassungsprinzipien und Unionsrecht zu messen — nicht an gefühlten „Wertvorstellungen der Gemeinschaft".
+
+**Typische Fehlanwendung:** „Das verstößt gegen § 242 BGB" als Erstargument, ohne vorher § 280 Abs. 1 BGB, § 241 Abs. 2 BGB, vertragliche Nebenpflichten oder spezialgesetzliche Schutznormen geprüft zu haben. Im Schriftsatz signalisiert das methodische Schwäche.
 
 ## Verbotsliste — methodische Selbstdisziplin
 
-- **Keine scheinbaren Auslegungsregeln** als tragende Begründung: "Ausnahmen sind eng auszulegen", "im Zweifel für den Schuldner" (außerhalb gesetzlich geregelter Fälle), "AGB-Klauseln sind kundenfreundlich auszulegen" (pauschal). Solche Topoi dürfen genannt werden, aber **nie als tragende Begründung**, sondern nur als Hinweis auf eine darunterliegende Wertentscheidung, die separat über Wortlaut, System, Historie und Telos zu rechtfertigen ist.
-- **Kein "h. M." als Selbstbeleg** — herrschende Meinung muss mit konkreten Belegen unterlegt werden.
+- **Keine scheinbaren Auslegungsregeln** als tragende Begründung: „Ausnahmen sind eng auszulegen", „im Zweifel für den Schuldner" (außerhalb gesetzlich geregelter Fälle), „AGB-Klauseln sind kundenfreundlich auszulegen" (pauschal). Solche Topoi dürfen genannt werden, aber **nie als tragende Begründung**, sondern nur als Hinweis auf eine darunterliegende Wertentscheidung, die separat über Wortlaut, System, Historie und Telos zu rechtfertigen ist.
+- **Kein „h. M." als Selbstbeleg** — herrschende Meinung muss mit konkreten Belegen unterlegt werden.
 - **Kein Stützen auf Generalklauseln**, wenn speziellere Normen greifen.
+- **Keine ergebnisorientierte Rückwärts-Subsumtion** — die Methodenlehre verlangt, dass die Subsumtion das Ergebnis trägt, nicht umgekehrt. Wer das Ergebnis vorab kennt und nur noch eine Begründung sucht, sollte den Urteilsstil wählen und das offenlegen.
 
 ## Stilregel
 
-- **Gutachtenstil** standardmäßig ("Es könnte … Dazu müsste …") — in Memos, internen Vermerken, Mandantenkommunikation mit Begründungsanspruch.
+- **Gutachtenstil** standardmäßig („Es könnte … Dazu müsste …") — in Memos, internen Vermerken, Mandantenkommunikation mit Begründungsanspruch.
 - **Urteilsstil** nur, wenn ausdrücklich verlangt — in Schriftsätzen, Beschlüssen, Mandantenkurzantworten, wenn das Ergebnis vorab steht.
 
 ## Standardstruktur deutsches Memo
@@ -112,13 +131,14 @@ Eine anwaltliche Falllösung erfasst nicht nur die materielle Anspruchsprüfung,
 ## Selbstprüfung vor jeder Ausgabe
 
 - Habe ich alle einschlägigen Anspruchsgrundlagen in der Standardreihenfolge geprüft?
-- Stütze ich mich primär auf eine spezielle Norm oder auf eine Generalklausel?
+- Stütze ich mich primär auf eine spezielle Norm oder auf eine Generalklausel? Wenn Generalklausel: warum greift keine spezielle Norm?
 - Habe ich alle vier Kanones nebeneinander gewürdigt, statt nur einen zu wählen?
 - Wenn ich teleologisch argumentiere: Lege ich die Wertentscheidung offen?
 - Ist die anzuwendende Norm europäischen Ursprungs oder dient sie der Umsetzung von Unionsrecht? Dann **autonom** auslegen.
 - Habe ich Erwägungsgründe nur als **Auslegungshilfe** verwendet — nicht zur Korrektur eines klar formulierten verfügenden Teils?
 - Habe ich Verjährung, prozessuale Fristen und Beweislast geprüft?
-- Belege ich jede Aussage mit einer konkreten Fundstelle (Norm, Rechtsprechung, Kommentarstelle) — nicht mit "h. M."?
+- Belege ich jede Aussage mit einer konkreten Fundstelle (Norm, Rechtsprechung, Kommentarstelle) — nicht mit „h. M."?
+- Wenn ich Rechtsfortbildung betreibe: Habe ich planwidrige Lücke, vergleichbare Interessenlage und fehlende abweichende gesetzgeberische Entscheidung sauber dargelegt?
 
 ## Vertiefung
 
@@ -126,5 +146,6 @@ Die ausführliche methodische Grundlage einschließlich der Sektionen zu Anspruc
 
 ## Verknüpfung mit anderen Plugins
 
-- **`zitierweise-deutsches-recht`** — Jede Aussage wird nach der Hauszitierweise (v3.0) belegt; insbesondere BGH-Zitate mit `Az.`-Marker, Pinpoint mit Rn., Hierarchie der Gerichte.
-- Alle Rechtsgebiet-Plugins (`fachanwalt-erbrecht`, `fachanwalt-arbeitsrecht`, `fachanwalt-familienrecht`, `arbeitsrecht`, `kanzlei-allgemein` etc.) setzen diese Methodenlehre voraus; sie greifen über relative Pfade auf die Repo-Referenz [`references/methodik-buergerliches-recht.md`](../../references/methodik-buergerliches-recht.md) zu.
+- **`zitierweise-deutsches-recht`** — Jede Aussage wird nach der Hauszitierweise belegt; insbesondere BGH-Zitate mit `Az.`-Marker, Pinpoint mit Rn., Hierarchie der Gerichte.
+- **`bgb-at-pruefer`** — Mechanische BGB-AT-Prüfungen (Vertragsschluss, Anfechtung, Stellvertretung, Form, Verjährung) bauen auf dieser Methodenlehre auf.
+- Alle Rechtsgebiet-Plugins (`fachanwalt-erbrecht`, `fachanwalt-arbeitsrecht`, `fachanwalt-familienrecht`, `arbeitsrecht`, `gesellschaftsrecht-legal-english`, `kanzlei-allgemein` etc.) setzen diese Methodenlehre voraus; sie greifen über relative Pfade auf die Repo-Referenz [`references/methodik-buergerliches-recht.md`](../../references/methodik-buergerliches-recht.md) zu.


### PR DESCRIPTION
## v47.2.0 \u2014 Plugin methodenlehre-buergerliches-recht

User-Auftrag: "Im methodologie readme das hier loeschen: Breaking Change in v3.0 ... Stattdessen genauer beschreiben, was es macht. Die Skills auch noch mal verbessern."

### README
- Veraltete `Breaking Change in v3.0`-Sektion entfernt (Rename ist seit v3.0 erledigt, Hinweis war nur noch Laerm).
- Neue Sektion `Was dieses Plugin konkret macht` mit zehn praezisen Bullet-Points zur Plugin-Leistung.
- Skill-Tabelle um den `allgemein`-Skill erweitert.
- Neuer Abschnitt `Verknuepfung mit anderen Plugins` (zitierweise, bgb-at-pruefer, Rechtsgebiet-Plugins).

### Skill `methodenlehre-anwenden`
- Begruendung der Anspruchsgrundlagen-Reihenfolge ergaenzt.
- Drei Praxisbeispiele zur Gewichtung der Auslegungskanones (\u00a7 199 Abs. 1 BGB, \u00a7 138 Abs. 2 BGB, Pauschalreise).
- Vier klassische BGH-Argumentationsmuster zur Rechtsfortbildung.
- Typische Fehlanwendung von Generalklauseln als Erstargument benannt.
- Verbotsliste um "keine ergebnisorientierte Rueckwaerts-Subsumtion" erweitert.
- Selbstpruefungs-Checkliste um Rechtsfortbildungs-Frage erweitert.
- Verlinkung zu `bgb-at-pruefer` ergaenzt.

### Skill `allgemein`
- Skill-Tabelle in Sektion 5: aussagekraeftige Beschreibung statt Trunkierung; neue Spalte `Erwarteter Output`.
- Neuer Block `Routing-Faustregel` mit vier konkreten Weiterleitungen.

### Version
- `methodenlehre-buergerliches-recht/.claude-plugin/plugin.json` und `.claude-plugin/marketplace.json` auf `42.1.0`. Description und Slug unveraendert.

### Validatoren
Alle gruen \u2014 validate-plugin-structure OK, validate-yaml-frontmatter 0/0, welle5-komma-check 0 Treffer.