### PR TITLE
fix(nkrg): § 1 Abs. 1 Satz 2 für Unabhängigkeit und § 3 Abs. 4 für Vorsitz präzisieren

### DIFF
--- a/normenkontrollrat-nkr/skills/nkr-aufgabe-und-kompetenz-nkrg/SKILL.md
+++ b/normenkontrollrat-nkr/skills/nkr-aufgabe-und-kompetenz-nkrg/SKILL.md
@@ -22,9 +22,9 @@ Eine Rueckfrage nur dann, wenn der konkrete Bezug unklar ist: *"Welcher Vorgang 
 
 **Gesetz ueber die Einsetzung eines Nationalen Normenkontrollrats (NKRG) vom 14.08.2006, BGBl. I S. 1866** in der jeweils geltenden Fassung. Kernregelungen:
 
-- **§ 1 NKRG** — Einsetzung beim **Bundesministerium der Justiz (BMJ)** mit Dienstsitz in Berlin; nur an den durch das NKRG begruendeten Auftrag gebunden und in seiner Taetigkeit unabhaengig (§ 1 Abs. 2); Pruefung der Darstellung des Erfuellungsaufwands auf Nachvollziehbarkeit und Methodengerechtigkeit (§ 1 Abs. 3)
+- **§ 1 NKRG** — Einsetzung beim **Bundesministerium der Justiz (BMJ)** mit Dienstsitz in Berlin (§ 1 Abs. 1 Satz 1); nur an den durch das NKRG begruendeten Auftrag gebunden und in seiner Taetigkeit unabhaengig (§ 1 Abs. 1 Satz 2); Aufgabe ist die Unterstuetzung der Bundesregierung bei Buerokratieabbau und besserer Rechtsetzung (§ 1 Abs. 2); Pruefung der Darstellung des Erfuellungsaufwands auf Nachvollziehbarkeit und Methodengerechtigkeit (§ 1 Abs. 3)
 - **§ 2 NKRG** — Erfuellungsaufwand: gesamter messbarer Zeitaufwand und Kosten fuer Buerger, Wirtschaft und Verwaltung; Buerokratiekosten als Teilmenge; methodische Grundlage Standardkostenmodell (SKM)
-- **§ 3 NKRG** — Zusammensetzung: 10 ehrenamtliche Mitglieder; Vorschlag durch das BMJ, Berufung durch den Bundespraesidenten; Amtszeit 5 Jahre, einmalige Wiederberufung moeglich; Vorsitz und stellvertretender Vorsitz werden vom BMJ bestimmt; Rechtsaufsicht liegt beim BMJ; Geschaeftsstelle (Sekretariat) ist beim BMJ angesiedelt; Bund traegt die Kosten
+- **§ 3 NKRG** — Zusammensetzung: 10 ehrenamtliche Mitglieder; Vorschlag durch den Bundesminister der Justiz im Einvernehmen mit den uebrigen Mitgliedern der Bundesregierung, Berufung durch den Bundespraesidenten; Amtszeit 5 Jahre, eine erneute Berufung ist zulaessig (§ 3 Abs. 1 NKRG, ohne Begrenzung auf eine einmalige Wiederberufung); das den Vorsitz fuehrende Mitglied wird vom BMJ bestimmt, eine erneute Bestimmung dieses Vorsitzmitglieds ist nur einmal zulaessig (§ 3 Abs. 4 NKRG); Rechtsaufsicht beim BMJ (§ 3 Abs. 8); Sekretariat beim BMJ (§ 3 Abs. 9); Bund traegt die Kosten (§ 3 Abs. 12)
 - **§ 4 NKRG** — Pruefungsgegenstand: Darstellung des Erfuellungsaufwands neuer Regelungsvorhaben; **§ 4 Abs. 3 NKRG** — Digitalcheck (Pruefung der Moeglichkeiten digitaler Ausfuehrung)
 - **§ 5 NKRG** — Auskunfts- und Akteneinsichtsrecht gegenueber den Ressorts
 - **§ 6 NKRG** — Stellungnahme als formelle Aeusserung; Vorlage an Bundesregierung und Bundestag
@@ -84,7 +84,7 @@ Hier dient die NKR-Sicht der Selbstvergewisserung der Institution:
 - Fehlhinweise auf "vorlaeufige NKR-Befassung" (es gibt nur die foermliche)
 - Annahme, NKR pruefe Verfassungsmaessigkeit (das pruefen BMJ-Rechtsabteilung und ggf. BVerfG)
 - Annahme, NKR pruefe Kosten fuer den Bundeshaushalt (das ist BMF und Bundesrechnungshof)
-- Veraltete Angabe "NKR sitzt beim Bundeskanzleramt" — NKR ist nach § 1 NKRG **beim BMJ** eingerichtet, Geschaeftsstelle beim BMJ (§ 3 NKRG); Unabhaengigkeit nach § 1 Abs. 2 NKRG bleibt davon unberuehrt
+- Veraltete Angabe "NKR sitzt beim Bundeskanzleramt" — NKR ist nach § 1 Abs. 1 Satz 1 NKRG **beim BMJ** eingerichtet, Geschaeftsstelle beim BMJ (§ 3 Abs. 9 NKRG); Unabhaengigkeit nach § 1 Abs. 1 Satz 2 NKRG bleibt davon unberuehrt
 
 ## Querverweise
 

--- a/normenkontrollrat-nkr/skills/nkr-zusammenarbeit-mit-bundesregierung-und-ressorts/SKILL.md
+++ b/normenkontrollrat-nkr/skills/nkr-zusammenarbeit-mit-bundesregierung-und-ressorts/SKILL.md
@@ -20,8 +20,8 @@ Rueckfrage nur wenn der Konflikt unklar ist: *"Wo hakt es konkret — Daten, Met
 
 ## Rechtlicher und methodischer Rahmen
 
-- **§ 1 NKRG** — Einsetzung beim Bundesministerium der Justiz (BMJ); unabhaengig nach § 1 Abs. 2
-- **§ 3 NKRG** — Geschaeftsstelle des NKR ist beim BMJ angesiedelt; Rechtsaufsicht beim BMJ
+- **§ 1 NKRG** — Einsetzung beim Bundesministerium der Justiz (BMJ) gemaess § 1 Abs. 1 Satz 1 NKRG; unabhaengig nach § 1 Abs. 1 Satz 2 NKRG; Aufgabe der Unterstuetzung der Bundesregierung folgt aus § 1 Abs. 2 NKRG
+- **§ 3 NKRG** — Sekretariat (Geschaeftsstelle) des NKR ist beim BMJ angesiedelt (§ 3 Abs. 9); Rechtsaufsicht beim BMJ (§ 3 Abs. 8); das den Vorsitz fuehrende Mitglied wird vom BMJ bestimmt (§ 3 Abs. 4)
 - **§ 5 NKRG** — Auskunfts- und Akteneinsichtsrecht
 - **§ 62 GGO** — Pflicht zur NKR-Befassung
 - **GGO § 22, § 23** — Ressortabstimmung allgemein
@@ -51,7 +51,7 @@ Rueckfrage nur wenn der Konflikt unklar ist: *"Wo hakt es konkret — Daten, Met
 
 - Wenn auch Unterabteilung nicht reagiert
 - Schreiben an Abteilungs- oder Staatssekretaersebene
-- Information an das **Bundesministerium der Justiz (BMJ)** als institutionelle Anbindung des NKR (§ 1, § 3 NKRG); ggf. parallel Hinweis an das Bundeskanzleramt im Rahmen der allgemeinen Kabinettsbefassung
+- Information an das **Bundesministerium der Justiz (BMJ)** als institutionelle Anbindung des NKR (§ 1 Abs. 1 Satz 1, § 3 Abs. 8 und Abs. 9 NKRG); ggf. parallel Hinweis an das Bundeskanzleramt im Rahmen der allgemeinen Kabinettsbefassung
 
 ### Stufe 5 — Negative Stellungnahme
 


### PR DESCRIPTION
Codex-Findings auf PR #196 umgesetzt.

## § 1 NKRG — richtige Absatzzuordnung
- **§ 1 Abs. 1 Satz 2** = Unabhängigkeit (zuvor fälschlich § 1 Abs. 2)
- **§ 1 Abs. 2** = Aufgabe Unterstützung der Bundesregierung bei Bürokratieabbau / besserer Rechtsetzung
- **§ 1 Abs. 3** = Prüfung Nachvollziehbarkeit und Methodengerechtigkeit Erfüllungsaufwand

## § 3 NKRG — keine fingierten Begrenzungen
- **§ 3 Abs. 1 Satz 4**: "Eine erneute Berufung ist zulässig" — keine Einmal-Begrenzung der Mitgliedschaft; nicht behaupten
- **§ 3 Abs. 4**: BMJ bestimmt **das den Vorsitz führende Mitglied** (nicht stellvertretender Vorsitz); erneute Bestimmung dieses Vorsitzmitglieds nur einmal zulässig
- **§ 3 Abs. 8 / Abs. 9 / Abs. 12**: präzise Absatzverweise Rechtsaufsicht / Sekretariat / Kosten

## Betroffene Dateien
- normenkontrollrat-nkr/skills/nkr-aufgabe-und-kompetenz-nkrg/SKILL.md
- normenkontrollrat-nkr/skills/nkr-zusammenarbeit-mit-bundesregierung-und-ressorts/SKILL.md

## Quelle
NKRG i.d.F. 2022 (gesetze-im-internet.de/nkrg/__1.html, /__3.html).

## Validatoren
- validate-plugin-structure: OK
- validate-yaml-frontmatter: 0 Fehler, 0 Warnungen