### PR TITLE
fix(legw-ressort): toten RuleMapping-Verweis in allen 16 Ressort-Skills umbiegen

### DIFF
--- a/legistik-werkstatt/skills/legw-ressort-aa/SKILL.md
+++ b/legistik-werkstatt/skills/legw-ressort-aa/SKILL.md
@@ -100,7 +100,7 @@ Verbaendeanhoerung; Bundestagsweg; Aufsicht).
 
 ### Schritt 5 - Optional RuleMapping-Anschluss
 
-Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-einstieg-und-eignung`.
+Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-grundlagen` als Einstieg in die 10 RuleMapping-Skills (Abschluss mit `legw-rmap-anschluss-an-legw`).
 
 ## Output
 

--- a/legistik-werkstatt/skills/legw-ressort-bmas/SKILL.md
+++ b/legistik-werkstatt/skills/legw-ressort-bmas/SKILL.md
@@ -100,7 +100,7 @@ Verbaendeanhoerung; Bundestagsweg; Aufsicht).
 
 ### Schritt 5 - Optional RuleMapping-Anschluss
 
-Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-einstieg-und-eignung`.
+Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-grundlagen` als Einstieg in die 10 RuleMapping-Skills (Abschluss mit `legw-rmap-anschluss-an-legw`).
 
 ## Output
 

--- a/legistik-werkstatt/skills/legw-ressort-bmbfsfj/SKILL.md
+++ b/legistik-werkstatt/skills/legw-ressort-bmbfsfj/SKILL.md
@@ -100,7 +100,7 @@ Verbaendeanhoerung; Bundestagsweg; Aufsicht).
 
 ### Schritt 5 - Optional RuleMapping-Anschluss
 
-Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-einstieg-und-eignung`.
+Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-grundlagen` als Einstieg in die 10 RuleMapping-Skills (Abschluss mit `legw-rmap-anschluss-an-legw`).
 
 ## Output
 

--- a/legistik-werkstatt/skills/legw-ressort-bmds/SKILL.md
+++ b/legistik-werkstatt/skills/legw-ressort-bmds/SKILL.md
@@ -100,7 +100,7 @@ Verbaendeanhoerung; Bundestagsweg; Aufsicht).
 
 ### Schritt 5 - Optional RuleMapping-Anschluss
 
-Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-einstieg-und-eignung`.
+Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-grundlagen` als Einstieg in die 10 RuleMapping-Skills (Abschluss mit `legw-rmap-anschluss-an-legw`).
 
 ## Output
 

--- a/legistik-werkstatt/skills/legw-ressort-bmf/SKILL.md
+++ b/legistik-werkstatt/skills/legw-ressort-bmf/SKILL.md
@@ -100,7 +100,7 @@ Verbaendeanhoerung; Bundestagsweg; Aufsicht).
 
 ### Schritt 5 - Optional RuleMapping-Anschluss
 
-Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-einstieg-und-eignung`.
+Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-grundlagen` als Einstieg in die 10 RuleMapping-Skills (Abschluss mit `legw-rmap-anschluss-an-legw`).
 
 ## Output
 

--- a/legistik-werkstatt/skills/legw-ressort-bmftr/SKILL.md
+++ b/legistik-werkstatt/skills/legw-ressort-bmftr/SKILL.md
@@ -100,7 +100,7 @@ Verbaendeanhoerung; Bundestagsweg; Aufsicht).
 
 ### Schritt 5 - Optional RuleMapping-Anschluss
 
-Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-einstieg-und-eignung`.
+Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-grundlagen` als Einstieg in die 10 RuleMapping-Skills (Abschluss mit `legw-rmap-anschluss-an-legw`).
 
 ## Output
 

--- a/legistik-werkstatt/skills/legw-ressort-bmg/SKILL.md
+++ b/legistik-werkstatt/skills/legw-ressort-bmg/SKILL.md
@@ -100,7 +100,7 @@ Verbaendeanhoerung; Bundestagsweg; Aufsicht).
 
 ### Schritt 5 - Optional RuleMapping-Anschluss
 
-Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-einstieg-und-eignung`.
+Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-grundlagen` als Einstieg in die 10 RuleMapping-Skills (Abschluss mit `legw-rmap-anschluss-an-legw`).
 
 ## Output
 

--- a/legistik-werkstatt/skills/legw-ressort-bmi/SKILL.md
+++ b/legistik-werkstatt/skills/legw-ressort-bmi/SKILL.md
@@ -100,7 +100,7 @@ Verbaendeanhoerung; Bundestagsweg; Aufsicht).
 
 ### Schritt 5 - Optional RuleMapping-Anschluss
 
-Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-einstieg-und-eignung`.
+Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-grundlagen` als Einstieg in die 10 RuleMapping-Skills (Abschluss mit `legw-rmap-anschluss-an-legw`).
 
 ## Output
 

--- a/legistik-werkstatt/skills/legw-ressort-bmjv/SKILL.md
+++ b/legistik-werkstatt/skills/legw-ressort-bmjv/SKILL.md
@@ -100,7 +100,7 @@ Verbaendeanhoerung; Bundestagsweg; Aufsicht).
 
 ### Schritt 5 - Optional RuleMapping-Anschluss
 
-Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-einstieg-und-eignung`.
+Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-grundlagen` als Einstieg in die 10 RuleMapping-Skills (Abschluss mit `legw-rmap-anschluss-an-legw`).
 
 ## Output
 

--- a/legistik-werkstatt/skills/legw-ressort-bmleh/SKILL.md
+++ b/legistik-werkstatt/skills/legw-ressort-bmleh/SKILL.md
@@ -100,7 +100,7 @@ Verbaendeanhoerung; Bundestagsweg; Aufsicht).
 
 ### Schritt 5 - Optional RuleMapping-Anschluss
 
-Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-einstieg-und-eignung`.
+Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-grundlagen` als Einstieg in die 10 RuleMapping-Skills (Abschluss mit `legw-rmap-anschluss-an-legw`).
 
 ## Output
 

--- a/legistik-werkstatt/skills/legw-ressort-bmukn/SKILL.md
+++ b/legistik-werkstatt/skills/legw-ressort-bmukn/SKILL.md
@@ -100,7 +100,7 @@ Verbaendeanhoerung; Bundestagsweg; Aufsicht).
 
 ### Schritt 5 - Optional RuleMapping-Anschluss
 
-Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-einstieg-und-eignung`.
+Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-grundlagen` als Einstieg in die 10 RuleMapping-Skills (Abschluss mit `legw-rmap-anschluss-an-legw`).
 
 ## Output
 

--- a/legistik-werkstatt/skills/legw-ressort-bmv/SKILL.md
+++ b/legistik-werkstatt/skills/legw-ressort-bmv/SKILL.md
@@ -100,7 +100,7 @@ Verbaendeanhoerung; Bundestagsweg; Aufsicht).
 
 ### Schritt 5 - Optional RuleMapping-Anschluss
 
-Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-einstieg-und-eignung`.
+Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-grundlagen` als Einstieg in die 10 RuleMapping-Skills (Abschluss mit `legw-rmap-anschluss-an-legw`).
 
 ## Output
 

--- a/legistik-werkstatt/skills/legw-ressort-bmvg/SKILL.md
+++ b/legistik-werkstatt/skills/legw-ressort-bmvg/SKILL.md
@@ -100,7 +100,7 @@ Verbaendeanhoerung; Bundestagsweg; Aufsicht).
 
 ### Schritt 5 - Optional RuleMapping-Anschluss
 
-Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-einstieg-und-eignung`.
+Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-grundlagen` als Einstieg in die 10 RuleMapping-Skills (Abschluss mit `legw-rmap-anschluss-an-legw`).
 
 ## Output
 

--- a/legistik-werkstatt/skills/legw-ressort-bmwe/SKILL.md
+++ b/legistik-werkstatt/skills/legw-ressort-bmwe/SKILL.md
@@ -100,7 +100,7 @@ Verbaendeanhoerung; Bundestagsweg; Aufsicht).
 
 ### Schritt 5 - Optional RuleMapping-Anschluss
 
-Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-einstieg-und-eignung`.
+Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-grundlagen` als Einstieg in die 10 RuleMapping-Skills (Abschluss mit `legw-rmap-anschluss-an-legw`).
 
 ## Output
 

--- a/legistik-werkstatt/skills/legw-ressort-bmwsb/SKILL.md
+++ b/legistik-werkstatt/skills/legw-ressort-bmwsb/SKILL.md
@@ -100,7 +100,7 @@ Verbaendeanhoerung; Bundestagsweg; Aufsicht).
 
 ### Schritt 5 - Optional RuleMapping-Anschluss
 
-Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-einstieg-und-eignung`.
+Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-grundlagen` als Einstieg in die 10 RuleMapping-Skills (Abschluss mit `legw-rmap-anschluss-an-legw`).
 
 ## Output
 

--- a/legistik-werkstatt/skills/legw-ressort-bmz/SKILL.md
+++ b/legistik-werkstatt/skills/legw-ressort-bmz/SKILL.md
@@ -100,7 +100,7 @@ Verbaendeanhoerung; Bundestagsweg; Aufsicht).
 
 ### Schritt 5 - Optional RuleMapping-Anschluss
 
-Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-einstieg-und-eignung`.
+Wenn das Vorhaben digital-tauglich werden soll: `legw-rmap-grundlagen` als Einstieg in die 10 RuleMapping-Skills (Abschluss mit `legw-rmap-anschluss-an-legw`).
 
 ## Output
 


### PR DESCRIPTION
Codex-Finding auf PR #199 umgesetzt.

## Problem
Der vorherige Fix (PR #199) hat den toten Verweis `legw-rmap-einstieg-und-eignung` nur im zentralen Router und in der Auftragsaufnahme korrigiert. Im normalen Nutzungsablauf (Auftragsaufnahme → Router → Ressort-Skill) sieht der Nutzer aber **erst den Ressort-Skill** und folgt dort dem optionalen Schritt 5 RuleMapping. In allen 16 Ressort-Skills war der tote Link weiterhin enthalten.

## Fix
Einheitliche Umbiegung auf `legw-rmap-grundlagen` (didaktischer Einstieg in die 10 RuleMapping-Skills) mit Hinweis auf `legw-rmap-anschluss-an-legw` als Rückkopplung.

## Betroffen (16 Dateien)
legw-ressort-{aa, bmas, bmbfsfj, bmds, bmf, bmftr, bmg, bmi, bmjv, bmleh, bmukn, bmv, bmvg, bmwe, bmwsb, bmz}/SKILL.md

## Validatoren
- validate-plugin-structure: OK
- validate-yaml-frontmatter: 0 Fehler, 0 Warnungen
- grep -rn legw-rmap-einstieg-und-eignung legistik-werkstatt/ → 0 Treffer