### PR TITLE
fix: NKRG-Paragrafen, BMJ-Anbindung, Digitalcheck-Termin und DDG Paragraph 8 Mere Conduit

### DIFF
--- a/normenkontrollrat-nkr/skills/nkr-aufgabe-und-kompetenz-nkrg/SKILL.md
+++ b/normenkontrollrat-nkr/skills/nkr-aufgabe-und-kompetenz-nkrg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nkr-aufgabe-und-kompetenz-nkrg
-description: "Zeigt Aufgabe Zustaendigkeit Unabhaengigkeit und Befassungspflichten des Nationalen Normenkontrollrats nach NKRG. Erklaert insbesondere § 1 Einsetzung § 4 Pruefung § 6 Stellungnahme und die institutionelle Stellung als Beratungs- und Kontrollgremium der Bundesregierung. Liefert Bausteine fuer interne Vermerke und Mandatsbrief sowie eine Kompetenz-Checkliste zur Abgrenzung."
+description: "Zeigt Aufgabe Zustaendigkeit Unabhaengigkeit und Befassungspflichten des Nationalen Normenkontrollrats nach NKRG. Erklaert insbesondere § 1 Einsetzung beim BMJ § 2 Erfuellungsaufwand § 3 Zusammensetzung § 4 Pruefung § 6 Stellungnahme und die institutionelle Stellung als Beratungs- und Kontrollgremium der Bundesregierung. Liefert Bausteine fuer interne Vermerke und Mandatsbrief sowie eine Kompetenz-Checkliste zur Abgrenzung."
 ---
 
 # NKR-Aufgabe und Kompetenz nach NKRG
@@ -22,14 +22,14 @@ Eine Rueckfrage nur dann, wenn der konkrete Bezug unklar ist: *"Welcher Vorgang 
 
 **Gesetz ueber die Einsetzung eines Nationalen Normenkontrollrats (NKRG) vom 14.08.2006, BGBl. I S. 1866** in der jeweils geltenden Fassung. Kernregelungen:
 
-- **§ 1 NKRG** — Einsetzung als unabhaengiges Gremium beim Bundeskanzleramt
-- **§ 2 NKRG** — Zusammensetzung (10 ehrenamtliche Mitglieder, Berufung auf 5 Jahre)
-- **§ 3 NKRG** — Unabhaengigkeit; nur dem Gesetz unterworfen
-- **§ 4 NKRG** — Pruefungsgegenstand: Darstellung des Erfuellungsaufwands neuer Regelungsvorhaben
+- **§ 1 NKRG** — Einsetzung beim **Bundesministerium der Justiz (BMJ)** mit Dienstsitz in Berlin; nur an den durch das NKRG begruendeten Auftrag gebunden und in seiner Taetigkeit unabhaengig (§ 1 Abs. 2); Pruefung der Darstellung des Erfuellungsaufwands auf Nachvollziehbarkeit und Methodengerechtigkeit (§ 1 Abs. 3)
+- **§ 2 NKRG** — Erfuellungsaufwand: gesamter messbarer Zeitaufwand und Kosten fuer Buerger, Wirtschaft und Verwaltung; Buerokratiekosten als Teilmenge; methodische Grundlage Standardkostenmodell (SKM)
+- **§ 3 NKRG** — Zusammensetzung: 10 ehrenamtliche Mitglieder; Vorschlag durch das BMJ, Berufung durch den Bundespraesidenten; Amtszeit 5 Jahre, einmalige Wiederberufung moeglich; Vorsitz und stellvertretender Vorsitz werden vom BMJ bestimmt; Rechtsaufsicht liegt beim BMJ; Geschaeftsstelle (Sekretariat) ist beim BMJ angesiedelt; Bund traegt die Kosten
+- **§ 4 NKRG** — Pruefungsgegenstand: Darstellung des Erfuellungsaufwands neuer Regelungsvorhaben; **§ 4 Abs. 3 NKRG** — Digitalcheck (Pruefung der Moeglichkeiten digitaler Ausfuehrung)
 - **§ 5 NKRG** — Auskunfts- und Akteneinsichtsrecht gegenueber den Ressorts
 - **§ 6 NKRG** — Stellungnahme als formelle Aeusserung; Vorlage an Bundesregierung und Bundestag
 - **§ 7 NKRG** — Jahresbericht
-- **§ 8 NKRG** — Sekretariat (Geschaeftsstelle beim Bundeskanzleramt)
+- **§ 9 NKRG** — § 4 Abs. 3 (Digitalcheck) ist ab dem **1. Januar 2023** anzuwenden
 
 Ergaenzend: **§ 44 GGO** (Pruefung der Gesetzesfolgen), **§ 45 GGO** (Erfuellungsaufwand-Darstellung), **§ 62 Abs. 1 GGO** (NKR-Befassungspflicht vor Kabinettsbefassung).
 
@@ -69,7 +69,7 @@ Hier dient die NKR-Sicht der Selbstvergewisserung der Institution:
 |---|---|
 | Ressort liefert vollstaendig | Sachpruefung |
 | Ressort liefert luckenhaft | Nachforderung |
-| Ressort verweigert | § 5 NKRG, ggf. Eskalation an Kanzleramt |
+| Ressort verweigert | § 5 NKRG, ggf. Eskalation an das BMJ (institutionelle Anbindung NKR) |
 | Vorhaben politisch heikel, methodisch sauber | NKR aeussert nur Methodik |
 | Vorhaben methodisch sauber, Vollzug unpraktikabel | NKR aeussert sich zu Praktikabilitaet |
 
@@ -84,6 +84,7 @@ Hier dient die NKR-Sicht der Selbstvergewisserung der Institution:
 - Fehlhinweise auf "vorlaeufige NKR-Befassung" (es gibt nur die foermliche)
 - Annahme, NKR pruefe Verfassungsmaessigkeit (das pruefen BMJ-Rechtsabteilung und ggf. BVerfG)
 - Annahme, NKR pruefe Kosten fuer den Bundeshaushalt (das ist BMF und Bundesrechnungshof)
+- Veraltete Angabe "NKR sitzt beim Bundeskanzleramt" — NKR ist nach § 1 NKRG **beim BMJ** eingerichtet, Geschaeftsstelle beim BMJ (§ 3 NKRG); Unabhaengigkeit nach § 1 Abs. 2 NKRG bleibt davon unberuehrt
 
 ## Querverweise
 

--- a/normenkontrollrat-nkr/skills/nkr-digitalcheck-und-onlinezugangsgesetz-ozg/SKILL.md
+++ b/normenkontrollrat-nkr/skills/nkr-digitalcheck-und-onlinezugangsgesetz-ozg/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: nkr-digitalcheck-und-onlinezugangsgesetz-ozg
-description: "Spezialskill OZG und Digitalcheck. Beschreibt das Onlinezugangsgesetz die OZG-Leistungen den Portalverbund das Once-Only-Prinzip und die seit 2022 eingefuehrte Digitalcheck-Methodik fuer Bundesregelungsvorhaben. Mit Schnittstellen-Checkliste FIM XOEV ELSTER beA und Standardbausteinen fuer die Stellungnahme."
+description: "Spezialskill OZG und Digitalcheck. Beschreibt das Onlinezugangsgesetz die OZG-Leistungen den Portalverbund das Once-Only-Prinzip und die ab dem 1. Januar 2023 anwendbare Digitalcheck-Methodik nach § 4 Abs. 3 i.V.m. § 9 NKRG fuer Bundesregelungsvorhaben. Mit Schnittstellen-Checkliste FIM XOEV ELSTER beA und Standardbausteinen fuer die Stellungnahme."
 ---
 
 # NKR-Digitalcheck und Onlinezugangsgesetz (OZG)
 
 ## Worum geht es konkret
 
-Das Onlinezugangsgesetz (OZG) verpflichtet Bund und Laender, Verwaltungsleistungen digital anzubieten. Der Digitalcheck (BMI/NKR seit 2022) prueft, ob Bundesregelungsvorhaben digital praktikabel sind. Beide Instrumente sind zentral fuer die NKR-Pruefung von Vorhaben mit digitalen Bezuegen.
+Das Onlinezugangsgesetz (OZG) verpflichtet Bund und Laender, Verwaltungsleistungen digital anzubieten. Der Digitalcheck (BMI / NKR; gesetzliche Grundlage § 4 Abs. 3 NKRG, ab dem **1. Januar 2023 anzuwenden** gemaess § 9 NKRG) prueft, ob Bundesregelungsvorhaben digital praktikabel sind. Beide Instrumente sind zentral fuer die NKR-Pruefung von Vorhaben mit digitalen Bezuegen.
 
 ## Wann brauchen Sie diesen Skill / Kaltstart-Fragen
 
@@ -21,10 +21,12 @@ Rueckfrage nur wenn unklar: *"Welche OZG-Leistung ist betroffen? Wer ist Leistun
 ## Rechtlicher und methodischer Rahmen
 
 - **Onlinezugangsgesetz (OZG)** in der jeweils geltenden Fassung (urspruenglich vom 14.08.2017; OZG 2.0 / Folgeregulierung Stand vom Anwender zu verifizieren)
-- **Digitalcheck-Methodik** (BMI / NKR, seit 2022, jeweils aktuelle Fassung)
+- **Digitalcheck-Methodik** (BMI / NKR, jeweils aktuelle Fassung)
+- **§ 4 Abs. 3 NKRG** — Digitalcheck als Pruefungsbestandteil (Pruefung der Moeglichkeiten digitaler Ausfuehrung)
+- **§ 9 NKRG** — § 4 Abs. 3 NKRG ist **ab dem 1. Januar 2023 anzuwenden** (Uebergangsregelung)
 - **eIDAS-Verordnung (EU) 910/2014** in der jeweils geltenden Fassung
 - **EU Single Digital Gateway-VO (EU) 2018/1724** (Once-Only auf EU-Ebene)
-- **§ 44 GGO**, **NKRG** § 4
+- **§ 44 GGO**, **NKRG** § 4 (Pruefungsgegenstand)
 - **Standards XOEV, FIM, ELSTER, beA**
 
 ## OZG-Grundbegriffe
@@ -132,9 +134,9 @@ Rueckfrage nur wenn unklar: *"Welche OZG-Leistung ist betroffen? Wer ist Leistun
 ## Quellen Stand 06/2026
 
 - Onlinezugangsgesetz (OZG) vom 14.08.2017 in der jeweils geltenden Fassung; OZG-Folgeregulierung Stand vom Anwender zu verifizieren
-- Digitalcheck-Methodik (BMI / NKR, seit 2022, jeweils aktuelle Fassung)
+- Digitalcheck-Methodik (BMI / NKR, jeweils aktuelle Fassung)
 - eIDAS-Verordnung (EU) 910/2014 in der jeweils geltenden Fassung
 - EU Single Digital Gateway-VO (EU) 2018/1724
-- § 44 GGO; NKRG vom 14.08.2006 (BGBl. I S. 1866) § 4
+- § 44 GGO; NKRG vom 14.08.2006 (BGBl. I S. 1866) § 4 Abs. 3 (Digitalcheck) i.V.m. § 9 (Anwendbarkeit ab 1. Januar 2023)
 - NKR-Jahresbericht (jeweils aktuelle Ausgabe)
 - Live verifizieren ueber [www.digitalcheck.bund.de](https://www.digitalcheck.bund.de), [www.normenkontrollrat.bund.de](https://www.normenkontrollrat.bund.de)

--- a/normenkontrollrat-nkr/skills/nkr-zusammenarbeit-mit-bundesregierung-und-ressorts/SKILL.md
+++ b/normenkontrollrat-nkr/skills/nkr-zusammenarbeit-mit-bundesregierung-und-ressorts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nkr-zusammenarbeit-mit-bundesregierung-und-ressorts
-description: "Verhaltens-Skill fuer die taegliche Zusammenarbeit zwischen NKR-Sekretariat und Ressorts. Beschreibt informelle Vorklaerungen Datenanforderungen § 5 NKRG Eskalationsstufen Konfliktbewaeltigung Dialog mit dem federfuehrenden Referat und Schnittstelle Bundeskanzleramt. Mit Mustertexten fuer Nachforderungsschreiben und Eskalationsmail."
+description: "Verhaltens-Skill fuer die taegliche Zusammenarbeit zwischen NKR-Sekretariat und Ressorts. Beschreibt informelle Vorklaerungen Datenanforderungen § 5 NKRG Eskalationsstufen Konfliktbewaeltigung Dialog mit dem federfuehrenden Referat und Schnittstelle Bundesministerium der Justiz als institutionelle Anbindung des NKR. Mit Mustertexten fuer Nachforderungsschreiben und Eskalationsmail."
 ---
 
 # NKR-Zusammenarbeit mit Bundesregierung und Ressorts
@@ -20,8 +20,9 @@ Rueckfrage nur wenn der Konflikt unklar ist: *"Wo hakt es konkret — Daten, Met
 
 ## Rechtlicher und methodischer Rahmen
 
+- **§ 1 NKRG** — Einsetzung beim Bundesministerium der Justiz (BMJ); unabhaengig nach § 1 Abs. 2
+- **§ 3 NKRG** — Geschaeftsstelle des NKR ist beim BMJ angesiedelt; Rechtsaufsicht beim BMJ
 - **§ 5 NKRG** — Auskunfts- und Akteneinsichtsrecht
-- **§ 8 NKRG** — Sekretariat als Geschaeftsstelle
 - **§ 62 GGO** — Pflicht zur NKR-Befassung
 - **GGO § 22, § 23** — Ressortabstimmung allgemein
 - Geschaeftsordnung des NKR (intern)
@@ -50,7 +51,7 @@ Rueckfrage nur wenn der Konflikt unklar ist: *"Wo hakt es konkret — Daten, Met
 
 - Wenn auch Unterabteilung nicht reagiert
 - Schreiben an Abteilungs- oder Staatssekretaersebene
-- Information an Bundeskanzleramt (institutionelle Anbindung des NKR)
+- Information an das **Bundesministerium der Justiz (BMJ)** als institutionelle Anbindung des NKR (§ 1, § 3 NKRG); ggf. parallel Hinweis an das Bundeskanzleramt im Rahmen der allgemeinen Kabinettsbefassung
 
 ### Stufe 5 — Negative Stellungnahme
 
@@ -72,7 +73,7 @@ Rueckfrage nur wenn der Konflikt unklar ist: *"Wo hakt es konkret — Daten, Met
 | Niedrig (Verstaendnisfrage) | Telefon Referent zu Referent | gering |
 | Mittel (Datenluecke) | Schriftliche Nachfrage | gering |
 | Hoch (Verweigerung) | Eskalation Abteilung / Staatssekretaer | mittel |
-| Sehr hoch (institutionell) | Information Kanzleramt, harte Stellungnahme | hoch — politisch |
+| Sehr hoch (institutionell) | Information BMJ (institutionelle Anbindung NKR), harte Stellungnahme; ggf. flankierend Kabinettsebene | hoch — politisch |
 
 ## Mustertexte / Stellungnahme-Bausteine
 
@@ -102,7 +103,7 @@ In der Stellungnahme:
 
 ## Quellen Stand 06/2026
 
-- NKRG vom 14.08.2006 (BGBl. I S. 1866) §§ 5, 6, 8
+- NKRG vom 14.08.2006 (BGBl. I S. 1866) §§ 1, 3, 5, 6
 - §§ 22, 23, 47, 62 GGO
 - Geschaeftsordnung des NKR (intern)
 - NKR-Jahresbericht (jeweils aktuelle Ausgabe)

--- a/verlagsredaktion/skills/verl-rueckruf-fehlerbeitrag-spaet-erkannt/SKILL.md
+++ b/verlagsredaktion/skills/verl-rueckruf-fehlerbeitrag-spaet-erkannt/SKILL.md
@@ -26,7 +26,7 @@ Nach Erscheinen wird ein gravierender Fehler entdeckt: falsche Aktenzeichen-Anga
 - UrhG § 14 - Recht des Urhebers auf Schutz vor Entstellung des Werks (bei eigenmaechtiger Aenderung).
 - UrhG §§ 97, 97a - Schadensersatz, Abmahnung.
 - DDG § 7 Abs. 1 i.V.m. DSA Art. 4-8 (Mere Conduit, Caching, Hosting, freiwillige Untersuchungen, kein allgemeines Monitoring) - beschraenkte Verantwortlichkeit der Diensteanbieter; DDG § 7 Abs. 2 - Sondervorschrift fuer WLAN-Anbieter (keine behoerdliche Pflicht zu Registrierung oder Passwortabfrage).
-- DDG § 8 - Anspruch auf Sperrung bei Rechtsverletzung: Inhaber eines Rechts am geistigen Eigentum kann vom Diensteanbieter die Sperrung verlangen, wenn keine andere Abhilfemoeglichkeit besteht; Sperrung muss zumutbar und verhaeltnismaessig sein; Kostenerstattung nur bei vorsaetzlichem Zusammenwirken. Verpflichtungen zur Entfernung oder Sperrung nach allgemeinen Gesetzen auf Grund gerichtlicher oder behoerdlicher Anordnungen bleiben unberuehrt (§ 8 Abs. 4 DDG).
+- DDG § 8 - Anspruch auf Sperrung bei Rechtsverletzung am geistigen Eigentum: Anspruch besteht nur gegen Diensteanbieter, die einen digitalen Dienst erbringen, der darin besteht, von einem Nutzer bereitgestellte Informationen in einem Kommunikationsnetz zu uebermitteln oder den Zugang zu einem Kommunikationsnetz zu vermitteln (§ 8 Abs. 1 DDG; reine Durchleitungs-/Zugangsdienste - nicht Hosting, Datenbankanbieter oder sonstige Diensteanbieter ausserhalb von Mere Conduit). Sperrung muss zumutbar und verhaeltnismaessig sein; Kostenerstattung nur bei vorsaetzlichem Zusammenwirken. Verpflichtungen zur Entfernung oder Sperrung nach allgemeinen Gesetzen auf Grund gerichtlicher oder behoerdlicher Anordnungen bleiben unberuehrt (§ 8 Abs. 4 DDG). Gegen Hosting- und Datenbankanbieter (juris, beck-online) richten sich Ansprueche stattdessen aus DSA Art. 6 i.V.m. den allgemeinen Gesetzen (Beseitigung, Unterlassung).
 - Hinweis: Das TMG ist seit Mai 2024 durch DDG plus DSA abgeloest.
 - UWG §§ 5, 5a - Irrefuehrung; bei Werbeaussagen relevant.
 - Aeusserungsrecht: BVerfG-Rechtsprechung zu Werturteil vs. Tatsachenbehauptung (zu pruefen unter bundesverfassungsgericht.de).
@@ -162,6 +162,6 @@ Mit freundlichen Gruessen
 
 - BGB §§ 823, 824, 1004 (analog) - Schadensersatz, Kreditgefaehrdung, Beseitigung.
 - UrhG §§ 14, 97, 97a - Werkschutz, Schadensersatz, Abmahnung.
-- DDG § 7 i.V.m. DSA Art. 4-8 - beschraenkte Verantwortlichkeit Diensteanbieter; § 7 Abs. 2 DDG - WLAN-Sondervorschrift; DDG § 8 - Anspruch auf Sperrung bei Rechtsverletzung an geistigem Eigentum.
+- DDG § 7 i.V.m. DSA Art. 4-8 - beschraenkte Verantwortlichkeit Diensteanbieter; § 7 Abs. 2 DDG - WLAN-Sondervorschrift; DDG § 8 Abs. 1 - Sperrungsanspruch nur gegen Uebermittlungs-/Zugangsdiensteanbieter (Mere Conduit), nicht gegen Hosting oder Datenbankanbieter.
 - UWG §§ 5, 5a - Irrefuehrung.
 - Aktuelle BVerfG-Rechtsprechung zur Abwaegung Meinungsfreiheit/Persoenlichkeitsrecht (bundesverfassungsgericht.de).


### PR DESCRIPTION
## Codex-Findings P1/P2 — NKRG-Paragrafen, BMJ-Anbindung, Digitalcheck-Termin, DDG § 8 Mere Conduit

Hotfix der vier von Codex gemeldeten Befunde. Rechtsgrundlagen am amtlichen Text auf [gesetze-im-internet.de](https://www.gesetze-im-internet.de/nkrg/) und [gesetze-im-internet.de/ddg/__8.html](https://www.gesetze-im-internet.de/ddg/__8.html) verifiziert.

### P1 `nkr-aufgabe-und-kompetenz-nkrg`
Paragrafen-Mapping korrigiert:
- **§ 1 NKRG**: NKR ist **beim Bundesministerium der Justiz (BMJ)** mit Dienstsitz in Berlin eingerichtet, nicht beim Bundeskanzleramt. Unabhängigkeit nach § 1 Abs. 2; Prüfung Erfüllungsaufwand auf Nachvollziehbarkeit und Methodengerechtigkeit nach § 1 Abs. 3.
- **§ 2 NKRG**: Erfüllungsaufwand-Definition (gesamter messbarer Zeitaufwand und Kosten; Bürokratiekosten als Teilmenge; SKM-Methodik).
- **§ 3 NKRG**: Zusammensetzung — 10 ehrenamtliche Mitglieder, Vorschlag BMJ, Berufung durch Bundespräsident, 5 Jahre, einmalige Wiederberufung; Vorsitz/Stellvertretung durch BMJ; Rechtsaufsicht BMJ; Geschäftsstelle beim BMJ.
- **§ 4 Abs. 3 NKRG**: Digitalcheck (Prüfung der Möglichkeiten digitaler Ausführung).
- **§ 9 NKRG**: § 4 Abs. 3 ist ab dem 1. Januar 2023 anzuwenden.
- Neuer Pitfall-Eintrag: Veraltete Annahme "NKR sitzt beim Bundeskanzleramt" — NKR ist nach § 1 NKRG beim BMJ; Unabhängigkeit nach § 1 Abs. 2 bleibt unberührt.

### P2 `nkr-zusammenarbeit-mit-bundesregierung-und-ressorts`
- Stufe 4 (Hausleitungs-Eskalation): primär Information an das **BMJ als institutionelle Anbindung des NKR** (§§ 1, 3 NKRG), nicht primär ans Bundeskanzleramt; Kabinettsweg als ergänzende Flanke.
- Rechtsrahmen, Trade-off-Matrix und Quellen entsprechend aktualisiert.

### P2 `nkr-digitalcheck-und-onlinezugangsgesetz-ozg`
- Anwendbarkeit Digitalcheck **ab dem 1. Januar 2023** statt 2022 (§ 4 Abs. 3 i.V.m. § 9 NKRG, Übergangsregelung).
- Beschreibung, Worum-geht-es, Rechtsrahmen und Quellen mit dem korrekten Stichtag versehen.

### P2 `verl-rueckruf-fehlerbeitrag-spaet-erkannt`
- **§ 8 Abs. 1 DDG**: Sperrungsanspruch besteht **nur gegen Übermittlungs- und Zugangsdiensteanbieter (Mere Conduit)** — nicht gegen Hosting- und Datenbankanbieter.
- Ergänzender Hinweis: Gegen Hosting (juris, beck-online) richten sich Ansprüche aus DSA Art. 6 i.V.m. den allgemeinen Gesetzen (Beseitigung, Unterlassung).
- § 8 Abs. 4 DDG (unberührte gerichtliche/behördliche Anordnungen) bleibt erhalten.

## Validierung

- `node scripts/validate-plugin-structure.mjs` → validate-plugin-structure OK
- `python3 scripts/validate-yaml-frontmatter.py` → 0 Fehler, 0 Warnungen

## Quellen

- NKRG: https://www.gesetze-im-internet.de/nkrg/
- DDG § 8: https://www.gesetze-im-internet.de/ddg/__8.html
