### PR TITLE
fix(legw-router): toter Verweis legw-rmap-einstieg-und-eignung auf legw-rmap-grundlagen umbiegen

### DIFF
--- a/legistik-werkstatt/skills/legistik-auftragsaufnahme/SKILL.md
+++ b/legistik-werkstatt/skills/legistik-auftragsaufnahme/SKILL.md
@@ -134,5 +134,5 @@ Politikwissenschaftler bekommen erst dort das Sachfeld-Verstaendnis fuer Landwir
 Bauwesen; Verkehr und Co.
 
 Wenn das Vorhaben digital-tauglich werden soll (Rulemap; BMJ-Initiative; SPRIND), zusaetzlich
-Anschluss an **`legw-rmap-einstieg-und-eignung`**.
+Anschluss an **`legw-rmap-grundlagen`** (didaktischer Einstieg in 10 RuleMapping-Skills, abschliessend `legw-rmap-anschluss-an-legw` als Rueckkopplung).
 

--- a/legistik-werkstatt/skills/legw-ressort-router/SKILL.md
+++ b/legistik-werkstatt/skills/legw-ressort-router/SKILL.md
@@ -76,7 +76,7 @@ wenn er an eine fremde Materie heran muss.
 ### Schritt 5 - Optional RuleMapping-Anschluss
 
 Wenn das Vorhaben digital-tauglich werden soll (BMJ-Initiative; SPRIND-Foerderung; Rulemap-Builder):
-weiter zu `legw-rmap-einstieg-und-eignung`. Von dort 9 RuleMapping-Skills.
+weiter zu `legw-rmap-grundlagen` als didaktischem Einstieg in die RuleMapping-Methodik. Von dort fuehren insgesamt 10 RuleMapping-Skills durch den Workflow: `legw-rmap-grundlagen`, `legw-rmap-norm-zu-rulemap`, `legw-rmap-tatbestand-und-rechtsfolge`, `legw-rmap-verweisungen-und-ausnahmen`, `legw-rmap-bestimmtheit-und-justitiabilitaet`, `legw-rmap-entscheidungsbaum-validierung`, `legw-rmap-vollzugstauglichkeit`, `legw-rmap-evaluierung-und-aenderung`, `legw-rmap-export-und-systemintegration` und `legw-rmap-anschluss-an-legw` als Rueckkopplung in die Legistik-Werkstatt.
 
 ## Output
 
@@ -91,7 +91,7 @@ Empfohlene Skill-Kette:
   3. legw-<kuerzel>-<thema>            (Spezialfeld)
   4. normhierarchie-routing            (Normwahl)
   5. <weitere Spezial- und Werkstattskills>
-Optional RuleMapping-Anschluss: legw-rmap-einstieg-und-eignung
+Optional RuleMapping-Anschluss: legw-rmap-grundlagen (Einstieg in 10 RuleMapping-Skills)
 ```
 
 ## Quellenregel


### PR DESCRIPTION
Codex-Finding auf PR #198 umgesetzt.

## Problem
Der Ressort-Router und legistik-auftragsaufnahme verweisen am Übergang zu RuleMapping auf einen nicht existierenden Slug `legw-rmap-einstieg-und-eignung`. Das hätte den optionalen RuleMapping-Pfad ins Leere laufen lassen.

## Fix
- Verweis auf `legw-rmap-grundlagen` (didaktischer Einstieg in die 10 RuleMapping-Skills)
- Zusätzlich `legw-rmap-anschluss-an-legw` als Rückkopplung benannt
- Zahl korrigiert: **10** RuleMapping-Skills (nicht 9)
- Vollständige Skill-Kette im Router dokumentiert

## Betroffen
- legistik-werkstatt/skills/legw-ressort-router/SKILL.md (2 Stellen)
- legistik-werkstatt/skills/legistik-auftragsaufnahme/SKILL.md (1 Stelle)

## Validatoren
- validate-plugin-structure: OK
- validate-yaml-frontmatter: 0 Fehler, 0 Warnungen