### PR TITLE
fix(verlagsredaktion): DDG-Paragrafen korrigiert und UrhG § 38 Abs. 1 / Abs. 4 getrennt

### DIFF
--- a/verlagsredaktion/skills/verl-rueckruf-fehlerbeitrag-spaet-erkannt/SKILL.md
+++ b/verlagsredaktion/skills/verl-rueckruf-fehlerbeitrag-spaet-erkannt/SKILL.md
@@ -25,7 +25,7 @@ Nach Erscheinen wird ein gravierender Fehler entdeckt: falsche Aktenzeichen-Anga
 - BGB § 1004 analog - Unterlassungs- und Beseitigungsanspruch.
 - UrhG § 14 - Recht des Urhebers auf Schutz vor Entstellung des Werks (bei eigenmaechtiger Aenderung).
 - UrhG §§ 97, 97a - Schadensersatz, Abmahnung.
-- DDG § 8 - Verantwortlichkeit fuer eigene Inhalte; § 10 - Stoererhaftung mit Privileg fuer Diensteanbieter.
+- DDG § 7 i.V.m. DSA Art. 4-8 (Mere Conduit, Caching, Hosting, freiwillige Untersuchungen, kein allgemeines Monitoring) - Haftungsprivilegien fuer Diensteanbieter; DDG § 8 - Sondervorschrift WLAN-Betreiber. Hinweis: Das TMG ist seit Mai 2024 durch DDG plus DSA abgeloest.
 - UWG §§ 5, 5a - Irrefuehrung; bei Werbeaussagen relevant.
 - Aeusserungsrecht: BVerfG-Rechtsprechung zu Werturteil vs. Tatsachenbehauptung (zu pruefen unter bundesverfassungsgericht.de).
 - BGB § 314 - Kuendigung aus wichtigem Grund (bei Aufnahmevertrag mit Autor).
@@ -160,6 +160,6 @@ Mit freundlichen Gruessen
 
 - BGB §§ 823, 824, 1004 (analog) - Schadensersatz, Kreditgefaehrdung, Beseitigung.
 - UrhG §§ 14, 97, 97a - Werkschutz, Schadensersatz, Abmahnung.
-- DDG §§ 8, 10 - Verantwortlichkeit Diensteanbieter.
+- DDG § 7 i.V.m. DSA Art. 4-8 - Haftungsprivilegien Diensteanbieter; DDG § 8 - WLAN-Sondervorschrift.
 - UWG §§ 5, 5a - Irrefuehrung.
 - Aktuelle BVerfG-Rechtsprechung zur Abwaegung Meinungsfreiheit/Persoenlichkeitsrecht (bundesverfassungsgericht.de).

--- a/verlagsredaktion/skills/verl-zweitverwertungsrechte-pauschal/SKILL.md
+++ b/verlagsredaktion/skills/verl-zweitverwertungsrechte-pauschal/SKILL.md
@@ -21,8 +21,8 @@ Neben der Hauptverwertung (Print, E-Book) entstehen Nebenrechte: Datenbankeinste
 
 ## Rechtlicher und sachlicher Rahmen
 
-- UrhG § 38 - Zeitschriftenbeitrag: ausschliessliches Vervielfaeltigungs- und Verbreitungsrecht des Verlags 12 Monate; Sammelwerk fuer Lehrbuch 1 Jahr; danach Zweitverwertungsrecht der Autorin (nicht-kommerziell).
-- UrhG § 38 Abs. 4 - Zweitverwertungsrecht bei oeffentlich gefoerderten wissenschaftlichen Beitraegen nach 12 Monaten in akzeptierter Manuskriptfassung (Open Access).
+- UrhG § 38 Abs. 1 - Zeitschriftenbeitrag: ausschliessliches Vervielfaeltigungs- und Verbreitungsrecht des Verlags fuer ein Jahr nach Erscheinen; danach darf der Autor den Beitrag anderweitig vervielfaeltigen und verbreiten (keine gesetzliche Beschraenkung auf nicht-kommerzielle Nutzung), soweit nichts anderes vereinbart ist.
+- UrhG § 38 Abs. 4 - Open-Access-Zweitverwertungsrecht: nur bei wissenschaftlichen Beitraegen aus oeffentlich gefoerderter Forschungstaetigkeit; nach Ablauf von zwoelf Monaten seit Erstveroeffentlichung; in der akzeptierten Manuskriptfassung; ausschliesslich zu nicht-kommerziellen Zwecken; entgegenstehende Vereinbarungen sind unwirksam.
 - UrhG § 31 - Einraeumung von Nutzungsrechten; § 31a - unbekannte Nutzungsarten; § 40a - 10-Jahres-Klausel.
 - UrhG § 32 - Verguetung; § 32a - Bestsellerklausel; § 32d - Auskunft.
 - VerlG §§ 28, 29 - Verlagsrechte und ihr Ende.
@@ -30,7 +30,7 @@ Neben der Hauptverwertung (Print, E-Book) entstehen Nebenrechte: Datenbankeinste
 ## Praxisleitfaden / Schritt fuer Schritt
 
 1. **Vertragsstand pruefen.** Welche Nebenrechte sind dem Verlag eingeraeumt? Schriftform fuer unbekannte Nutzungsarten beachten.
-2. **Gesetzliches Zweitverwertungsrecht.** UrhG § 38 - bei Zeitschriftenbeitrag faellt das Recht zur Online-Bereitstellung nach 12 Monaten auf den Autor zurueck (bei oeffentlich gefoerderten Beitraegen, akzeptierte Fassung).
+2. **Gesetzliches Zweitverwertungsrecht.** Zwei Regime sauber trennen: (a) UrhG § 38 Abs. 1 - bei Zeitschriftenbeitraegen allgemein endet die Verlagsexklusivitaet nach einem Jahr; danach kann der Autor frei weiterverwerten (kein gesetzliches Non-Commercial-Limit), wenn nicht vertraglich anders geregelt. (b) UrhG § 38 Abs. 4 - Sonderregel fuer oeffentlich gefoerderte wissenschaftliche Beitraege: nach 12 Monaten, akzeptierte Manuskriptfassung, ausschliesslich nicht-kommerziell; abweichende Vereinbarungen sind unwirksam.
 3. **Datenbankeinstellung (juris, beck-online).** Vertraglich pruefen, Sublizenz-Klausel, Erloesteilung.
 4. **Sonderdruck und Festschriftsuebernahme.** Honorar pro Stueck oder pauschal; Verteilung an Co-Autoren.
 5. **Open Access.** Pruefen, ob Foerderbedingungen Green oder Gold OA verlangen. Embargofrist beachten.


### PR DESCRIPTION
## P2-Fixes Verlagsredaktion: DDG- und UrhG-§-38-Paragrafenbezüge

### 1. `verl-rueckruf-fehlerbeitrag-spaet-erkannt` — DDG-Bezüge korrigiert

**Vorher (falsch):**
> DDG § 8 — Verantwortlichkeit für eigene Inhalte; § 10 — Störerhaftung mit Privileg für Diensteanbieter.

**Nachher (richtig):**
> DDG § 7 i.V.m. DSA Art. 4–8 (Mere Conduit, Caching, Hosting, freiwillige Untersuchungen, kein allgemeines Monitoring) — Haftungsprivilegien für Diensteanbieter; DDG § 8 — Sondervorschrift WLAN-Betreiber. Hinweis: TMG seit Mai 2024 abgelöst durch DDG plus DSA.

**Begründung:**
- § 7 DDG enthält die nationale Verweisungsnorm auf die DSA-Haftungsprivilegien; die früheren TMG §§ 7–10 sind seit Mai 2024 in DSA Art. 4–8 aufgegangen.
- § 8 DDG ist Sondervorschrift für WLAN-Betreiber (keine Identifizierungspflicht), nicht „Verantwortlichkeit für eigene Inhalte".
- § 10 DDG regelt Auskunftsanordnung an Behörden, nicht „Störerhaftung mit Privileg".

Zwei Stellen geändert: Abschnitt „Rechtlicher und sachlicher Rahmen" und „Quellen Stand 06/2026".

### 2. `verl-zweitverwertungsrechte-pauschal` — UrhG § 38 Abs. 1 und Abs. 4 sauber getrennt

**Vorher (vermischt):**
> UrhG § 38 — Zeitschriftenbeitrag: ausschließliches Vervielfältigungs- und Verbreitungsrecht des Verlags 12 Monate; Sammelwerk für Lehrbuch 1 Jahr; danach Zweitverwertungsrecht der Autorin (nicht-kommerziell).

**Nachher (korrekt getrennt):**
> - UrhG § 38 Abs. 1 — Zeitschriftenbeitrag: ausschließliches Vervielfältigungs- und Verbreitungsrecht des Verlags für ein Jahr nach Erscheinen; danach darf der Autor den Beitrag anderweitig vervielfältigen und verbreiten (keine gesetzliche Beschränkung auf nicht-kommerzielle Nutzung), soweit nichts anderes vereinbart ist.
> - UrhG § 38 Abs. 4 — Open-Access-Zweitverwertungsrecht: nur bei wissenschaftlichen Beiträgen aus öffentlich geförderter Forschungstätigkeit; nach Ablauf von zwölf Monaten seit Erstveröffentlichung; in der akzeptierten Manuskriptfassung; ausschließlich zu nicht-kommerziellen Zwecken; entgegenstehende Vereinbarungen sind unwirksam.

**Begründung:**
- § 38 Abs. 1 UrhG gilt allgemein für Zeitschriftenbeiträge; die Verlagsexklusivität endet nach einem Jahr, danach freie Verwertung durch den Autor (kein gesetzliches Non-Commercial-Limit, nur sofern vertraglich nicht anders geregelt).
- § 38 Abs. 4 UrhG ist die spezielle Open-Access-Sonderregel für öffentlich geförderte wissenschaftliche Beiträge mit 12 Monate Embargo, akzeptierter Manuskriptfassung und Non-Commercial-Restriktion; abweichende Vereinbarungen unwirksam.

Zwei Stellen geändert: Abschnitt „Rechtlicher und sachlicher Rahmen" und Schritt 2 im „Praxisleitfaden".

### Validatoren
- `node scripts/validate-plugin-structure.mjs` → OK
- `python3 scripts/validate-yaml-frontmatter.py` → 0 Fehler, 0 Warnungen
