### PR TITLE
fix(datenschutz): aktuelle Postanschriften BlnBDI und LfDI BW

### DIFF
--- a/datenschutzrecht/skills/dsv-meldung-bln-bdi/SKILL.md
+++ b/datenschutzrecht/skills/dsv-meldung-bln-bdi/SKILL.md
@@ -36,7 +36,7 @@ Quellenregel: Keine Kommentar-, Handbuch- oder Aufsatzfundstellen aus Modellwiss
 ## Behördenstammdaten BlnBDI
 
 - Name: Berliner Beauftragte für Datenschutz und Informationsfreiheit
-- Anschrift: Friedrichstraße 219; 10969 Berlin
+- Anschrift: Alt-Moabit 59-61; 10555 Berlin (Eingang Alt-Moabit 60)
 - Kontakt: mailbox@datenschutz-berlin.de; Telefon 030 13889-0
 - Online-Meldeformular: datenpannen.datenschutz-berlin.de — Online-Meldeformular (Goldstandard)
 - Sondernorm: BlnDSG insbesondere § 51 BlnDSG

--- a/datenschutzrecht/skills/dsv-meldung-lfdi-bw/SKILL.md
+++ b/datenschutzrecht/skills/dsv-meldung-lfdi-bw/SKILL.md
@@ -36,7 +36,7 @@ Quellenregel: Keine Kommentar-, Handbuch- oder Aufsatzfundstellen aus Modellwiss
 ## Behördenstammdaten LfDI BW
 
 - Name: Landesbeauftragter für den Datenschutz und die Informationsfreiheit Baden-Württemberg
-- Anschrift: Lautenschlagerstraße 20; 70173 Stuttgart
+- Anschrift: Heilbronner Straße 35; 70191 Stuttgart (stufenloser Zugang ueber Rampe; Navigationsadresse Räpplenstraße 2; 70191 Stuttgart; Umzug zum 22.12.2025)
 - Kontakt: poststelle@lfdi.bwl.de; Telefon 0711 615541-0
 - Online-Meldeformular: baden-wuerttemberg.datenschutz.de — Online-Meldeformular
 - Sondernorm: LDSG Baden-Württemberg

--- a/fachanwalt-it-recht/skills/dsv-meldung-bln-bdi/SKILL.md
+++ b/fachanwalt-it-recht/skills/dsv-meldung-bln-bdi/SKILL.md
@@ -36,7 +36,7 @@ Quellenregel: Keine Kommentar-, Handbuch- oder Aufsatzfundstellen aus Modellwiss
 ## Behördenstammdaten BlnBDI
 
 - Name: Berliner Beauftragte für Datenschutz und Informationsfreiheit
-- Anschrift: Friedrichstraße 219; 10969 Berlin
+- Anschrift: Alt-Moabit 59-61; 10555 Berlin (Eingang Alt-Moabit 60)
 - Kontakt: mailbox@datenschutz-berlin.de; Telefon 030 13889-0
 - Online-Meldeformular: datenpannen.datenschutz-berlin.de — Online-Meldeformular (Goldstandard)
 - Sondernorm: BlnDSG insbesondere § 51 BlnDSG

--- a/fachanwalt-it-recht/skills/dsv-meldung-lfdi-bw/SKILL.md
+++ b/fachanwalt-it-recht/skills/dsv-meldung-lfdi-bw/SKILL.md
@@ -36,7 +36,7 @@ Quellenregel: Keine Kommentar-, Handbuch- oder Aufsatzfundstellen aus Modellwiss
 ## Behördenstammdaten LfDI BW
 
 - Name: Landesbeauftragter für den Datenschutz und die Informationsfreiheit Baden-Württemberg
-- Anschrift: Lautenschlagerstraße 20; 70173 Stuttgart
+- Anschrift: Heilbronner Straße 35; 70191 Stuttgart (stufenloser Zugang ueber Rampe; Navigationsadresse Räpplenstraße 2; 70191 Stuttgart; Umzug zum 22.12.2025)
 - Kontakt: poststelle@lfdi.bwl.de; Telefon 0711 615541-0
 - Online-Meldeformular: baden-wuerttemberg.datenschutz.de — Online-Meldeformular
 - Sondernorm: LDSG Baden-Württemberg


### PR DESCRIPTION
# Fix: Aktuelle Postanschriften BlnBDI und LfDI BW

Behebt zwei P2-Befunde aus Code Review:

## BlnBDI (Berliner Beauftragte fuer Datenschutz und Informationsfreiheit)

- **Alt:** Friedrichstraße 219; 10969 Berlin
- **Neu:** Alt-Moabit 59-61; 10555 Berlin (Eingang Alt-Moabit 60)
- **Hintergrund:** Umzug bereits seit November 2022; alte Adresse war veraltet.

## LfDI BW (Landesbeauftragter Datenschutz und Informationsfreiheit Baden-Wuerttemberg)

- **Alt:** Lautenschlagerstraße 20; 70173 Stuttgart
- **Neu:** Heilbronner Straße 35; 70191 Stuttgart (stufenloser Zugang ueber Rampe; Navigationsadresse Räpplenstraße 2; 70191 Stuttgart)
- **Hintergrund:** Umzug zum 22.12.2025. Da die Skills nach diesem Datum hinzugefuegt wurden; war die alte Adresse direkt veraltet.

## Quellen

- [datenschutzkonferenz-online.de](https://www.datenschutzkonferenz-online.de/kontakt.html) (Vorsitzland-Kontakt BlnBDI)
- [baden-wuerttemberg.datenschutz.de](https://www.baden-wuerttemberg.datenschutz.de/lfdi-neue-adresse-ab-22-12-2025/) (Adresswechsel-Mitteilung LfDI BW)
- [lda.brandenburg.de](https://www.lda.brandenburg.de/lda/de/datenschutz/zustaendigkeiten/datenschutzaufsichtsbehoerden-in-bund-und-laendern/) (Aufsichtsbehoerden-Liste)

## Beide Plugins angepasst

- `datenschutzrecht/skills/dsv-meldung-bln-bdi/SKILL.md`
- `datenschutzrecht/skills/dsv-meldung-lfdi-bw/SKILL.md`
- `fachanwalt-it-recht/skills/dsv-meldung-bln-bdi/SKILL.md`
- `fachanwalt-it-recht/skills/dsv-meldung-lfdi-bw/SKILL.md`

## Validatoren

- `validate-plugin-structure` — OK
- `validate-yaml-frontmatter` — 0 Fehler; 0 Warnungen
