### PR TITLE
docs(v54): READMEs vollständig + alphabetisch, Dublette in agb-recht-pruefer entfernt

### DIFF
--- a/agb-recht-pruefer/README.md
+++ b/agb-recht-pruefer/README.md
@@ -290,8 +290,3 @@ Automatisch generierte Komplett-Liste aller 200 Skills in diesem Plugin. Beschre
 | `zahlungsverzug-mahnkosten` | Klausel-Spezialskill für Zahlungsverzug Mahnkosten: prüft, redlined und entwirft die Klausel mit Risikoampel, Verbraucher-/B2B-Unterscheidung und praxistauglicher Ersatzfassung. |
 
 <!-- END SKILLS-OVERVIEW (auto-generated) -->
-iken des Vertragstyps und erzeugt Klauselarchitektur, Red Flags und bessere Bedingungen. |
-| `zahlungsmittel-chargeback` | Klausel-Spezialskill für Zahlungsmittel Chargeback: prüft, redlined und entwirft die Klausel mit Risikoampel, Verbraucher-/B2B-Unterscheidung und praxistauglicher Ersatzfassung. |
-| `zahlungsverzug-mahnkosten` | Klausel-Spezialskill für Zahlungsverzug Mahnkosten: prüft, redlined und entwirft die Klausel mit Risikoampel, Verbraucher-/B2B-Unterscheidung und praxistauglicher Ersatzfassung. |
-
-<!-- END SKILLS-OVERVIEW (auto-generated) -->

--- a/skills-index/README.md
+++ b/skills-index/README.md
@@ -1,6 +1,6 @@
 # Skills-Index: Detailseiten pro Plugin
 
-Eine Detailseite pro Plugin mit allen Skills, Beschreibungen und Einzel-Downloads. Stand: `v53.6.0`.
+Eine Detailseite pro Plugin mit allen Skills, Beschreibungen und Einzel-Downloads. Stand: `v54.0.0`.
 
 Die Aufteilung verhindert, dass GitHubs Markdown-Renderer bei 2600+ Tabellenzeilen abstuerzt oder die Seite endlos neu laedt.
 

--- a/skills-index/agb-recht-pruefer.md
+++ b/skills-index/agb-recht-pruefer.md
@@ -1,6 +1,6 @@
 # agb-recht-pruefer
 
-**200 Skills** · Stand `v53.6.0`
+**200 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/agb-recht-pruefer/README.md)

--- a/skills-index/aktenaufbereiter-strafrecht.md
+++ b/skills-index/aktenaufbereiter-strafrecht.md
@@ -1,6 +1,6 @@
 # aktenaufbereiter-strafrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/aktenaufbereiter-strafrecht/README.md)

--- a/skills-index/aktenauszug-gerichtsverfahren.md
+++ b/skills-index/aktenauszug-gerichtsverfahren.md
@@ -1,6 +1,6 @@
 # aktenauszug-gerichtsverfahren
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/aktenauszug-gerichtsverfahren/README.md)

--- a/skills-index/anlagen-zu-schriftsaetzen.md
+++ b/skills-index/anlagen-zu-schriftsaetzen.md
@@ -1,6 +1,6 @@
 # anlagen-zu-schriftsaetzen
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/anlagen-zu-schriftsaetzen/README.md)

--- a/skills-index/arbeitsrecht.md
+++ b/skills-index/arbeitsrecht.md
@@ -1,6 +1,6 @@
 # arbeitsrecht
 
-**81 Skills** · Stand `v53.6.0`
+**81 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/arbeitsrecht/README.md)

--- a/skills-index/arbeitszeugnis-analyse.md
+++ b/skills-index/arbeitszeugnis-analyse.md
@@ -1,6 +1,6 @@
 # arbeitszeugnis-analyse
 
-**50 Skills** · Stand `v53.6.0`
+**50 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/arbeitszeugnis-analyse/README.md)

--- a/skills-index/aussenwirtschaft-zoll-sanktionen.md
+++ b/skills-index/aussenwirtschaft-zoll-sanktionen.md
@@ -1,6 +1,6 @@
 # aussenwirtschaft-zoll-sanktionen
 
-**100 Skills** · Stand `v53.6.0`
+**100 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/aussenwirtschaft-zoll-sanktionen/README.md)

--- a/skills-index/bank-rechtsabteilung.md
+++ b/skills-index/bank-rechtsabteilung.md
@@ -1,6 +1,6 @@
 # bank-rechtsabteilung
 
-**100 Skills** · Stand `v53.6.0`
+**100 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/bank-rechtsabteilung/README.md)

--- a/skills-index/barrierefreiheit-web-checker.md
+++ b/skills-index/barrierefreiheit-web-checker.md
@@ -1,6 +1,6 @@
 # barrierefreiheit-web-checker
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/barrierefreiheit-web-checker/README.md)

--- a/skills-index/bav-strategie-konzern.md
+++ b/skills-index/bav-strategie-konzern.md
@@ -1,6 +1,6 @@
 # bav-strategie-konzern
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/bav-strategie-konzern/README.md)

--- a/skills-index/bereicherungs-und-anfechtungsrecht-pruefer.md
+++ b/skills-index/bereicherungs-und-anfechtungsrecht-pruefer.md
@@ -1,6 +1,6 @@
 # bereicherungs-und-anfechtungsrecht-pruefer
 
-**98 Skills** · Stand `v53.6.0`
+**98 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/bereicherungs-und-anfechtungsrecht-pruefer/README.md)

--- a/skills-index/berufsrecht-ki-vertragspruefung.md
+++ b/skills-index/berufsrecht-ki-vertragspruefung.md
@@ -1,6 +1,6 @@
 # berufsrecht-ki-vertragspruefung
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/berufsrecht-ki-vertragspruefung/README.md)

--- a/skills-index/betreuungsrecht.md
+++ b/skills-index/betreuungsrecht.md
@@ -1,6 +1,6 @@
 # betreuungsrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/betreuungsrecht/README.md)

--- a/skills-index/bgb-at-pruefer.md
+++ b/skills-index/bgb-at-pruefer.md
@@ -1,6 +1,6 @@
 # bgb-at-pruefer
 
-**53 Skills** · Stand `v53.6.0`
+**53 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/bgb-at-pruefer/README.md)

--- a/skills-index/buerokratieversteher-entbuerokratisierer.md
+++ b/skills-index/buerokratieversteher-entbuerokratisierer.md
@@ -1,6 +1,6 @@
 # buerokratieversteher-entbuerokratisierer
 
-**100 Skills** · Stand `v53.6.0`
+**100 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/buerokratieversteher-entbuerokratisierer/README.md)

--- a/skills-index/commercial-courts-deutschland.md
+++ b/skills-index/commercial-courts-deutschland.md
@@ -1,6 +1,6 @@
 # commercial-courts-deutschland
 
-**57 Skills** · Stand `v53.6.0`
+**57 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/commercial-courts-deutschland/README.md)

--- a/skills-index/common-law-kompass.md
+++ b/skills-index/common-law-kompass.md
@@ -1,6 +1,6 @@
 # common-law-kompass
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/common-law-kompass/README.md)

--- a/skills-index/corporate-kanzlei.md
+++ b/skills-index/corporate-kanzlei.md
@@ -1,6 +1,6 @@
 # corporate-kanzlei
 
-**50 Skills** · Stand `v53.6.0`
+**50 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/corporate-kanzlei/README.md)

--- a/skills-index/datenschutzrecht.md
+++ b/skills-index/datenschutzrecht.md
@@ -1,6 +1,6 @@
 # datenschutzrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/datenschutzrecht/README.md)

--- a/skills-index/dfg-foerderantrag.md
+++ b/skills-index/dfg-foerderantrag.md
@@ -1,6 +1,6 @@
 # dfg-foerderantrag
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/dfg-foerderantrag/README.md)

--- a/skills-index/dsa-dma-digitalregulierung.md
+++ b/skills-index/dsa-dma-digitalregulierung.md
@@ -1,6 +1,6 @@
 # dsa-dma-digitalregulierung
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/dsa-dma-digitalregulierung/README.md)

--- a/skills-index/einfache-leichte-sprache-jura.md
+++ b/skills-index/einfache-leichte-sprache-jura.md
@@ -1,6 +1,6 @@
 # einfache-leichte-sprache-jura
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/einfache-leichte-sprache-jura/README.md)

--- a/skills-index/email-umformulierer-berufsrecht.md
+++ b/skills-index/email-umformulierer-berufsrecht.md
@@ -1,6 +1,6 @@
 # email-umformulierer-berufsrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/email-umformulierer-berufsrecht/README.md)

--- a/skills-index/energierecht.md
+++ b/skills-index/energierecht.md
@@ -1,6 +1,6 @@
 # energierecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/energierecht/README.md)

--- a/skills-index/europarecht-kompass.md
+++ b/skills-index/europarecht-kompass.md
@@ -1,6 +1,6 @@
 # europarecht-kompass
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/europarecht-kompass/README.md)

--- a/skills-index/fachanwalt-agrarrecht.md
+++ b/skills-index/fachanwalt-agrarrecht.md
@@ -1,6 +1,6 @@
 # fachanwalt-agrarrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-agrarrecht/README.md)

--- a/skills-index/fachanwalt-arbeitsrecht.md
+++ b/skills-index/fachanwalt-arbeitsrecht.md
@@ -1,6 +1,6 @@
 # fachanwalt-arbeitsrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-arbeitsrecht/README.md)

--- a/skills-index/fachanwalt-bank-kapitalmarktrecht.md
+++ b/skills-index/fachanwalt-bank-kapitalmarktrecht.md
@@ -1,6 +1,6 @@
 # fachanwalt-bank-kapitalmarktrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-bank-kapitalmarktrecht/README.md)

--- a/skills-index/fachanwalt-bau-architektenrecht.md
+++ b/skills-index/fachanwalt-bau-architektenrecht.md
@@ -1,6 +1,6 @@
 # fachanwalt-bau-architektenrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-bau-architektenrecht/README.md)

--- a/skills-index/fachanwalt-erbrecht.md
+++ b/skills-index/fachanwalt-erbrecht.md
@@ -1,6 +1,6 @@
 # fachanwalt-erbrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-erbrecht/README.md)

--- a/skills-index/fachanwalt-familienrecht.md
+++ b/skills-index/fachanwalt-familienrecht.md
@@ -1,6 +1,6 @@
 # fachanwalt-familienrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-familienrecht/README.md)

--- a/skills-index/fachanwalt-gewerblicher-rechtsschutz.md
+++ b/skills-index/fachanwalt-gewerblicher-rechtsschutz.md
@@ -1,6 +1,6 @@
 # fachanwalt-gewerblicher-rechtsschutz
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-gewerblicher-rechtsschutz/README.md)

--- a/skills-index/fachanwalt-handels-gesellschaftsrecht.md
+++ b/skills-index/fachanwalt-handels-gesellschaftsrecht.md
@@ -1,6 +1,6 @@
 # fachanwalt-handels-gesellschaftsrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-handels-gesellschaftsrecht/README.md)

--- a/skills-index/fachanwalt-insolvenz-sanierungsrecht.md
+++ b/skills-index/fachanwalt-insolvenz-sanierungsrecht.md
@@ -1,6 +1,6 @@
 # fachanwalt-insolvenz-sanierungsrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-insolvenz-sanierungsrecht/README.md)

--- a/skills-index/fachanwalt-internationales-wirtschaftsrecht.md
+++ b/skills-index/fachanwalt-internationales-wirtschaftsrecht.md
@@ -1,6 +1,6 @@
 # fachanwalt-internationales-wirtschaftsrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-internationales-wirtschaftsrecht/README.md)

--- a/skills-index/fachanwalt-it-recht.md
+++ b/skills-index/fachanwalt-it-recht.md
@@ -1,6 +1,6 @@
 # fachanwalt-it-recht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-it-recht/README.md)

--- a/skills-index/fachanwalt-medizinrecht.md
+++ b/skills-index/fachanwalt-medizinrecht.md
@@ -1,6 +1,6 @@
 # fachanwalt-medizinrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-medizinrecht/README.md)

--- a/skills-index/fachanwalt-miet-wohnungseigentumsrecht.md
+++ b/skills-index/fachanwalt-miet-wohnungseigentumsrecht.md
@@ -1,6 +1,6 @@
 # fachanwalt-miet-wohnungseigentumsrecht
 
-**225 Skills** · Stand `v53.6.0`
+**225 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-miet-wohnungseigentumsrecht/README.md)

--- a/skills-index/fachanwalt-migrationsrecht.md
+++ b/skills-index/fachanwalt-migrationsrecht.md
@@ -1,6 +1,6 @@
 # fachanwalt-migrationsrecht
 
-**376 Skills** · Stand `v53.6.0`
+**376 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-migrationsrecht/README.md)

--- a/skills-index/fachanwalt-sozialrecht.md
+++ b/skills-index/fachanwalt-sozialrecht.md
@@ -1,6 +1,6 @@
 # fachanwalt-sozialrecht
 
-**83 Skills** · Stand `v53.6.0`
+**83 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-sozialrecht/README.md)

--- a/skills-index/fachanwalt-sportrecht.md
+++ b/skills-index/fachanwalt-sportrecht.md
@@ -1,6 +1,6 @@
 # fachanwalt-sportrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-sportrecht/README.md)

--- a/skills-index/fachanwalt-strafrecht.md
+++ b/skills-index/fachanwalt-strafrecht.md
@@ -1,6 +1,6 @@
 # fachanwalt-strafrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-strafrecht/README.md)

--- a/skills-index/fachanwalt-transport-speditionsrecht.md
+++ b/skills-index/fachanwalt-transport-speditionsrecht.md
@@ -1,6 +1,6 @@
 # fachanwalt-transport-speditionsrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-transport-speditionsrecht/README.md)

--- a/skills-index/fachanwalt-urheber-medienrecht.md
+++ b/skills-index/fachanwalt-urheber-medienrecht.md
@@ -1,6 +1,6 @@
 # fachanwalt-urheber-medienrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-urheber-medienrecht/README.md)

--- a/skills-index/fachanwalt-vergaberecht.md
+++ b/skills-index/fachanwalt-vergaberecht.md
@@ -1,6 +1,6 @@
 # fachanwalt-vergaberecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-vergaberecht/README.md)

--- a/skills-index/fachanwalt-verkehrsrecht.md
+++ b/skills-index/fachanwalt-verkehrsrecht.md
@@ -1,6 +1,6 @@
 # fachanwalt-verkehrsrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-verkehrsrecht/README.md)

--- a/skills-index/fachanwalt-versicherungsrecht.md
+++ b/skills-index/fachanwalt-versicherungsrecht.md
@@ -1,6 +1,6 @@
 # fachanwalt-versicherungsrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-versicherungsrecht/README.md)

--- a/skills-index/fachanwalt-verwaltungsrecht.md
+++ b/skills-index/fachanwalt-verwaltungsrecht.md
@@ -1,6 +1,6 @@
 # fachanwalt-verwaltungsrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fachanwalt-verwaltungsrecht/README.md)

--- a/skills-index/fluggastrechte.md
+++ b/skills-index/fluggastrechte.md
@@ -1,6 +1,6 @@
 # fluggastrechte
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fluggastrechte/README.md)

--- a/skills-index/forderungsmanagement-klagewerkstatt.md
+++ b/skills-index/forderungsmanagement-klagewerkstatt.md
@@ -1,6 +1,6 @@
 # forderungsmanagement-klagewerkstatt
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/forderungsmanagement-klagewerkstatt/README.md)

--- a/skills-index/forschungszulage-antragstellung.md
+++ b/skills-index/forschungszulage-antragstellung.md
@@ -1,6 +1,6 @@
 # forschungszulage-antragstellung
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/forschungszulage-antragstellung/README.md)

--- a/skills-index/fortbestehensprognose.md
+++ b/skills-index/fortbestehensprognose.md
@@ -1,6 +1,6 @@
 # fortbestehensprognose
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/fortbestehensprognose/README.md)

--- a/skills-index/geldwaeschepraevention-aml-kyc.md
+++ b/skills-index/geldwaeschepraevention-aml-kyc.md
@@ -1,6 +1,6 @@
 # geldwaeschepraevention-aml-kyc
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/geldwaeschepraevention-aml-kyc/README.md)

--- a/skills-index/gesellschaftsgruender.md
+++ b/skills-index/gesellschaftsgruender.md
@@ -1,6 +1,6 @@
 # gesellschaftsgruender
 
-**50 Skills** · Stand `v53.6.0`
+**50 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/gesellschaftsgruender/README.md)

--- a/skills-index/gesellschaftsrecht-legal-english.md
+++ b/skills-index/gesellschaftsrecht-legal-english.md
@@ -1,6 +1,6 @@
 # gesellschaftsrecht-legal-english
 
-**50 Skills** · Stand `v53.6.0`
+**50 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/gesellschaftsrecht-legal-english/README.md)

--- a/skills-index/gesellschaftsrecht.md
+++ b/skills-index/gesellschaftsrecht.md
@@ -1,6 +1,6 @@
 # gesellschaftsrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/gesellschaftsrecht/README.md)

--- a/skills-index/gewerblicher-rechtsschutz.md
+++ b/skills-index/gewerblicher-rechtsschutz.md
@@ -1,6 +1,6 @@
 # gewerblicher-rechtsschutz
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/gewerblicher-rechtsschutz/README.md)

--- a/skills-index/grosskanzlei-corporate-ma.md
+++ b/skills-index/grosskanzlei-corporate-ma.md
@@ -1,6 +1,6 @@
 # grosskanzlei-corporate-ma
 
-**56 Skills** · Stand `v53.6.0`
+**56 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/grosskanzlei-corporate-ma/README.md)

--- a/skills-index/hausarbeitenmacher.md
+++ b/skills-index/hausarbeitenmacher.md
@@ -1,6 +1,6 @@
 # hausarbeitenmacher
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/hausarbeitenmacher/README.md)

--- a/skills-index/immobilienrechtspraxis.md
+++ b/skills-index/immobilienrechtspraxis.md
@@ -1,6 +1,6 @@
 # immobilienrechtspraxis
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/immobilienrechtspraxis/README.md)

--- a/skills-index/insolvenzforderungsanmeldungspruefung.md
+++ b/skills-index/insolvenzforderungsanmeldungspruefung.md
@@ -1,6 +1,6 @@
 # insolvenzforderungsanmeldungspruefung
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/insolvenzforderungsanmeldungspruefung/README.md)

--- a/skills-index/insolvenzplan-starug-planwerkstatt.md
+++ b/skills-index/insolvenzplan-starug-planwerkstatt.md
@@ -1,6 +1,6 @@
 # insolvenzplan-starug-planwerkstatt
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/insolvenzplan-starug-planwerkstatt/README.md)

--- a/skills-index/insolvenzrecht.md
+++ b/skills-index/insolvenzrecht.md
@@ -1,6 +1,6 @@
 # insolvenzrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/insolvenzrecht/README.md)

--- a/skills-index/insolvenzverwaltung.md
+++ b/skills-index/insolvenzverwaltung.md
@@ -1,6 +1,6 @@
 # insolvenzverwaltung
 
-**50 Skills** · Stand `v53.6.0`
+**50 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/insolvenzverwaltung/README.md)

--- a/skills-index/jurastudium.md
+++ b/skills-index/jurastudium.md
@@ -1,6 +1,6 @@
 # jurastudium
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/jurastudium/README.md)

--- a/skills-index/juristische-sprache-deutsch-als-zweitsprache.md
+++ b/skills-index/juristische-sprache-deutsch-als-zweitsprache.md
@@ -1,6 +1,6 @@
 # juristische-sprache-deutsch-als-zweitsprache
 
-**50 Skills** · Stand `v53.6.0`
+**50 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/juristische-sprache-deutsch-als-zweitsprache/README.md)

--- a/skills-index/jveg-kostenpruefer.md
+++ b/skills-index/jveg-kostenpruefer.md
@@ -1,6 +1,6 @@
 # jveg-kostenpruefer
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/jveg-kostenpruefer/README.md)

--- a/skills-index/kanzlei-allgemein.md
+++ b/skills-index/kanzlei-allgemein.md
@@ -1,6 +1,6 @@
 # kanzlei-allgemein
 
-**50 Skills** · Stand `v53.6.0`
+**50 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/kanzlei-allgemein/README.md)

--- a/skills-index/kanzlei-builder-hub.md
+++ b/skills-index/kanzlei-builder-hub.md
@@ -1,6 +1,6 @@
 # kanzlei-builder-hub
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/kanzlei-builder-hub/README.md)

--- a/skills-index/kartellrecht-marktabgrenzung-pruefung.md
+++ b/skills-index/kartellrecht-marktabgrenzung-pruefung.md
@@ -1,6 +1,6 @@
 # kartellrecht-marktabgrenzung-pruefung
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/kartellrecht-marktabgrenzung-pruefung/README.md)

--- a/skills-index/ki-governance.md
+++ b/skills-index/ki-governance.md
@@ -1,6 +1,6 @@
 # ki-governance
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/ki-governance/README.md)

--- a/skills-index/ki-richtlinie-kanzleien.md
+++ b/skills-index/ki-richtlinie-kanzleien.md
@@ -1,6 +1,6 @@
 # ki-richtlinie-kanzleien
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/ki-richtlinie-kanzleien/README.md)

--- a/skills-index/ki-vo-ai-act-pruefer.md
+++ b/skills-index/ki-vo-ai-act-pruefer.md
@@ -1,6 +1,6 @@
 # ki-vo-ai-act-pruefer
 
-**50 Skills** · Stand `v53.6.0`
+**50 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/ki-vo-ai-act-pruefer/README.md)

--- a/skills-index/krisenfrueherkennung-starug.md
+++ b/skills-index/krisenfrueherkennung-starug.md
@@ -1,6 +1,6 @@
 # krisenfrueherkennung-starug
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/krisenfrueherkennung-starug/README.md)

--- a/skills-index/legistik-werkstatt.md
+++ b/skills-index/legistik-werkstatt.md
@@ -1,6 +1,6 @@
 # legistik-werkstatt
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/legistik-werkstatt/README.md)

--- a/skills-index/liquiditaetsplanung.md
+++ b/skills-index/liquiditaetsplanung.md
@@ -1,6 +1,6 @@
 # liquiditaetsplanung
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/liquiditaetsplanung/README.md)

--- a/skills-index/lobbyregister-bundestag.md
+++ b/skills-index/lobbyregister-bundestag.md
@@ -1,6 +1,6 @@
 # lobbyregister-bundestag
 
-**51 Skills** · Stand `v53.6.0`
+**51 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/lobbyregister-bundestag/README.md)

--- a/skills-index/mandantenanfragen-assistent.md
+++ b/skills-index/mandantenanfragen-assistent.md
@@ -1,6 +1,6 @@
 # mandantenanfragen-assistent
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/mandantenanfragen-assistent/README.md)

--- a/skills-index/markenrecht-fashion-luxus.md
+++ b/skills-index/markenrecht-fashion-luxus.md
@@ -1,6 +1,6 @@
 # markenrecht-fashion-luxus
 
-**50 Skills** · Stand `v53.6.0`
+**50 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/markenrecht-fashion-luxus/README.md)

--- a/skills-index/meinungspruefer.md
+++ b/skills-index/meinungspruefer.md
@@ -1,6 +1,6 @@
 # meinungspruefer
 
-**50 Skills** · Stand `v53.6.0`
+**50 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/meinungspruefer/README.md)

--- a/skills-index/memorandums-ersteller.md
+++ b/skills-index/memorandums-ersteller.md
@@ -1,6 +1,6 @@
 # memorandums-ersteller
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/memorandums-ersteller/README.md)

--- a/skills-index/methodenlehre-buergerliches-recht.md
+++ b/skills-index/methodenlehre-buergerliches-recht.md
@@ -1,6 +1,6 @@
 # methodenlehre-buergerliches-recht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/methodenlehre-buergerliches-recht/README.md)

--- a/skills-index/mietrecht.md
+++ b/skills-index/mietrecht.md
@@ -1,6 +1,6 @@
 # mietrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/mietrecht/README.md)

--- a/skills-index/mittelstand-corporate-ma.md
+++ b/skills-index/mittelstand-corporate-ma.md
@@ -1,6 +1,6 @@
 # mittelstand-corporate-ma
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/mittelstand-corporate-ma/README.md)

--- a/skills-index/nachbarschaftsstreit-pruefer.md
+++ b/skills-index/nachbarschaftsstreit-pruefer.md
@@ -1,6 +1,6 @@
 # nachbarschaftsstreit-pruefer
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/nachbarschaftsstreit-pruefer/README.md)

--- a/skills-index/nda-abgleich.md
+++ b/skills-index/nda-abgleich.md
@@ -1,6 +1,6 @@
 # nda-abgleich
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/nda-abgleich/README.md)

--- a/skills-index/normenkontrolle-bauleitplanung.md
+++ b/skills-index/normenkontrolle-bauleitplanung.md
@@ -1,6 +1,6 @@
 # normenkontrolle-bauleitplanung
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/normenkontrolle-bauleitplanung/README.md)

--- a/skills-index/parteienrecht-parteiorganisation.md
+++ b/skills-index/parteienrecht-parteiorganisation.md
@@ -1,6 +1,6 @@
 # parteienrecht-parteiorganisation
 
-**75 Skills** · Stand `v53.6.0`
+**75 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/parteienrecht-parteiorganisation/README.md)

--- a/skills-index/patentrecherche.md
+++ b/skills-index/patentrecherche.md
@@ -1,6 +1,6 @@
 # patentrecherche
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/patentrecherche/README.md)

--- a/skills-index/patentrecht.md
+++ b/skills-index/patentrecht.md
@@ -1,6 +1,6 @@
 # patentrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/patentrecht/README.md)

--- a/skills-index/phishing-vorfall-pruefer.md
+++ b/skills-index/phishing-vorfall-pruefer.md
@@ -1,6 +1,6 @@
 # phishing-vorfall-pruefer
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/phishing-vorfall-pruefer/README.md)

--- a/skills-index/produktrecht.md
+++ b/skills-index/produktrecht.md
@@ -1,6 +1,6 @@
 # produktrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/produktrecht/README.md)

--- a/skills-index/prozessrecht.md
+++ b/skills-index/prozessrecht.md
@@ -1,6 +1,6 @@
 # prozessrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/prozessrecht/README.md)

--- a/skills-index/rechtsberatungsstelle.md
+++ b/skills-index/rechtsberatungsstelle.md
@@ -1,6 +1,6 @@
 # rechtsberatungsstelle
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/rechtsberatungsstelle/README.md)

--- a/skills-index/regulatorisches-recht.md
+++ b/skills-index/regulatorisches-recht.md
@@ -1,6 +1,6 @@
 # regulatorisches-recht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/regulatorisches-recht/README.md)

--- a/skills-index/robotik-recht.md
+++ b/skills-index/robotik-recht.md
@@ -1,6 +1,6 @@
 # robotik-recht
 
-**143 Skills** · Stand `v53.6.0`
+**143 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/robotik-recht/README.md)

--- a/skills-index/schriftform-und-textform-bgb.md
+++ b/skills-index/schriftform-und-textform-bgb.md
@@ -1,6 +1,6 @@
 # schriftform-und-textform-bgb
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/schriftform-und-textform-bgb/README.md)

--- a/skills-index/selbstvertreter-amtsgericht.md
+++ b/skills-index/selbstvertreter-amtsgericht.md
@@ -1,6 +1,6 @@
 # selbstvertreter-amtsgericht
 
-**86 Skills** · Stand `v53.6.0`
+**86 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/selbstvertreter-amtsgericht/README.md)

--- a/skills-index/selbstvertreter-sozialgericht.md
+++ b/skills-index/selbstvertreter-sozialgericht.md
@@ -1,6 +1,6 @@
 # selbstvertreter-sozialgericht
 
-**80 Skills** · Stand `v53.6.0`
+**80 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/selbstvertreter-sozialgericht/README.md)

--- a/skills-index/steuerrecht-anwalt-und-berater.md
+++ b/skills-index/steuerrecht-anwalt-und-berater.md
@@ -1,6 +1,6 @@
 # steuerrecht-anwalt-und-berater
 
-**209 Skills** · Stand `v53.6.0`
+**209 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/steuerrecht-anwalt-und-berater/README.md)

--- a/skills-index/strafbefehl-verteidiger.md
+++ b/skills-index/strafbefehl-verteidiger.md
@@ -1,6 +1,6 @@
 # strafbefehl-verteidiger
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/strafbefehl-verteidiger/README.md)

--- a/skills-index/strafzumessung.md
+++ b/skills-index/strafzumessung.md
@@ -1,6 +1,6 @@
 # strafzumessung
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/strafzumessung/README.md)

--- a/skills-index/subsumtions-pruefer.md
+++ b/skills-index/subsumtions-pruefer.md
@@ -1,6 +1,6 @@
 # subsumtions-pruefer
 
-**50 Skills** · Stand `v53.6.0`
+**50 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/subsumtions-pruefer/README.md)

--- a/skills-index/tabellenreview-3d.md
+++ b/skills-index/tabellenreview-3d.md
@@ -1,6 +1,6 @@
 # tabellenreview-3d
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/tabellenreview-3d/README.md)

--- a/skills-index/umweltrecht.md
+++ b/skills-index/umweltrecht.md
@@ -1,6 +1,6 @@
 # umweltrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/umweltrecht/README.md)

--- a/skills-index/urteilsbauer-relationsmacher.md
+++ b/skills-index/urteilsbauer-relationsmacher.md
@@ -1,6 +1,6 @@
 # urteilsbauer-relationsmacher
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/urteilsbauer-relationsmacher/README.md)

--- a/skills-index/vereinsrecht-vereinsmanager.md
+++ b/skills-index/vereinsrecht-vereinsmanager.md
@@ -1,6 +1,6 @@
 # vereinsrecht-vereinsmanager
 
-**58 Skills** · Stand `v53.6.0`
+**58 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/vereinsrecht-vereinsmanager/README.md)

--- a/skills-index/verfassungsrecht.md
+++ b/skills-index/verfassungsrecht.md
@@ -1,6 +1,6 @@
 # verfassungsrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/verfassungsrecht/README.md)

--- a/skills-index/verkehr-infrastrukturrecht.md
+++ b/skills-index/verkehr-infrastrukturrecht.md
@@ -1,6 +1,6 @@
 # verkehr-infrastrukturrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/verkehr-infrastrukturrecht/README.md)

--- a/skills-index/verkehrsowi-verteidiger.md
+++ b/skills-index/verkehrsowi-verteidiger.md
@@ -1,6 +1,6 @@
 # verkehrsowi-verteidiger
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/verkehrsowi-verteidiger/README.md)

--- a/skills-index/verlagsredaktion.md
+++ b/skills-index/verlagsredaktion.md
@@ -1,6 +1,6 @@
 # verlagsredaktion
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/verlagsredaktion/README.md)

--- a/skills-index/vertragsausfueller.md
+++ b/skills-index/vertragsausfueller.md
@@ -1,6 +1,6 @@
 # vertragsausfueller
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/vertragsausfueller/README.md)

--- a/skills-index/vertragsrecht.md
+++ b/skills-index/vertragsrecht.md
@@ -1,6 +1,6 @@
 # vertragsrecht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/vertragsrecht/README.md)

--- a/skills-index/wandeldarlehen-lebenszyklus.md
+++ b/skills-index/wandeldarlehen-lebenszyklus.md
@@ -1,6 +1,6 @@
 # wandeldarlehen-lebenszyklus
 
-**50 Skills** · Stand `v53.6.0`
+**50 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/wandeldarlehen-lebenszyklus/README.md)

--- a/skills-index/weg-hausverwaltung.md
+++ b/skills-index/weg-hausverwaltung.md
@@ -1,6 +1,6 @@
 # weg-hausverwaltung
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/weg-hausverwaltung/README.md)

--- a/skills-index/word-legal-ai-plugin-and-skill-for-german-lawyers.md
+++ b/skills-index/word-legal-ai-plugin-and-skill-for-german-lawyers.md
@@ -1,6 +1,6 @@
 # word-legal-ai-plugin-and-skill-for-german-lawyers
 
-**50 Skills** · Stand `v53.6.0`
+**50 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/word-legal-ai-plugin-and-skill-for-german-lawyers/README.md)

--- a/skills-index/zitierweise-deutsches-recht.md
+++ b/skills-index/zitierweise-deutsches-recht.md
@@ -1,6 +1,6 @@
 # zitierweise-deutsches-recht
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/zitierweise-deutsches-recht/README.md)

--- a/skills-index/zwangsverwaltung-zvg.md
+++ b/skills-index/zwangsverwaltung-zvg.md
@@ -1,6 +1,6 @@
 # zwangsverwaltung-zvg
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/zwangsverwaltung-zvg/README.md)

--- a/skills-index/zwangsvollstreckung.md
+++ b/skills-index/zwangsvollstreckung.md
@@ -1,6 +1,6 @@
 # zwangsvollstreckung
 
-**54 Skills** · Stand `v53.6.0`
+**54 Skills** · Stand `v54.0.0`
 
 - [← Zurueck zur Gesamtuebersicht](../SKILLS.md)
 - [Plugin-README](https://github.com/Klotzkette/claude-fuer-deutsches-recht/blob/main/zwangsvollstreckung/README.md)


### PR DESCRIPTION
## Vollständigkeits-Audit v54.0.0

Ergebnis nach Audit aller READMEs:

- **SKILLS.md**: 119/119 Plugins alphabetisch + Download-Link pro Plugin + 2 Sammelpakete `alle-plugins-megazip.zip` / `alles-komplettpaket.zip`
- **119 Plugin-READMEs**: alle Skills alphabetisch und vollständig
- **119 skills-index/-Detailseiten**: vollständig + alphabetisch, Markdown- und Raw-Links pro Skill
- **testakten/README.md**: 129/129 Akten
- **GitHub Release v54.0.0**: 252 Assets, alle 119 Plugin-ZIPs + 2 Sammel-ZIPs vorhanden

## Gefundenes Problem

In `agb-recht-pruefer/README.md` doppelter `SKILLS-OVERVIEW`-Block: ein abgeschnittenes Textfragment plus zwei duplizierte Skill-Zeilen nach dem ersten `END`-Marker. Wahrscheinlich aus einem früheren Magic-Touch-Pass übriggeblieben. Entfernt.

`skills-index/*.md` ziehen außerdem ihren Versionsstempel auf `v54.0.0` nach.

```
node scripts/validate-plugin-structure.mjs    → OK
python3 scripts/validate-yaml-frontmatter.py  → 0 Fehler, 0 Warnungen
```