### PR TITLE
chore(readme): kleine Drift-Korrekturen (130 Plugins / v58.0.0 in ASSET_INDEX)

### DIFF
--- a/ASSET_INDEX.md
+++ b/ASSET_INDEX.md
@@ -1,6 +1,6 @@
 # Release-Asset-Index
 
-**Stand:** v57.0.0 — automatisch aktualisierte Asset-Übersicht
+**Stand:** v58.0.0 — automatisch aktualisierte Asset-Übersicht
 
 ## Sammel-Assets
 

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ Wenn Nutzerinnen und Nutzer auf dem Mac scheitern, liegt es häufig an der herun
 - `alle-plugins-megazip.zip` ist nur ein Sammelarchiv. Es muss zuerst entpackt werden; anschließend die darin enthaltenen Plugin-ZIPs einzeln hochladen.
 - Nicht das GitHub-Repository-ZIP aus **Code → Download ZIP** verwenden. Das ist Quellcode, kein direkt installierbares Plugin-ZIP.
 - Bei iCloud-Desktop/Downloads die ZIP erst lokal vollständig laden. Im Zweifel nach `~/Downloads/claude-plugins/` verschieben und dann aus diesem lokalen Ordner auswählen.
-- Beim Cowork-Organisations-Upload müssen Plugin-ZIPs gültige ZIP-Dateien unter 50 MB sein; für alle 112 Plugins ist GitHub-Sync/Marketplace robuster als manueller Einzelupload.
+- Beim Cowork-Organisations-Upload müssen Plugin-ZIPs gültige ZIP-Dateien unter 50 MB sein; für alle 130 Plugins ist GitHub-Sync/Marketplace robuster als manueller Einzelupload.
 - Technischer Check im Terminal:
 
 ```bash


### PR DESCRIPTION
## README-Konsistenzcheck — zwei kleine Drifts

Konsistenzcheck der Repo-Übersichten nach Wachstum auf v58.0.0 / 130 Plugins / 9156 Skills / 139 Testakten.

### Korrekturen

1. **`README.md`** Z. 383: „für alle **112** Plugins" → „für alle **130** Plugins" (Cowork-Organisations-Upload-Hinweis war auf altem Stand)
2. **`ASSET_INDEX.md`** Z. 3: Stand `v57.0.0` → `v58.0.0` (Header war hinter dem Haupt-README zurück; Repo ist bereits v58.0.0)

### Was geprüft wurde (alles grün)

| Check | Ergebnis |
|---|---|
| Plugin-Anzahl FS vs. marketplace.json | 130 = 130 ✓ |
| Testakten-Ordner vs. testakten/README.md | 139 = 139 ✓ |
| Keine verwaisten Plugins/Testakten | ✓ |
| NKR-Plugin alphabetisch korrekt in marketplace.json (zwischen `nda-abgleich` und `normenkontrolle-bauleitplanung`) | ✓ |
| NKR-Testakte in Plugin-README und `testakten/README.md` verlinkt | ✓ |
| verlagsredaktion-Plugin-README zeigt aktuell 104 Skills | ✓ |
| `validate-plugin-structure.mjs` | OK |
| Root README v-Marker `v58.0.0` | ✓ |

## Test plan

- [x] Validator grün
- [x] Konsistenzcheck dokumentiert

https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL

---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_