### PR TITLE
fix: Codex-Findings zu FZulG-Auftragsforschung und Russland-Suspendierung

### DIFF
--- a/forschungszulage-antragstellung/skills/fz-bemessungsgrundlage-2026/SKILL.md
+++ b/forschungszulage-antragstellung/skills/fz-bemessungsgrundlage-2026/SKILL.md
@@ -25,7 +25,7 @@ Stand 2026 — alle Zahlen vom Antragsteller mit aktueller Gesetzesfassung und B
 | --- | --- | --- |
 | Eigene FuE-Personalkosten | Bruttolohn + Arbeitgeberanteil zur Sozialversicherung + Altersvorsorge | nur FuE-Anteil je Mitarbeiter |
 | Eigenleistung Einzelunternehmer/persönlich tätiger Gesellschafter | ab 2026 pauschal 100 Euro je Arbeitsstunde | max. 40 Stunden je Woche |
-| Auftragsforschung | 70 Prozent der Kosten | nur EU/EWR oder Wissenschaftseinrichtung; klare Leistungsbeschreibung |
+| Auftragsforschung | 70 Prozent der Kosten | Auftragnehmer (Unternehmen oder Wissenschaftseinrichtung) muss in EU/EWR ansaessig sein; klare Leistungsbeschreibung |
 | Wirtschaftsgüter | AfA, soweit dem FuE-Vorhaben zuordenbar | bewegliche abnutzbare Wirtschaftsgüter des Anlagevermögens |
 | Gemein- und Betriebskosten | pauschal 20 Prozent der übrigen förderfähigen Aufwendungen | nur für Vorhaben mit Beginn nach 31.12.2025 |
 
@@ -75,7 +75,7 @@ FuE-Anteil ist der dokumentierte Zeitanteil aus der Stundenaufzeichnung. Pauscha
 ### Auftragsforschung — die 70-Prozent-Regel
 
 - Förderfähig nur 70 Prozent der Kosten.
-- Auftragnehmer muss in EU/EWR ansässig sein oder Wissenschaftseinrichtung.
+- Auftragnehmer muss in EU/EWR ansässig sein — das gilt für Unternehmen und für Wissenschaftseinrichtungen gleichermaßen (eine außerhalb EU/EWR ansässige Forschungseinrichtung ist nicht förderfähig; vgl. `references/forschungszulage-quellen-und-zahlen.md` sowie die Ablehnungsgründe in `fz-ablehnung-nachbesserung-einspruch`).
 - **Klare Leistungsabgrenzung im Vertrag.** Wer was wann mit welchem Ziel.
 - Subunternehmer des Auftragnehmers werden mitgeprüft.
 - Verbundene Unternehmen sind kritisch — die BSFZ und das Finanzamt prüfen genau, ob es sich nicht doch um eigene FuE im Konzern handelt.

--- a/steuerrecht-anwalt-und-berater/skills/stb-dba-quellensteuer-atlas-weltweit/SKILL.md
+++ b/steuerrecht-anwalt-und-berater/skills/stb-dba-quellensteuer-atlas-weltweit/SKILL.md
@@ -96,7 +96,7 @@ Quellensteuerfragen sind schnell falsch, weil DBA-Sätze, nationale Abzugsregeln
 - **Brasilien**: technische Dienstleistungen oft als Lizenz qualifiziert (15 Prozent Quellensteuer); national Auslegungs-Praxis weitreichend.
 - **Indien**: Equalisation Levy auf digitale Dienste (eigene Pruefung), Service-PE-Tatbestand.
 - **China**: Service-PE bei 6 Monaten Anwesenheit; eigene Quellensteuer-Verfahren mit lokalen Bescheinigungen.
-- **Russland**: DBA seit 30.12.2023 suspendiert — keine BZSt-Entlastung.
+- **Russland**: DBA-Anwendung ab 01.01.2024 in voller Reichweite suspendiert (konsolidierter BMF-Stand 15.01.2024 und Wirkung der StAbwV-Listung) — keine BZSt-Entlastung mehr. Altvorgaenge bis 07.08.2023 mit vollem DBA-Schutz; Uebergangszeitraum 08.08.2023 bis 31.12.2023 sorgfaeltig pruefen (Details in `stb-dba-russland-suspendierung-2024`).
 - **VAE**: DBA seit 01.01.2022 ausser Kraft — kein Schutz.
 - **Hong Kong**: eigenes DBA (2003) — nicht CN-DBA anwenden.
 - **USA**: LOB-Klausel zusaetzlich zum PPT — eigenstaendiger Anti-Missbrauchstest.


### PR DESCRIPTION
## Codex-Findings

Zwei P2-Findings aus dem letzten Boost-Review umgesetzt:

### 1. `fz-bemessungsgrundlage-2026` — EU/EWR-Pflicht bei Auftragsforschung

**Problem:** Tabelle und Detailabschnitt formulierten "nur EU/EWR oder Wissenschaftseinrichtung". Das `oder` ließ sich so verstehen, als seien Wissenschaftseinrichtungen aus Drittstaaten förderfähig. Tatsächlich verlangt das FZulG, dass der **Auftragnehmer in EU/EWR ansässig** ist — unabhängig davon, ob es sich um ein Unternehmen oder eine Wissenschaftseinrichtung handelt. Bestätigt durch:
- `forschungszulage-antragstellung/references/forschungszulage-quellen-und-zahlen.md:24` ("innerhalb EU/EWR")
- `fz-ablehnung-nachbesserung-einspruch/SKILL.md:42` (außerhalb EU/EWR = Ablehnungsgrund)

**Fix:** Tabelle und Detailabschnitt umformuliert; Querverweis auf die maßgeblichen Referenzdateien.

### 2. `stb-dba-quellensteuer-atlas-weltweit` — Russland-Suspendierung mit Übergangszeitraum

**Problem:** Atlas-Skill hatte hartkodiert "DBA seit 30.12.2023 suspendiert", was bei Vorgängen am 30./31.12.2023 zu vorschnellem Entzug des DBA-Schutzes geführt hätte. Der dedizierte `stb-dba-russland-suspendierung-2024/SKILL.md:115` formuliert differenzierter: volle Wirkung ab 01.01.2024, Altvorgänge bis 07.08.2023 mit DBA-Schutz, Übergangszeitraum 08.08.2023 bis 31.12.2023 sorgfältig prüfen.

**Fix:** Atlas-Eintrag konsistent zum dedizierten Russland-Skill formuliert, mit Verweis darauf.

## Test plan

- [x] Validator `node scripts/validate-plugin-structure.mjs` → OK
- [ ] FZulG-Auftragsforschung im Mandat: Auftragnehmer-Domizil bewusst prüfen
- [ ] Russland-Vorgänge zwischen 08.08.2023 und 31.12.2023: dedizierter Skill statt Atlas-Shortcut

https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL

---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_