### PR TITLE
fix(testakten): CSV-Quoting in 9 Dateien fuer parsbare Strukturdaten

### DIFF
--- a/testakten/beispielakte-edelholz-berlin/04_offene_posten/opos_debitoren_30042026.csv
+++ b/testakten/beispielakte-edelholz-berlin/04_offene_posten/opos_debitoren_30042026.csv
@@ -5,7 +5,7 @@ RE-2026-0094;Privat: Bach/Wieland;02.04.2026;02.05.2026;12480,00;0;05.05.2026;Ei
 RE-2026-0098;Senatsverwaltung Bildung;05.04.2026;05.06.2026;31200,00;0;08.06.2026;Möblierung Schule Pankow (60-Tage-Ziel)
 RE-2026-0101;Privat: Hentschel/Vargas;11.04.2026;11.05.2026;7240,00;0;13.05.2026;Garderobe + Sideboard
 RE-2026-0103;Cafe Lichtfels;14.04.2026;14.05.2026;5860,00;0;18.05.2026;Theke Erweiterung
-RE-2026-0106;Hotel Lützowufer GmbH;18.04.2026;18.05.2026;38400,00;0;28.07.2026;Teilrechnung Suiten 4./5. OG; Zahlung nach Lieferung KW 28
+RE-2026-0106;Hotel Lützowufer GmbH;18.04.2026;18.05.2026;38400,00;0;28.07.2026;"Teilrechnung Suiten 4./5. OG; Zahlung nach Lieferung KW 28"
 RE-2026-0108;Anwaltskanzlei Bredow & Kollegen;22.04.2026;22.05.2026;14620,00;0;25.05.2026;Empfang + Konferenzraum
 RE-2026-0111;Privat: Liebrecht;25.04.2026;25.05.2026;6890,00;0;27.05.2026;Eichen-Esstisch Sondermaß
 RE-2026-0113;Senatsverwaltung Bildung;28.04.2026;28.06.2026;18750,00;0;01.07.2026;Schlussrechnung Schule Pankow
@@ -13,4 +13,4 @@ RE-2026-0115;Privat: Görlitz/Aydin;29.04.2026;29.05.2026;9420,00;0;01.06.2026;S
 RE-2025-0421;Bauträger Spreequartier GmbH;03.11.2025;03.12.2025;28640,00;3;30.06.2026;DISPUTE: Nachbesserung strittig, Mahnverfahren droht
 RE-2025-0438;Restaurant Glasperlenspiel;18.12.2025;17.01.2026;14380,00;2;15.06.2026;1. Mahnung 12.02., 2. Mahnung 11.03. – Kunde stundet bis Juni
 RE-2026-0067;Privat: Saalfeld;08.02.2026;10.03.2026;4220,00;2;15.05.2026;in Klärung, Mängelrüge
-Summe;;;;;;250470,00;
+Summe;;;;250470,00;;;

--- a/testakten/beispielakte-edelholz-berlin/04_offene_posten/opos_kreditoren_30042026.csv
+++ b/testakten/beispielakte-edelholz-berlin/04_offene_posten/opos_kreditoren_30042026.csv
@@ -20,4 +20,4 @@ ER-2026-0341;Lohnabrechnung April (Lohn an MA);28.04.2026;05.05.2026;52780,00;0;
 ER-2026-0344;Hettich Beschläge GmbH;28.04.2026;28.05.2026;4720,00;0;Beschläge Senatsverwaltung
 ER-2026-0349;Vermögensanlagen Korbach (Gesellschafterdarlehen);01.04.2026;laufend;25000,00;0;Tilgungsrate Q2 (Darlehen 120 TEUR ohne Rangrücktritt)
 ER-2026-0352;Sparkasse Kontokorrent Zinsen Q1;30.04.2026;15.05.2026;2940,00;0;Q1 Sollzinsen
-Summe;;;;;;217180,00;
+Summe;;;;217180,00;;

--- a/testakten/betreuung-schmalfeld-kontodaten-vertraege/02_ordentliche_dauerpositionen.csv
+++ b/testakten/betreuung-schmalfeld-kontodaten-vertraege/02_ordentliche_dauerpositionen.csv
@@ -11,4 +11,3 @@ Telekommunikation,Telekom Deutschland,ca. 54.00,monatlich,Vertrag,notwendige Kom
 Haftpflicht,Allianz,klein,jährlich,Police,plausible Absicherung
 Hausrat,HUK,klein,jährlich,Police,plausible Absicherung
 Wohngebäude,Provinzial,klein,jährlich,Police,für Immobilie plausibel
-

--- a/testakten/betreuung-schmalfeld-kontodaten-vertraege/03_verdaechtige_transaktionen.csv
+++ b/testakten/betreuung-schmalfeld-kontodaten-vertraege/03_verdaechtige_transaktionen.csv
@@ -24,4 +24,3 @@ Datum,Empfänger,Betrag_EUR,Kategorie,Risiko,Erstmaßnahme
 2023-02-04,NKL Nordwestdeutsche Klassenlotterie,218.74,lottery,mittel,Wunsch und Kündigung prüfen
 2025-09-06,NKL Nordwestdeutsche Klassenlotterie,210.52,lottery,mittel,SEPA-Mandat prüfen
 2025-07-05,Svetlana Petrova,500.00,private-care,mittel,Leistungsnachweis und Vertrag anfordern
-

--- a/testakten/betreuung-schmalfeld-kontodaten-vertraege/04_vertragsregister_schmalfeld.csv
+++ b/testakten/betreuung-schmalfeld-kontodaten-vertraege/04_vertragsregister_schmalfeld.csv
@@ -11,4 +11,3 @@ Rechnung SeniorenWohl,SeniorenWohl Handels GmbH,2024-05-15,1428.00 EUR netto,Ein
 Rechnung ThermoVital,ThermoVital Wärmesysteme GmbH,2024-08-08,4329.01 EUR brutto,Einzelkauf,hochpreisiges Gesundheits-/Wärmeprodukt,Bedarf und Lieferung prüfen
 Rechnung SafeGold,SafeGold Edelmetallhandel GmbH,2024-06-03,2919.90 EUR,Einzelkauf,Edelmetallanlage,Lieferung und Verwahrung prüfen
 Rechnung Diamanten Kontor,Diamanten Kontor Hamburg GmbH,2024-09-15,4719.00 EUR,Einzelkauf,Diamant als Anlage,Echtheit und Rückgabe prüfen
-

--- a/testakten/grosskanzlei-corporate-ma-datenraum/06_tabellenreview/review_grid.csv
+++ b/testakten/grosskanzlei-corporate-ma-datenraum/06_tabellenreview/review_grid.csv
@@ -9,7 +9,7 @@ C-007,Lieferant G,Zuliefervertrag,14.09.2025,no,n/a,6 Monate,nein,500.000 EUR,ja
 C-008,Kunde H,Rahmenvertrag,31.05.2026,no,n/a,12 Monate,nein,1x Jahresumsatz,ja,Deutsch,niedrig,section 9,Keine Sonderklausel,
 C-009,Kunde I,Liefervertrag PDS-500,28.02.2027,bedingt (>25%),45d,6 Monate,nein,250.000 EUR,nein,Deutsch,mittel,section 13(1),Garantie Seller: keine CoC-Kuendigung ausgeloest; Consent-Optierung moeglich,Schwelle 25% ist niedriger als bei C-003; aufmerksam bleiben
 C-010,SCare J,Servicevertrag S-Care,31.12.2027,no,n/a,3 Monate,nein,uncapped (Koerperschaftsschaden),ja,Deutsch,niedrig,section 5,Uncapped-Klausel fuer Koerperschaftsschaden monitoren,Sammelvertrag; einzelne Kunden nicht namentlich benannt
-C-011,IT-DL K,IT-Servicevertrag,31.12.2024 (Opt.),bedingt,30d,1 Monat,nein,100.000 EUR/Monat,nein,Deutsch,mittel (TSA),TSA-Entwurf fuer IT erforderlich,Laeuft Ende 2024 aus; Verlaengerungsoption muss aktiv gezogen werden; TSA-Kandidat
+C-011,IT-DL K,IT-Servicevertrag,31.12.2024 (Opt.),bedingt,30d,1 Monat,nein,100.000 EUR/Monat,nein,Deutsch,mittel (TSA),TSA-Entwurf fuer IT erforderlich,"Laeuft Ende 2024 aus; Verlaengerungsoption muss aktiv gezogen werden; TSA-Kandidat",
 C-012,Kunde L,Rahmenvertrag,31.08.2025,no,n/a,12 Monate,nein,1x Jahresumsatz,ja,Deutsch,niedrig,section 9,Keine Sonderklausel,Post-Closing Renewal zu adressieren
 TSA-IT,Holding / IT-Service,TSA Entwurf,18 Monate post-Closing,n/a,n/a,3 Monate,n/a,500.000 EUR,nein,Deutsch,mittel,n/a,TSA-Konditionen marktgerecht pruefen; Step-down-Plan erforderlich,Entwurf erhalten 5.12.2024; Kommentierung bis 12.12.2024
 TSA-HR,Holding / HR-Service,TSA Entwurf,12 Monate post-Closing,n/a,n/a,1 Monat,n/a,250.000 EUR,nein,Deutsch,niedrig,n/a,Personaluebergang § 613a beachten,

--- a/testakten/insolvenzplan-starug-planwerkstatt-metallbau-hansa/18_planvollzug_kalender.csv
+++ b/testakten/insolvenzplan-starug-planwerkstatt-metallbau-hansa/18_planvollzug_kalender.csv
@@ -12,35 +12,35 @@ Datum,Meilenstein,Kategorie,Verantwortlich,Nachweis,Status,Abhaengigkeit,Puffer_
 2026-06-05,Sicherheitengutachten Brandt endgueltiger Entwurf,Bewertung,SV Brandt,14_sicherheitenbewertung.md,erledigt,,3,Abschlussversion bis 10.06.2026
 2026-06-05,Gruppen-/Klassenentwurf fertiggestellt,Plan,RA Westphal,10_gruppen_klassen_entwurf.md,erledigt,,0,
 2026-06-09,Steuer- und SV-Risiken-Memo,Analyse,StB Dresen,13_steuer_sv_risiken.md,erledigt,,0,
-2026-06-10,Sicherheitengutachten Brandt finalisiert,Bewertung,SV Brandt,Gutachten PDF Anlage 3,offen,,2026-06-05,0,
-2026-06-12,Rechtsgutachten Globalzession Prioritaet (Müller & Fischer),Recht,RA Westphal,Rechtsgutachten,offen,,2026-06-09,0,Kritisch fuer Cram-Down-Vorbereitung
-2026-06-12,Vergleichsrechnung: Uebertragungsszenario ergaenzt,Plan,CFO Hollender,09_vergleichsrechnung_arbeitsstand.csv,offen,,2026-06-10,1,Red-Team-Einwand Nr. 1 schliessen
-2026-06-13,Mandantengespräch Verfahrenswahl finale Entscheidung,Mandat,GF Reimers / RA Westphal,Entscheidungsprotokoll,offen,,2026-06-12,0,Ergebnis: Insolvenzplan Eigenverwaltung (Option B)
-2026-06-14,Buchholz Retention-Bonus Gespräch und Vertrag,Personal,GF Petersen,Vereinbarung Buchholz,offen,,2026-06-13,0,
-2026-06-14,Verzichtserklarung Gesellschafterdarlehen (notariell),Plan,RA Westphal / M. Roensberg,Notarielle Erklarung,offen,,2026-06-13,0,Beurkundung Notar Dr. Schroeder Hamburg
-2026-06-14,Commitment Letter Investor Nordlicht (500 TEUR Konventionalstrafe),Finanzierung,RA Westphal,Commitment Letter,offen,,2026-06-13,1,
-2026-06-15,Betriebsrat-Unterrichtung § 111 BetrVG,Kommunikation,GF Reimers,Protokoll BR-Sitzung,offen,,2026-06-13,0,
-2026-06-15,Briefe an NordBank / LeasingWerk / Stahlhandel Kuefte,Kommunikation,RA Westphal,Briefe + Nachweisversand,offen,,2026-06-14,0,
-2026-06-15,Glaeubigerausschuss-Kandidaten benennen,Prozess,RA Westphal,Benennung an Gericht,offen,,2026-06-14,0,
-2026-06-15,Masseplan (Massesicherungsplan) finalisiert,Plan,CFO Hollender,Masseplan Excel,offen,,2026-06-12,1,
-2026-06-16,Insolvenzantrag und Eigenverwaltungsantrag beim AG Hamburg,Gericht,RA Westphal,Antragsschrift + Anlagen,offen,,alle vorherigen,0,KRITISCHER PFAD; Gebuehrenvorschuss 5000 EUR vorab
-2026-06-16,Planentwurf (darstellend + gestaltend) eingereicht,Plan,RA Westphal,Plan-PDF + DOCX,offen,,2026-06-16,0,
-2026-06-17,Anordnung vorläufige Eigenverwaltung erwartet (AG Hamburg),Gericht,Gericht,Beschluss,offen,,2026-06-16,3,
-2026-06-19,Datenraum vollstaendig und gesichert,Analyse,CFO Hollender / RA Westphal,Datenraumprotokoll,offen,,2026-06-17,0,
-2026-06-23,Glaeubigerversammlung / Eruterungstermin (Termin voraussichtlich),Gericht,Gericht / RA Westphal,Protokoll Versammlung,offen,,2026-06-17,7,Termin muss Gericht festsetzen; erfahrungsgemäss 1-2 Wochen nach Eroeffnung
-2026-06-25,Insolvenzgeldsicherung Lohn Juni (bei Insolvenzeroeffnung),Personal,CFO Hollender / BA,Insolvenzgeld-Antrag,offen,,2026-06-17,0,Bundesagentur fuer Arbeit; Vorschuss moeglich
-2026-07-01,Abstimmungstermin (Planentwurf vorgelegt),Gericht,RA Westphal / Sachwalter,Abstimmungsprotokoll,offen,,2026-06-23,7,Nein-Stimmen NordBank + ggf Gruppe 3; Cram-Down beantragt
-2026-07-15,Planbestaetigung durch AG Hamburg erwartet (§ 248 InsO),Gericht,Gericht,Bestaetungsbeschluss,offen,,2026-07-01,14,
-2026-07-20,Ausfertigung Planbestaetigung + Rechtsmittelfrist laeuft,Recht,RA Westphal,Ausfertigung + Fristnotiz,offen,,2026-07-15,5,Beschwerdefrist 2 Wochen gem § 253 InsO
-2026-08-04,Rechtskraft der Planbestaetigung (wenn keine Beschwerde),Recht,Gericht,Rechtskraftbescheinigung,offen,,2026-07-20,0,MAC-Risiko: NordBank koennte Beschwerde einlegen
-2026-08-07,Investor Tranche 1 (900 TEUR) Auszahlung bei Planannahme,Finanzierung,Nordlicht / CFO,Kontoeingang,offen,,2026-08-04,3,
-2026-08-14,Erste Planraten an Gruppen 2 (40%) und Kleinglaeubigerklasse (75%),Planvollzug,Treuhander,Zahlungsnachweise,offen,,2026-08-07,7,
-2026-08-14,Eigentumsvorbehalts-Abgeltung Stahlhandel Kuefte (480 TEUR),Planvollzug,Treuhander / CFO,Zahlungsnachweis,offen,,2026-08-07,0,
-2026-09-01,Audit DIN EN 1090-2 EXC 3 Verlängerung (DQS GmbH),Betrieb,GF Petersen / Buchholz,Zertifikat neu,offen,,2026-08-14,0,KRITISCH; Zertifikat gueltig bis 30.09.2026
-2026-09-30,DIN EN 1090-2 Zertifikat Verlängerung erwartet,Betrieb,DQS GmbH,Zertifikat,offen,,2026-09-01,0,
-2026-10-01,Investor Tranche 2 (500 TEUR) Auszahlung nach Rechtskraft,Finanzierung,Nordlicht / CFO,Kontoeingang,offen,,2026-08-04,0,
-2026-10-15,Zweite Planraten Gruppe 4 (FA Hamburg Erstrate),Planvollzug,Treuhander,Zahlungsnachweis,offen,,2026-10-01,0,
-2026-12-31,Erster Jahresabschluss nach Planvollzug (2026 geprueft),Reporting,StB Dresen / WP,Jahresabschluss testiert,offen,,2026-10-01,0,
-2027-02-15,Zweite Rate Gruppe 2 (20%) und Gruppe 3 Restrate,Planvollzug,Treuhander,Zahlungsnachweise,offen,,2026-08-04,0,12 Monate nach Rechtskraft
-2028-08-04,Ende Planüberwachung (24 Monate nach Rechtskraft),Planvollzug,Treuhander,Abschlussbericht,offen,,2026-08-04,0,
-2030-08-07,Investor-Darlehen Rueckzahlung (Bullet 1.4 Mio + Zinsen),Finanzierung,CFO,Zahlungsnachweis,offen,,2028-08-04,0,48 Monate nach Auszahlung Tranche 1
+2026-06-10,Sicherheitengutachten Brandt finalisiert,Bewertung,SV Brandt,Gutachten PDF Anlage 3,offen,2026-06-05,0,
+2026-06-12,Rechtsgutachten Globalzession Prioritaet (Müller & Fischer),Recht,RA Westphal,Rechtsgutachten,offen,2026-06-09,0,Kritisch fuer Cram-Down-Vorbereitung
+2026-06-12,Vergleichsrechnung: Uebertragungsszenario ergaenzt,Plan,CFO Hollender,09_vergleichsrechnung_arbeitsstand.csv,offen,2026-06-10,1,Red-Team-Einwand Nr. 1 schliessen
+2026-06-13,Mandantengespräch Verfahrenswahl finale Entscheidung,Mandat,GF Reimers / RA Westphal,Entscheidungsprotokoll,offen,2026-06-12,0,Ergebnis: Insolvenzplan Eigenverwaltung (Option B)
+2026-06-14,Buchholz Retention-Bonus Gespräch und Vertrag,Personal,GF Petersen,Vereinbarung Buchholz,offen,2026-06-13,0,
+2026-06-14,Verzichtserklarung Gesellschafterdarlehen (notariell),Plan,RA Westphal / M. Roensberg,Notarielle Erklarung,offen,2026-06-13,0,Beurkundung Notar Dr. Schroeder Hamburg
+2026-06-14,Commitment Letter Investor Nordlicht (500 TEUR Konventionalstrafe),Finanzierung,RA Westphal,Commitment Letter,offen,2026-06-13,1,
+2026-06-15,Betriebsrat-Unterrichtung § 111 BetrVG,Kommunikation,GF Reimers,Protokoll BR-Sitzung,offen,2026-06-13,0,
+2026-06-15,Briefe an NordBank / LeasingWerk / Stahlhandel Kuefte,Kommunikation,RA Westphal,Briefe + Nachweisversand,offen,2026-06-14,0,
+2026-06-15,Glaeubigerausschuss-Kandidaten benennen,Prozess,RA Westphal,Benennung an Gericht,offen,2026-06-14,0,
+2026-06-15,Masseplan (Massesicherungsplan) finalisiert,Plan,CFO Hollender,Masseplan Excel,offen,2026-06-12,1,
+2026-06-16,Insolvenzantrag und Eigenverwaltungsantrag beim AG Hamburg,Gericht,RA Westphal,Antragsschrift + Anlagen,offen,alle vorherigen,0,KRITISCHER PFAD; Gebuehrenvorschuss 5000 EUR vorab
+2026-06-16,Planentwurf (darstellend + gestaltend) eingereicht,Plan,RA Westphal,Plan-PDF + DOCX,offen,2026-06-16,0,
+2026-06-17,Anordnung vorläufige Eigenverwaltung erwartet (AG Hamburg),Gericht,Gericht,Beschluss,offen,2026-06-16,3,
+2026-06-19,Datenraum vollstaendig und gesichert,Analyse,CFO Hollender / RA Westphal,Datenraumprotokoll,offen,2026-06-17,0,
+2026-06-23,Glaeubigerversammlung / Eruterungstermin (Termin voraussichtlich),Gericht,Gericht / RA Westphal,Protokoll Versammlung,offen,2026-06-17,7,Termin muss Gericht festsetzen; erfahrungsgemäss 1-2 Wochen nach Eroeffnung
+2026-06-25,Insolvenzgeldsicherung Lohn Juni (bei Insolvenzeroeffnung),Personal,CFO Hollender / BA,Insolvenzgeld-Antrag,offen,2026-06-17,0,Bundesagentur fuer Arbeit; Vorschuss moeglich
+2026-07-01,Abstimmungstermin (Planentwurf vorgelegt),Gericht,RA Westphal / Sachwalter,Abstimmungsprotokoll,offen,2026-06-23,7,Nein-Stimmen NordBank + ggf Gruppe 3; Cram-Down beantragt
+2026-07-15,Planbestaetigung durch AG Hamburg erwartet (§ 248 InsO),Gericht,Gericht,Bestaetungsbeschluss,offen,2026-07-01,14,
+2026-07-20,Ausfertigung Planbestaetigung + Rechtsmittelfrist laeuft,Recht,RA Westphal,Ausfertigung + Fristnotiz,offen,2026-07-15,5,Beschwerdefrist 2 Wochen gem § 253 InsO
+2026-08-04,Rechtskraft der Planbestaetigung (wenn keine Beschwerde),Recht,Gericht,Rechtskraftbescheinigung,offen,2026-07-20,0,MAC-Risiko: NordBank koennte Beschwerde einlegen
+2026-08-07,Investor Tranche 1 (900 TEUR) Auszahlung bei Planannahme,Finanzierung,Nordlicht / CFO,Kontoeingang,offen,2026-08-04,3,
+2026-08-14,Erste Planraten an Gruppen 2 (40%) und Kleinglaeubigerklasse (75%),Planvollzug,Treuhander,Zahlungsnachweise,offen,2026-08-07,7,
+2026-08-14,Eigentumsvorbehalts-Abgeltung Stahlhandel Kuefte (480 TEUR),Planvollzug,Treuhander / CFO,Zahlungsnachweis,offen,2026-08-07,0,
+2026-09-01,Audit DIN EN 1090-2 EXC 3 Verlängerung (DQS GmbH),Betrieb,GF Petersen / Buchholz,Zertifikat neu,offen,2026-08-14,0,KRITISCH; Zertifikat gueltig bis 30.09.2026
+2026-09-30,DIN EN 1090-2 Zertifikat Verlängerung erwartet,Betrieb,DQS GmbH,Zertifikat,offen,2026-09-01,0,
+2026-10-01,Investor Tranche 2 (500 TEUR) Auszahlung nach Rechtskraft,Finanzierung,Nordlicht / CFO,Kontoeingang,offen,2026-08-04,0,
+2026-10-15,Zweite Planraten Gruppe 4 (FA Hamburg Erstrate),Planvollzug,Treuhander,Zahlungsnachweis,offen,2026-10-01,0,
+2026-12-31,Erster Jahresabschluss nach Planvollzug (2026 geprueft),Reporting,StB Dresen / WP,Jahresabschluss testiert,offen,2026-10-01,0,
+2027-02-15,Zweite Rate Gruppe 2 (20%) und Gruppe 3 Restrate,Planvollzug,Treuhander,Zahlungsnachweise,offen,2026-08-04,0,12 Monate nach Rechtskraft
+2028-08-04,Ende Planüberwachung (24 Monate nach Rechtskraft),Planvollzug,Treuhander,Abschlussbericht,offen,2026-08-04,0,
+2030-08-07,Investor-Darlehen Rueckzahlung (Bullet 1.4 Mio + Zinsen),Finanzierung,CFO,Zahlungsnachweis,offen,2028-08-04,0,48 Monate nach Auszahlung Tranche 1

--- a/testakten/legistik-pflichtpostfach/eingang/synopse.csv
+++ b/testakten/legistik-pflichtpostfach/eingang/synopse.csv
@@ -2,4 +2,4 @@ Geltendes Recht;Aenderung nach Entwurf;Begruendung
 HGB § 33 (Eintragung von Aenderungen);HGB § 33 unveraendert. Neu eingefuegt § 33a Pflichtpostfach: 'Im Handelsregister eingetragene Gesellschaften und ihre inlaendischen Zweigniederlassungen halten ein Pflichtpostfach nach dem Pflichtpostfachgesetz vor.';Verankerung im Stammgesetz HGB sichert die Pflicht fuer alle HReg-Eintragungspflichtigen.
 ZPO § 130d Satz 1 (Pflicht zur elektronischen Uebermittlung durch Rechtsanwaelte etc.);ZPO § 130d Satz 2 neu: 'Verpflichtete im Sinne des § 1 des Pflichtpostfachgesetzes sind zur Zustellung an ihr Pflichtpostfach verpflichtet.';Verfahrensseite der Pflicht.
 FamFG § 14 Absatz 4 (elektronische Akte);Einfuegung '§ 1 des Pflichtpostfachgesetzes bleibt unberuehrt';Klarstellung fuer FreiwGB-Verfahren.
-DSA Artikel 33 (VLOP/VLOSE-Kriterien);Keine Aenderung; Verweis im PflPostG § 1 Absatz 1 Nummer 2;Direktanknuepfung an Unionsrecht vermeidet Goldplating.
+DSA Artikel 33 (VLOP/VLOSE-Kriterien);"Keine Aenderung; Verweis im PflPostG § 1 Absatz 1 Nummer 2";Direktanknuepfung an Unionsrecht vermeidet Goldplating.

--- a/testakten/vertragsausfueller-bsag-kiosk-huckelriede/01_feldinventar_bsag.csv
+++ b/testakten/vertragsausfueller-bsag-kiosk-huckelriede/01_feldinventar_bsag.csv
@@ -1,7 +1,7 @@
 Feld,Quelle,Wert,Einfügeort,Pflichtfeld,Vertrauensgrad,Rückfrage,Freigabe
 Mieter Name,Term Sheet,Scherflein GmbH,Parteienrubrum,ja,hoch,,offen
 Mietobjekt Adresse,Term Sheet,Huckelriede / Niedersachsendamm 28201 Bremen,§ 1.1,ja,hoch,,offen
-Nebenkosten,Term Sheet,230,00 EUR,§ 3.2,ja,hoch,,offen
-Kaution,Term Sheet,2.475,00 EUR,§ 3.5,ja,hoch,Kaution gegen Kaltmiete prüfen,offen
+Nebenkosten,Term Sheet,"230,00 EUR",§ 3.2,ja,hoch,,offen
+Kaution,Term Sheet,"2.475,00 EUR",§ 3.5,ja,hoch,Kaution gegen Kaltmiete prüfen,offen
 Mietbeginn,Term Sheet,01.10.2026,§ 2.1,ja,hoch,,offen
 Laufzeit,Term Sheet,5 Jahre bis 30.09.2031,§ 2.1,ja,hoch,,offen


### PR DESCRIPTION
## Was

Codex-Audit zu PR #165 monierte unquotierte Kommas im Belege-Feld von `meinungspruefer-grenzfaelle-alltag/12_zeitachse_aeusserungen.csv` (Rupprecht-Zeile). Im finalen Merge-Stand bereits korrekt quotiert.

Vollscan aller 87 CSVs in `testakten/` mit korrektem Delimiter-Auto-Detect deckte **9 weitere Parsing-Probleme** auf:

| Datei | Problem | Fix |
|---|---|---|
| vertragsausfueller-bsag-kiosk-huckelriede/01_feldinventar_bsag.csv | 2 Geldbetraege mit Komma unquoted | Quotes ergaenzt |
| insolvenzplan-starug-planwerkstatt-metallbau-hansa/18_planvollzug_kalender.csv | 32 Zeilen mit zusaetzlichem leeren Feld | Spalte entfernt, einheitlich 9 |
| legistik-pflichtpostfach/eingang/synopse.csv | Wert mit Semikolon unquoted | Quotes ergaenzt |
| grosskanzlei-corporate-ma-datenraum/06_tabellenreview/review_grid.csv | C-011 mit 14 statt 15 Spalten | Kommentar quotiert + Spalte ergaenzt |
| betreuung-schmalfeld-kontodaten-vertraege/02/03/04 | trailing Leerzeilen | bereinigt |
| beispielakte-edelholz-berlin/04_offene_posten/opos_kreditoren_30042026.csv | Summen-Zeile in falscher Spalte | korrigiert |
| beispielakte-edelholz-berlin/04_offene_posten/opos_debitoren_30042026.csv | Bemerkung mit Semikolon + Summen-Zeile | quotiert + korrigiert |

## Verifikation
Vorher: 9 CSV-Dateien mit Spaltenanzahl-Mismatch.
Nachher: **Alle 87 testakten-CSVs parsen konsistent** mit `csv.reader`.

## Validatoren
- `validate-plugin-structure` OK
- `validate-yaml-frontmatter` 0 Fehler, 0 Warnungen
- `validate-testakten-gesamt-pdf` OK (127 Testakten)