### PR TITLE
fix(verlagsredaktion): DDG-Paragrafen präzise zuordnen (§ 7 Abs. 2 WLAN, § 8 Sperrungsanspruch)

### DIFF
--- a/verlagsredaktion/skills/verl-rueckruf-fehlerbeitrag-spaet-erkannt/SKILL.md
+++ b/verlagsredaktion/skills/verl-rueckruf-fehlerbeitrag-spaet-erkannt/SKILL.md
@@ -25,7 +25,9 @@ Nach Erscheinen wird ein gravierender Fehler entdeckt: falsche Aktenzeichen-Anga
 - BGB § 1004 analog - Unterlassungs- und Beseitigungsanspruch.
 - UrhG § 14 - Recht des Urhebers auf Schutz vor Entstellung des Werks (bei eigenmaechtiger Aenderung).
 - UrhG §§ 97, 97a - Schadensersatz, Abmahnung.
-- DDG § 7 i.V.m. DSA Art. 4-8 (Mere Conduit, Caching, Hosting, freiwillige Untersuchungen, kein allgemeines Monitoring) - Haftungsprivilegien fuer Diensteanbieter; DDG § 8 - Sondervorschrift WLAN-Betreiber. Hinweis: Das TMG ist seit Mai 2024 durch DDG plus DSA abgeloest.
+- DDG § 7 Abs. 1 i.V.m. DSA Art. 4-8 (Mere Conduit, Caching, Hosting, freiwillige Untersuchungen, kein allgemeines Monitoring) - beschraenkte Verantwortlichkeit der Diensteanbieter; DDG § 7 Abs. 2 - Sondervorschrift fuer WLAN-Anbieter (keine behoerdliche Pflicht zu Registrierung oder Passwortabfrage).
+- DDG § 8 - Anspruch auf Sperrung bei Rechtsverletzung: Inhaber eines Rechts am geistigen Eigentum kann vom Diensteanbieter die Sperrung verlangen, wenn keine andere Abhilfemoeglichkeit besteht; Sperrung muss zumutbar und verhaeltnismaessig sein; Kostenerstattung nur bei vorsaetzlichem Zusammenwirken. Verpflichtungen zur Entfernung oder Sperrung nach allgemeinen Gesetzen auf Grund gerichtlicher oder behoerdlicher Anordnungen bleiben unberuehrt (§ 8 Abs. 4 DDG).
+- Hinweis: Das TMG ist seit Mai 2024 durch DDG plus DSA abgeloest.
 - UWG §§ 5, 5a - Irrefuehrung; bei Werbeaussagen relevant.
 - Aeusserungsrecht: BVerfG-Rechtsprechung zu Werturteil vs. Tatsachenbehauptung (zu pruefen unter bundesverfassungsgericht.de).
 - BGB § 314 - Kuendigung aus wichtigem Grund (bei Aufnahmevertrag mit Autor).
@@ -160,6 +162,6 @@ Mit freundlichen Gruessen
 
 - BGB §§ 823, 824, 1004 (analog) - Schadensersatz, Kreditgefaehrdung, Beseitigung.
 - UrhG §§ 14, 97, 97a - Werkschutz, Schadensersatz, Abmahnung.
-- DDG § 7 i.V.m. DSA Art. 4-8 - Haftungsprivilegien Diensteanbieter; DDG § 8 - WLAN-Sondervorschrift.
+- DDG § 7 i.V.m. DSA Art. 4-8 - beschraenkte Verantwortlichkeit Diensteanbieter; § 7 Abs. 2 DDG - WLAN-Sondervorschrift; DDG § 8 - Anspruch auf Sperrung bei Rechtsverletzung an geistigem Eigentum.
 - UWG §§ 5, 5a - Irrefuehrung.
 - Aktuelle BVerfG-Rechtsprechung zur Abwaegung Meinungsfreiheit/Persoenlichkeitsrecht (bundesverfassungsgericht.de).


### PR DESCRIPTION
## P2-Korrektur Verlagsredaktion: DDG-Paragrafen richtig zuordnen

Dennis (PR-Review) hat zu Recht angemerkt, dass der vorherige Fix die DDG-Paragrafen immer noch falsch zugeordnet hat. Tatsächlich verteilt das DDG die Regelungen so:

- **§ 7 DDG „Beschränkte Verantwortlichkeit"** — Abs. 1 verweist auf DSA Art. 4-8 (Mere Conduit/Caching/Hosting/freiwillige Untersuchungen/kein Monitoring); **Abs. 2** enthält die WLAN-Sondervorschrift (keine Behördenpflicht zu Registrierung/Passwort).
- **§ 8 DDG „Anspruch auf Sperrung bei Rechtsverletzung"** — Blocking Claim bei Verletzung von Rechten am geistigen Eigentum; Subsidiarität; Sperrung muss zumutbar und verhältnismäßig sein; Kostenerstattung nur bei vorsätzlichem Zusammenwirken; in Abs. 4 ausdrücklich der Verweis auf gerichtliche/behördliche Entfernungs- und Sperrungsanordnungen.

Verifiziert am amtlichen Wortlaut unter [gesetze-im-internet.de/ddg/__7.html](https://www.gesetze-im-internet.de/ddg/__7.html) und [gesetze-im-internet.de/ddg/__8.html](https://www.gesetze-im-internet.de/ddg/__8.html).

### Diff

**verl-rueckruf-fehlerbeitrag-spaet-erkannt — Abschnitt „Rechtlicher und sachlicher Rahmen"**

Vorher (in PR #192 gemergt — leider falsch):
> DDG § 7 i.V.m. DSA Art. 4-8 (Mere Conduit, Caching, Hosting, freiwillige Untersuchungen, kein allgemeines Monitoring) - Haftungsprivilegien für Diensteanbieter; DDG § 8 - Sondervorschrift WLAN-Betreiber. Hinweis: Das TMG ist seit Mai 2024 durch DDG plus DSA abgelöst.

Jetzt:
> - DDG § 7 Abs. 1 i.V.m. DSA Art. 4-8 (Mere Conduit, Caching, Hosting, freiwillige Untersuchungen, kein allgemeines Monitoring) - beschränkte Verantwortlichkeit der Diensteanbieter; DDG § 7 Abs. 2 - Sondervorschrift für WLAN-Anbieter (keine behördliche Pflicht zu Registrierung oder Passwortabfrage).
> - DDG § 8 - Anspruch auf Sperrung bei Rechtsverletzung: Inhaber eines Rechts am geistigen Eigentum kann vom Diensteanbieter die Sperrung verlangen, wenn keine andere Abhilfemöglichkeit besteht; Sperrung muss zumutbar und verhältnismäßig sein; Kostenerstattung nur bei vorsätzlichem Zusammenwirken. Verpflichtungen zur Entfernung oder Sperrung nach allgemeinen Gesetzen auf Grund gerichtlicher oder behördlicher Anordnungen bleiben unberührt (§ 8 Abs. 4 DDG).
> - Hinweis: Das TMG ist seit Mai 2024 durch DDG plus DSA abgelöst.

**Quellen Stand 06/2026 (analog konsistent gezogen).**

### Praxisrelevanz für den Skill
Im Rückruf-/Online-Takedown-Szenario brauchen Redaktionen genau diese korrekte Zuordnung: § 8 DDG ist die einschlägige Anspruchsgrundlage gegenüber Hosting- und Access-Diensteanbietern bei IP-Verletzungen — nicht eine WLAN-Sondernorm.

### Validatoren
- `node scripts/validate-plugin-structure.mjs` → OK
- `python3 scripts/validate-yaml-frontmatter.py` → 0 Fehler, 0 Warnungen
