### PR TITLE
release(v59.0.0): Codex-Sweep-Release + Versions-Drift-Bereinigung

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "aktenaufbereiter-strafrecht",
@@ -22,13 +22,13 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "aktenauszug-gerichtsverfahren",
       "source": "./aktenauszug-gerichtsverfahren",
       "description": "Strukturierter Aktenauszug für deutsche Gerichtsverfahren: Verfahrensidentifikation Einleitungssatz Verfahrenszusammenfassung Sachverhaltschronologie Verfahrensgeschichte tabellarische Gegenüberstellung der Parteivortraege Beweismittel und Rechtsargumente für schnelle Einarbeitung in Akten.",
-      "version": "58.0.0",
+      "version": "59.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -40,7 +40,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "apothekenrecht",
@@ -49,7 +49,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "arbeitsrecht",
@@ -58,7 +58,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "arbeitszeugnis-analyse",
@@ -67,7 +67,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "aussenwirtschaft-zoll-sanktionen",
@@ -76,7 +76,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "bank-rechtsabteilung",
@@ -85,7 +85,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "barrierefreiheit-web-checker",
@@ -94,7 +94,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "bav-strategie-konzern",
@@ -103,7 +103,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "bereicherungs-und-anfechtungsrecht-pruefer",
@@ -112,7 +112,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "berufsrecht-ki-vertragspruefung",
@@ -121,7 +121,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "betreuungsrecht",
@@ -130,7 +130,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "bgb-at-pruefer",
@@ -139,7 +139,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "bgb-bt-pruefer",
@@ -148,7 +148,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "buerokratieversteher-entbuerokratisierer",
@@ -157,7 +157,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "bundesnetzagentur-verfahren",
@@ -166,7 +166,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "bundeswehrrecht-wehrrecht",
@@ -175,7 +175,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "commercial-courts-deutschland",
@@ -184,7 +184,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "common-law-kompass",
@@ -193,7 +193,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "corporate-kanzlei",
@@ -202,7 +202,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "datenschutzrecht",
@@ -211,7 +211,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "dfg-foerderantrag",
@@ -220,7 +220,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "dsa-dma-digitalregulierung",
@@ -229,7 +229,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "ecommerce-recht",
@@ -238,7 +238,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "einfache-leichte-sprache-jura",
@@ -247,7 +247,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "email-umformulierer-berufsrecht",
@@ -256,7 +256,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "energierecht",
@@ -265,7 +265,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "europarecht-kompass",
@@ -274,7 +274,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-agrarrecht",
@@ -283,7 +283,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-arbeitsrecht",
@@ -292,7 +292,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-bank-kapitalmarktrecht",
@@ -301,7 +301,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-bau-architektenrecht",
@@ -310,7 +310,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-erbrecht",
@@ -319,7 +319,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-familienrecht",
@@ -328,7 +328,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-gewerblicher-rechtsschutz",
@@ -337,7 +337,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-handels-gesellschaftsrecht",
@@ -346,7 +346,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-insolvenz-sanierungsrecht",
@@ -355,7 +355,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-internationales-wirtschaftsrecht",
@@ -364,7 +364,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-it-recht",
@@ -373,7 +373,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-medizinrecht",
@@ -382,7 +382,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-miet-wohnungseigentumsrecht",
@@ -391,7 +391,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-migrationsrecht",
@@ -400,7 +400,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-sozialrecht",
@@ -409,7 +409,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-sportrecht",
@@ -418,7 +418,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-strafrecht",
@@ -427,7 +427,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-transport-speditionsrecht",
@@ -436,7 +436,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-urheber-medienrecht",
@@ -445,7 +445,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-vergaberecht",
@@ -454,7 +454,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-verkehrsrecht",
@@ -463,7 +463,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-versicherungsrecht",
@@ -472,7 +472,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fachanwalt-verwaltungsrecht",
@@ -481,7 +481,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "factoring-recht",
@@ -490,7 +490,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fluggastrechte",
@@ -499,7 +499,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "forderungsmanagement-klagewerkstatt",
@@ -508,7 +508,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "forschungszulage-antragstellung",
@@ -517,7 +517,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "fortbestehensprognose",
@@ -526,7 +526,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "geldwaeschepraevention-aml-kyc",
@@ -535,7 +535,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "gesellschaftsgruender",
@@ -544,7 +544,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "gesellschaftsrecht",
@@ -553,7 +553,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "gesellschaftsrecht-legal-english",
@@ -562,7 +562,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "gewerblicher-rechtsschutz",
@@ -571,7 +571,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "goae-gebuehrenordnung-aerzte",
@@ -580,7 +580,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "grosskanzlei-corporate-ma",
@@ -589,7 +589,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "handelsrecht-hgb",
@@ -598,7 +598,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "hausarbeitenmacher",
@@ -607,7 +607,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "immobilienrechtspraxis",
@@ -616,7 +616,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "insolvenzforderungsanmeldungspruefung",
@@ -625,7 +625,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "insolvenzplan-starug-planwerkstatt",
@@ -634,7 +634,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "insolvenzrecht",
@@ -643,7 +643,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "insolvenzverwaltung",
@@ -652,7 +652,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "jurastudium",
@@ -661,7 +661,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "juristische-sprache-deutsch-als-zweitsprache",
@@ -670,7 +670,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "jveg-kostenpruefer",
@@ -679,7 +679,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "kanzlei-allgemein",
@@ -688,7 +688,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "kanzlei-builder-hub",
@@ -697,12 +697,12 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "kartellrecht-marktabgrenzung-pruefung",
       "source": "./kartellrecht-marktabgrenzung-pruefung",
-      "version": "58.0.0",
+      "version": "59.0.0",
       "description": "Kritische kartellrechtliche Pruefinstanz fuer Marktabgrenzungen nach Paragraf 18 GWB sowie Art. 101 und 102 AEUV: SSNIP-Test, Nachfrage- und Angebotsumstellung, raeumlicher Markt, Evidenz, Konsistenz, Red Flags und Marktbeherrschung. Rechtsprechung nur nach Live-Verifikation.",
       "author": {
         "name": "Klotzkette"
@@ -715,7 +715,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "ki-richtlinie-kanzleien",
@@ -724,7 +724,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "ki-vo-ai-act-pruefer",
@@ -733,7 +733,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "krankenhausrecht",
@@ -742,7 +742,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "krisenfrueherkennung-starug",
@@ -751,14 +751,14 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "legistik-werkstatt",
       "source": "./legistik-werkstatt",
       "description": "Legistik-Werkstatt für Ministerien, Bundestag, Fraktionen/Opposition, Länder, Landtage und Normgeber. Baut Referenten- und Kabinettsentwürfe, Vorlagen aus der Mitte, Änderungs-/Entschließungsanträge, Rechtsverordnungen und Satzungen mit Begründung, Synopse, XML und Prüfpfaden.",
       "category": "verwaltung",
-      "version": "58.0.0",
+      "version": "59.0.0",
       "tags": [
         "legistik",
         "gesetzgebung",
@@ -780,7 +780,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "lobbyregister-bundestag",
@@ -789,7 +789,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "mandantenanfragen-assistent",
@@ -798,7 +798,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "markenrecht-fashion-luxus",
@@ -807,7 +807,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "meinungspruefer",
@@ -816,7 +816,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "memorandums-ersteller",
@@ -825,7 +825,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "methodenlehre-buergerliches-recht",
@@ -834,7 +834,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "mietrecht",
@@ -843,7 +843,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "mittelstand-corporate-ma",
@@ -852,7 +852,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "nachbarschaftsstreit-pruefer",
@@ -861,7 +861,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "nda-abgleich",
@@ -870,7 +870,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "normenkontrolle-bauleitplanung",
@@ -879,7 +879,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "normenkontrollrat-nkr",
@@ -888,7 +888,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "parteienrecht-parteiorganisation",
@@ -897,7 +897,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "patentrecherche",
@@ -906,7 +906,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "patentrecht",
@@ -915,7 +915,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "phishing-vorfall-pruefer",
@@ -924,7 +924,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "private-equity-praxis",
@@ -933,7 +933,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "produktrecht",
@@ -942,7 +942,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "prozessrecht",
@@ -951,7 +951,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "rechtsberatungsstelle",
@@ -960,7 +960,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "regulatorisches-recht",
@@ -969,7 +969,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "robotik-recht",
@@ -978,7 +978,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "schriftform-und-textform-bgb",
@@ -987,7 +987,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "selbstvertreter-amtsgericht",
@@ -996,7 +996,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "selbstvertreter-sozialgericht",
@@ -1005,7 +1005,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "steuerrecht-anwalt-und-berater",
@@ -1014,7 +1014,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "strafbefehl-verteidiger",
@@ -1023,7 +1023,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "strafzumessung",
@@ -1032,7 +1032,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "subsumtions-pruefer",
@@ -1041,7 +1041,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "tabellenreview-3d",
@@ -1050,7 +1050,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "umweltrecht",
@@ -1059,13 +1059,13 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "urteilsbauer-relationsmacher",
       "source": "./urteilsbauer-relationsmacher",
       "description": "Urteils- und Beschluss-Werkstatt für Amts- Land- und Familienrichter sowie Rechtspfleger. Aktenintake Relation Beweiswürdigung mit Richter-Input Tatbestandsmerkmale Tenor Tatbestand Entscheidungsgründe Rechtsmittelbelehrung. Erzeugt DOCX nach Paragraf 313 ZPO.",
-      "version": "58.0.0",
+      "version": "59.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1077,7 +1077,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "verfassungsrecht",
@@ -1086,7 +1086,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "verkehr-infrastrukturrecht",
@@ -1095,7 +1095,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "verkehrsowi-verteidiger",
@@ -1104,7 +1104,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "verlagsredaktion",
@@ -1113,7 +1113,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "vertragsausfueller",
@@ -1122,7 +1122,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "vertragsrecht",
@@ -1131,7 +1131,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "wandeldarlehen-lebenszyklus",
@@ -1140,7 +1140,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "weg-hausverwaltung",
@@ -1149,7 +1149,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "word-legal-ai-plugin-and-skill-for-german-lawyers",
@@ -1158,7 +1158,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "zitierweise-deutsches-recht",
@@ -1167,7 +1167,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "zwangsverwaltung-zvg",
@@ -1176,7 +1176,7 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     },
     {
       "name": "zwangsvollstreckung",
@@ -1185,8 +1185,8 @@
       "author": {
         "name": "Klotzkette"
       },
-      "version": "58.0.0"
+      "version": "59.0.0"
     }
   ],
-  "version": "58.1.0"
+  "version": "59.0.0"
 }

--- a/agb-recht-pruefer/.claude-plugin/plugin.json
+++ b/agb-recht-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agb-recht-pruefer",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Gigantischer AGB-Rechtsprüfer und Klausel-Entwerfer für deutsches Recht: §§ 305 bis 310 BGB, UKlaG, B2C/B2B, Branchen-AGB, Redlining, Klauselrisiko und rechtssichere Entwurfsworkflows.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/aktenaufbereiter-strafrecht/.claude-plugin/plugin.json
+++ b/aktenaufbereiter-strafrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aktenaufbereiter-strafrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Aktenaufbereiter für die Strafverteidigung. Sechs Excel-fähige Übersichten — Aktenvorblatt; Personenverzeichnis; Tatkomplexe; Beziehungen; Chronologie; Fristen. Fortlaufend ergaenzbar. Erkennt Luecken und Widersprueche. Kein Ersatz für Aktenlektuere.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/aktenauszug-gerichtsverfahren/.claude-plugin/plugin.json
+++ b/aktenauszug-gerichtsverfahren/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aktenauszug-gerichtsverfahren",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Strukturierter Aktenauszug für deutsche Gerichtsverfahren: Verfahrensidentifikation Einleitungssatz Verfahrenszusammenfassung Sachverhaltschronologie Verfahrensgeschichte tabellarische Gegenüberstellung der Parteivortraege Beweismittel und Rechtsargumente für schnelle Einarbeitung in Akten.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/anlagen-zu-schriftsaetzen/.claude-plugin/plugin.json
+++ b/anlagen-zu-schriftsaetzen/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anlagen-zu-schriftsaetzen",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Anlagenmanagement fuer gerichtliche Schriftsaetze: sortiert chaotische Mandantenordner, E-Mails, Scans, Tabellen und Vorversionen zu beA-tauglichen K/B/AST/AG-Anlagen mit Verzeichnis, Konvolutdeckblaettern, Stempel-/Dateinamenregeln, Hashlog, Lueckenliste und Qualitygate.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/apothekenrecht/.claude-plugin/plugin.json
+++ b/apothekenrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apothekenrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Super-Plugin für Apothekenrecht: Betriebserlaubnis, ApBetrO, Versand, E-Rezept, BtM, Retaxation, Aufsicht und Compliance.",
   "author": {
     "name": "Klotzkette"

--- a/arbeitsrecht/.claude-plugin/plugin.json
+++ b/arbeitsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "arbeitsrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Arbeitsrechtliche Workflows fuer Kuendigung, Befristung, Urlaub, AGG, Aufhebungsvertrag, Betriebsrat, Arbeitszeit, Lohn und Expansion. Rechtsprechung wird nur mit Gericht, Datum, Aktenzeichen und verifizierbarer Quelle verwendet.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/arbeitszeugnis-analyse/.claude-plugin/plugin.json
+++ b/arbeitszeugnis-analyse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "arbeitszeugnis-analyse",
   "displayName": "Arbeitszeugnis-Analyse (Ampelsystem)",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Analyse deutscher Arbeitszeugnisse nach Ampelsystem (Rot/Orange/Grün). Geheimcodes, Schaufenster-Drift, negative Codeworte, Steigerungsadverbien. Satzweise Notenmatrix, begründete Gesamtnotenspanne. Vollständiger Mandatsablauf: Erstgespräch, Mandantenbericht, Aufforderungsschreiben, Klagestrategie.",
   "author": {
     "name": "Klotzkette"

--- a/aussenwirtschaft-zoll-sanktionen/.claude-plugin/plugin.json
+++ b/aussenwirtschaft-zoll-sanktionen/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aussenwirtschaft-zoll-sanktionen",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Freistehendes Plugin für Außenwirtschaft, Sanktionen, Zoll, Exportkontrolle, BAFA, TARIC, CBAM, Verbrauchsteuer, AWV, AML/KYC und Ermittlungen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/bank-rechtsabteilung/.claude-plugin/plugin.json
+++ b/bank-rechtsabteilung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bank-rechtsabteilung",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Rechtsabteilung einer mittelgroßen deutschen Bank: Aufsicht, Kredit, ZAG/PSD2, PSD3/PSR-Vorschau, eWpG, MiCAR, Tokenisierung, BaFin, Vorstand, HV und Kanzleisteuerung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/barrierefreiheit-web-checker/.claude-plugin/plugin.json
+++ b/barrierefreiheit-web-checker/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "barrierefreiheit-web-checker",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Web-Barrierefreiheits-Checker für BFSG, BFSGV, BITV 2.0, EN 301 549 und WCAG: Scope, Audit, Tastatur, Screenreader, Formulare, PDFs, Erklärung, Roadmap und Abnahme.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/bav-strategie-konzern/.claude-plugin/plugin.json
+++ b/bav-strategie-konzern/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bav-strategie-konzern",
   "displayName": "Betriebliche Altersversorgung Strategie Konzern",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Strategische Beratung zur betrieblichen Altersversorgung in Konzernen: Pensionsmodelle alle fuenf Durchführungswege CTA Pension Buyouts Drei-Stufen-Theorie Versorgungssystem-Harmonisierung internationale Benefits Restrukturierung DB-zu-DC im Duesseldorfer Boutique-Stil.",
   "author": {
     "name": "Klotzkette"

--- a/bereicherungs-und-anfechtungsrecht-pruefer/.claude-plugin/plugin.json
+++ b/bereicherungs-und-anfechtungsrecht-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bereicherungs-und-anfechtungsrecht-pruefer",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Mechanisches Durchprüfen von Bereicherungsrecht §§ 812 ff. BGB, AnfG und Insolvenzanfechtung §§ 129-147 InsO. Mit KI-Screening von Schuldnerakten, § 135 Gesellschafterdarlehen, Bargeschäft § 142 und Verteidigung des Anfechtungsgegners. Keine Rechtsberatung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/berufsrecht-ki-vertragspruefung/.claude-plugin/plugin.json
+++ b/berufsrecht-ki-vertragspruefung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "berufsrecht-ki-vertragspruefung",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Berufsrechtliche und strafrechtliche Vorprüfung von Vertraegen mit privaten Legal-AI-Anbietern. Für Anwaelte StB WP Patentanwaelte Notare. §§ 43e BRAO 62a StBerG 50a WPO 39c PAO 26a BNotO § 203 StGB. DAV-Stellungnahme. Gutachten Rückfragebrief Klauseln.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/betreuungsrecht/.claude-plugin/plugin.json
+++ b/betreuungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "betreuungsrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Betreuungsrechtliche Skills für Jahresbericht, Vermögensverzeichnis, Genehmigungspflichten, Kontoanalyse und Verdachtsverträge nach BtOG und BGB.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/bgb-at-pruefer/.claude-plugin/plugin.json
+++ b/bgb-at-pruefer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bgb-at-pruefer",
   "displayName": "BGB AT Prüfer",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Großes Prüfplugin zum BGB Allgemeiner Teil: Vertragsschluss, Willenserklärung, Zugang, Geschäftsfähigkeit, Form, qES, beA, § 130e ZPO, § 46h ArbGG, Anfechtung, Stellvertretung, Fristen und Verjährung.",
   "author": {
     "name": "Klotzkette"

--- a/bgb-bt-pruefer/.claude-plugin/plugin.json
+++ b/bgb-bt-pruefer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bgb-bt-pruefer",
   "displayName": "BGB BT Prüfer",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Großer BGB-BT-Prüfer für Schuldrecht Besonderer Teil: Kauf, Miete, Pacht, Leihe, Darlehen, Dienst, Werk, Bau, Reise, Makler, Auftrag, Geschäftsbesorgung, Bürgschaft, Schuldversprechen, GoA, Bereicherung, Delikt und Rückabwicklung.",
   "author": {
     "name": "Klotzkette"

--- a/buerokratieversteher-entbuerokratisierer/.claude-plugin/plugin.json
+++ b/buerokratieversteher-entbuerokratisierer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "buerokratieversteher-entbuerokratisierer",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Allgemeiner Bürokratieversteher und Entbürokratisierer für Laien, Menschen mit Deutsch als Zweitsprache und alle, die Bescheide, Anträge, Vorladungen, Behördenbriefe, Jugendamt-, Schul-, Bau-, Sozial-, Familien- oder Kommunalverfahren verstehen und vorsichtig bearbeiten wollen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/bundesnetzagentur-verfahren/.claude-plugin/plugin.json
+++ b/bundesnetzagentur-verfahren/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bundesnetzagentur-verfahren",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Großes Regulierungs-Plugin für anwaltliche Arbeit mit der Bundesnetzagentur in Energie, Telekommunikation, Post, Eisenbahn und Digital Services.",
   "author": {
     "name": "Klotzkette"

--- a/bundeswehrrecht-wehrrecht/.claude-plugin/plugin.json
+++ b/bundeswehrrecht-wehrrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bundeswehrrecht-wehrrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Super-Plugin für Soldatenrecht, Wehrbeschwerde, Disziplinarrecht, Wehrpflicht, Reservisten, Versorgung und Bundeswehrverwaltung.",
   "author": {
     "name": "Klotzkette"

--- a/commercial-courts-deutschland/.claude-plugin/plugin.json
+++ b/commercial-courts-deutschland/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commercial-courts-deutschland",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Commercial-Courts-Plugin für englischsprachige Wirtschaftsverfahren in Deutschland: Zuständigkeit, Wahlklauseln, Klage, Case Management, Beweis, Geheimnisschutz, Wortprotokoll/Transcript, Rechtsmittel, BGH, Kosten, Vollstreckung und bilingualer Schriftsatz-/Hearing-Workflow.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/common-law-kompass/.claude-plugin/plugin.json
+++ b/common-law-kompass/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "common-law-kompass",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Freistehendes Common-Law-Plugin für deutsche Wirtschaftsjuristen: UK/US-False-Friends, Vertragsbegriffe, Consideration, Suretyship, Indemnity, UCC, Precedent, Discovery und bilinguale Drafting-Reviews.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/corporate-kanzlei/.claude-plugin/plugin.json
+++ b/corporate-kanzlei/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corporate-kanzlei",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Corporate-Kanzlei-Plugin: Deal-Kommandocenter, Datenraum, Due Diligence, SPA/APA, Umwandlung, StaRUG, Insolvenzplan, W&I, Signing/Closing, PMI.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/datenschutzrecht/.claude-plugin/plugin.json
+++ b/datenschutzrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "datenschutzrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "DSGVO/BDSG/TDDDG – PIA/DPIA, AVV-Review, Auskunft Art. 15, Datenpanne Art. 33/34, Drittlandstransfer Art. 44 ff. inkl. US-Transfer, DPF, SCC, TIA und Behördenpaket.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/dfg-foerderantrag/.claude-plugin/plugin.json
+++ b/dfg-foerderantrag/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dfg-foerderantrag",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "DFG-Förderantragssteller für Sachbeihilfe, adaptive Anfänger-/Profi-Führung, kleine schnelle Anträge, große Koselleck-Strategien, elan-Formalia, Finanzplan, Reviewer-Red-Team, Forschungsdaten, KI-/Ethik-Check und Wiedereinreichung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/dsa-dma-digitalregulierung/.claude-plugin/plugin.json
+++ b/dsa-dma-digitalregulierung/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dsa-dma-digitalregulierung",
   "displayName": "DSA DMA und Digitalregulierung EU",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Digitalregulierung der EU: DSA (VO 2022/2065) und DMA (VO 2022/1925) plus Data Act DGA AI Act NIS-2 DORA CRA eIDAS 2.0 DDG P2B-VO und § 19a GWB. Gatekeeper-Schwellen VLOP-Einordnung Risikobewertung Art. 34 Forschungsdatenzugang Art. 40 Account-Sperre Art. 20-23 Zustellung Art. 13 DSA Klagewege.",
   "author": {
     "name": "Klotzkette"

--- a/ecommerce-recht/.claude-plugin/plugin.json
+++ b/ecommerce-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ecommerce-recht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Super-Plugin für Online-Shops, Plattformen, Marktplätze und digitale Verbraucherprozesse.",
   "author": {
     "name": "Klotzkette"

--- a/einfache-leichte-sprache-jura/.claude-plugin/plugin.json
+++ b/einfache-leichte-sprache-jura/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "einfache-leichte-sprache-jura",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Juristische Texte in Einfache Sprache oder Leichte Sprache übertragen: experimentelle Standard-Annäherung, Zielgruppe klären, Rechtsinhalt sichern und Qualitätsgate nutzen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/email-umformulierer-berufsrecht/.claude-plugin/plugin.json
+++ b/email-umformulierer-berufsrecht/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "email-umformulierer-berufsrecht",
   "displayName": "E-Mail-Umformulierer (Berufsrechtskonform)",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Formuliert unfreundliche, emotionale oder unsachliche E-Mails in hoefliche, sachliche und berufsrechtskonform formulierte Texte um. Fokus auf BRAO/BORA-Konformität, mit Varianten für Steuerberater, Notare und allgemeine berufliche Korrespondenz.",
   "author": {
     "name": "Klotzkette"

--- a/energierecht/.claude-plugin/plugin.json
+++ b/energierecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "energierecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Freistehendes Energierecht-Plugin für Stadtwerke, Versorger, Wärme, Netze, Vertrieb, Industrie, EEG, KWKG, Verfahren, Transaktionen und Projektfinanzierung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/europarecht-kompass/.claude-plugin/plugin.json
+++ b/europarecht-kompass/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "europarecht-kompass",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Freistehendes Europarecht-Plugin gegen deutsche Denkfehler: Vorrang, unmittelbare Wirkung, Richtlinien, Verordnungen, Charta, Grundfreiheiten, Beihilfen, Vorlageverfahren und EU-Drafting.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-agrarrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-agrarrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-agrarrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin Fachanwalt für Agrarrecht. Höferecht (HöfeO Anerbenrecht Länder) Landpachtrecht BGB §§ 581 ff. GAP EU-Direktzahlungen Cross-Compliance Düngeverordnung Pflanzenschutz Tierschutz Forstrecht. Schnittstelle Plugin fachanwalt-erbrecht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-arbeitsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-arbeitsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-arbeitsrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Fachanwalt-Arbeitsrecht nach FAO Paragraf 10: KSchG, BetrVG, TzBfG, AGG, EntgTranspG, Urlaub, Betriebsrat, Befristung und Vergleichspraxis. Rechtsprechung nur mit Datum, Aktenzeichen und verifizierter Quelle.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-bank-kapitalmarktrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-bank-kapitalmarktrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-bank-kapitalmarktrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin Fachanwalt für Bank- und Kapitalmarktrecht. KWG ZAG WpHG WpIG MiFID-II MAR MiCAR Verbraucherkredit Vermögensanlage Beratungshaftung. Schnittstellen Plugin gesellschaftsrecht regulatorisches-recht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-bau-architektenrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-bau-architektenrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-bau-architektenrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin Fachanwalt für Bau- und Architektenrecht. BGB Werkvertrag VOB-A VOB-B VOB-C HOAI Bauordnungsrecht. Bauvertrag Maengelhaftung Abnahme Vergaberecht. Schnittstellen Plugin fachanwalt-vergaberecht kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-erbrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-erbrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-erbrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin Fachanwalt für Erbrecht. BGB Erbrecht §§ 1922 ff. Pflichtteil Testament Erbschein Erbauseinandersetzung Erbschaftsteuer EU-ErbVO. Schnittstellen Plugin steuerrecht-anwalt-und-berater kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-familienrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-familienrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-familienrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin Fachanwalt für Familienrecht. Orientierung Normen Mandate Fristen Literatur. Familiengericht FamFG Scheidung Sorge Umgang Unterhalt Zugewinn Ehevertrag eingetragene Lebenspartnerschaft. Ergaenzend zum Plugin kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-gewerblicher-rechtsschutz/.claude-plugin/plugin.json
+++ b/fachanwalt-gewerblicher-rechtsschutz/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-gewerblicher-rechtsschutz",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin Fachanwalt für gewerblichen Rechtsschutz nach FAO § 14k. MarkenG. DesignG. UWG. PatG GebrMG. UrhG-Bezuege. Markenanmeldung DPMA EUIPO. UWG-Abmahnung §§ 8 ff. UWG. Designverletzung. Einstweilige Verfuegung Verletzungsklage Lizenzanaloger Schadensersatz.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-handels-gesellschaftsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-handels-gesellschaftsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-handels-gesellschaftsrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin Fachanwalt für Handels- und Gesellschaftsrecht nach FAO § 14i. HGB. AktG. GmbHG. PartGG. UmwG. Geschäftsführerhaftung §§ 43 GmbHG 93 AktG. Gesellschafterstreit Beschlussanfechtung. Handelsvertreterausgleich § 89b HGB. MoPeG GbR seit 2024. Schnittstellen kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-insolvenz-sanierungsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-insolvenz-sanierungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-insolvenz-sanierungsrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin Fachanwalt für Insolvenz- und Sanierungsrecht nach FAO § 14. InsO Eroeffnung Antragspflicht § 15a Gläubigerantrag § 14 InsO. StaRUG Restrukturierungsplan. Insolvenzanfechtung §§ 129 ff. InsO. Schnittstellen insolvenzrecht und steuerrecht-anwalt-und-berater.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-internationales-wirtschaftsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-internationales-wirtschaftsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-internationales-wirtschaftsrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin Fachanwalt für Internationales Wirtschaftsrecht. CISG Bruessel Ia Rom I Rom II Schiedsverfahren ICC UNCITRAL Investitionsschutz ICSID WTO EU-Aussenhandel LkSG. Schnittstelle Plugin kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-it-recht/.claude-plugin/plugin.json
+++ b/fachanwalt-it-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-it-recht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin Fachanwalt für Informationstechnologierecht. SaaS Software-Lizenz DSGVO BDSG TTDSG TKG NIS2 DDG DSA DMA EU-KI-VO Open-Source. Schnittstellen Plugin datenschutzrecht ki-governance kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-medizinrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-medizinrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-medizinrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin Fachanwalt für Medizinrecht. Arzthaftung §§ 630a ff. BGB Patientenrechte Vertragsarztrecht Berufsrecht Aerzte SGB V Krankenversicherung MPDG Apothekenrecht. Schnittstellen Plugin fachanwalt-sozialrecht und kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-miet-wohnungseigentumsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-miet-wohnungseigentumsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-miet-wohnungseigentumsrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Großer Fachanwalt-Kompass Miet- und Wohnungseigentumsrecht mit über 200 Skills für Wohnraum, Gewerberaum, Betriebskosten, WEG, Hausverwaltung, Beschlüsse, GEG, Beweise, Fristen und Workflows.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-migrationsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-migrationsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-migrationsrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Großer Fachanwalt-Kompass Migrationsrecht mit über 200 Skills für Aufenthalt, Blaue Karte EU, Fachkräfte, Asyl, Dublin/GEAS, Einbürgerung, Staaten-/Gebietschecks und spanische/einfache Erklärung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-sozialrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-sozialrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-sozialrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin Fachanwalt für Sozialrecht nach FAO § 11. SGB I-XII und Sozialgerichtsbarkeit SGG. Widerspruch § 84 SGG Klage § 87 SGG Eilantrag § 86b SGG. Buergergeld Erwerbsminderung GdB Pflegegrad Hilfsmittel Eingliederungshilfe. Bescheidanalyse Akteneinsicht PKH Fristenbuch.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-sportrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-sportrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-sportrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin Fachanwalt für Sportrecht. Verbandsrecht (DFB FIFA UEFA IOC DOSB) CAS Schiedsverfahren Spielerverträge Doping WADA-Code NADA Sponsoring Persönlichkeitsrechte Veranstalterhaftung. Schnittstelle Plugin gesellschaftsrecht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-strafrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-strafrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-strafrecht",
-  "version": "58.1.0",
+  "version": "59.0.0",
   "description": "Plugin Fachanwalt für Strafrecht. Orientierung StPO StGB Nebenstrafrecht. Strafverteidigung Ermittlungsverfahren Hauptverhandlung Revision. Nebenklage Opfervertretung Zeugenbeistand Adhaesion Insolvenzantrag StA. Ergaenzt aktenaufbereiter-strafrecht und kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-transport-speditionsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-transport-speditionsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-transport-speditionsrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin Fachanwalt für Transport- und Speditionsrecht. HGB §§ 407 ff. Frachtvertrag §§ 453 ff. Spedition CMR COTIF Montrealer Übereinkommen Haager Visby Regeln ADSp. Schnittstelle Plugin kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-urheber-medienrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-urheber-medienrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-urheber-medienrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin Fachanwalt für Urheber- und Medienrecht. UrhG UWG KUG Recht am eigenen Bild Presserecht Persoenlichkeitsrecht Medienstaatsvertrag. Schnittstellen Plugin gewerblicher-rechtsschutz verlagsredaktion kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-vergaberecht/.claude-plugin/plugin.json
+++ b/fachanwalt-vergaberecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-vergaberecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin Fachanwalt für Vergaberecht. GWB §§ 97 ff. VgV UVgO SektVO KonzVgV VOB-A. EU-Vergabe-RL. Nachprüfungsverfahren Vergabekammer und OLG-Vergabesenat. Schnittstelle Plugin fachanwalt-bau-architektenrecht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-verkehrsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-verkehrsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-verkehrsrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin Fachanwalt für Verkehrsrecht. StVG StVO PflVG VVG-Bezuege. Verkehrsunfall Personen- und Sachschaden Bußgeld Fahrerlaubnis Verkehrsstrafrecht (§§ 315c 316 StGB). Schnittstelle Plugin kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-versicherungsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-versicherungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-versicherungsrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin Fachanwalt für Versicherungsrecht. VVG VAG Berufsunfähigkeit private Krankenversicherung Lebens- und Rentenversicherung Sachversicherung Haftpflicht D-und-O. Schnittstelle Plugin kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-verwaltungsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-verwaltungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-verwaltungsrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin Fachanwalt für Verwaltungsrecht. VwGO VwVfG. Anfechtungs- und Verpflichtungsklage Eilrechtsschutz § 80 Abs 5 VwGO einstweilige Anordnung Normenkontrolle Polizei- und Ordnungsrecht. Schnittstelle Plugin kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/factoring-recht/.claude-plugin/plugin.json
+++ b/factoring-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "factoring-recht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Super-Plugin für Factoring, Forderungskauf, Aufsichtsrecht, Vertragsgestaltung, Debitorenkommunikation, Insolvenz- und Sanierungsfragen.",
   "author": {
     "name": "Klotzkette"

--- a/fluggastrechte/.claude-plugin/plugin.json
+++ b/fluggastrechte/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fluggastrechte",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Fluggastrechte selber geltend machen nach VO (EG) Nr. 261/2004. Tickets erfassen, Annullierung oder Verspaetung pruefen, aussergewoehnliche Umstaende, Distanz, Ausgleich, Forderungsschreiben, Mahnung und Klage. Rechtsprechung nur nach Live-Verifikation.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/forderungsmanagement-klagewerkstatt/.claude-plugin/plugin.json
+++ b/forderungsmanagement-klagewerkstatt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forderungsmanagement-klagewerkstatt",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Klagewerkstatt für Forderungsmanagement mit Zuständigkeitsprüfung, Mahnvorlauf, Inkasso-Zahlungsklage und Anspruchs-Gatekeeper: Nur klare, fällige und belegte Forderungen werden zur Klage freigegeben.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/forschungszulage-antragstellung/.claude-plugin/plugin.json
+++ b/forschungszulage-antragstellung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forschungszulage-antragstellung",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Forschungszulage-Antragstellung nach FZulG: adaptiver Fördercheck, BSFZ-Portaltexte mit Zeichenbudgets, Finanzamt-Antrag, FuE-Abgrenzung, Bemessungsgrundlage 2026, Auszahlung, Verlust-/Insolvenzlage, Dokumentation, Beihilfen, Einspruch und Mehrjahresroadmap.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fortbestehensprognose/.claude-plugin/plugin.json
+++ b/fortbestehensprognose/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fortbestehensprognose",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Fortbestehensprognose § 19 Abs. 2 InsO als Geschäftsführer-Selbstdokumentation. Bilanzstatus Annahmen Plausibilisierung Zwoelf-Monats-Liquiditaet. Sanierungsbausteine Patronatserklärung Comfortletter Rangrücktritt Stundung Forderungsverzicht. IDW S 11 StaRUG. Eskalation bei negativer Prognose.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/geldwaeschepraevention-aml-kyc/.claude-plugin/plugin.json
+++ b/geldwaeschepraevention-aml-kyc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "geldwaeschepraevention-aml-kyc",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Freistehendes Plugin für Geldwäscheprävention, AML, KYC, GwG-Risikoanalyse, UBO, PEP, Sanktionen, FIU/goAML, Transparenzregister und Behördenverfahren.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gesellschaftsgruender/.claude-plugin/plugin.json
+++ b/gesellschaftsgruender/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gesellschaftsgruender",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Anfängerfreundlicher Gründungsassistent für deutsche Gesellschaften: Rechtsformwahl, Satzung, SHA, Cap Table, Notar, Handelsregister, Bank/KYC, Behörden, Steuerstart, IP, Datenschutz, erste 100 Tage und Streitprävention.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gesellschaftsrecht-legal-english/.claude-plugin/plugin.json
+++ b/gesellschaftsrecht-legal-english/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gesellschaftsrecht-legal-english",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Didaktisches Gesellschaftsrecht — English Business Terms: Corporate Legal English fuer Big-Law-Anfaenger. Dealroom: Cap Table vs Gesellschafterliste; Term Sheet; SHA; Vesting; Drag/Tag; Liquidation Preference; Anti-Dilution; SPA; DD; Notar/HR; Multi-Format-Auswertung; Frankfurt-Startup-Akte.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gesellschaftsrecht/.claude-plugin/plugin.json
+++ b/gesellschaftsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gesellschaftsrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Gesellschaftsrecht – GmbH/AG/Personengesellschaften, M&A-Due-Diligence ohne Discovery (Q&A + Datenraum), Gesellschafterbeschlüsse, HRB/HRA-Anmeldungen, Closing Checklists, Compliance-Fristen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gewerblicher-rechtsschutz/.claude-plugin/plugin.json
+++ b/gewerblicher-rechtsschutz/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gewerblicher-rechtsschutz",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Gewerblicher Rechtsschutz – DPMA/EUIPO-Markenrecherche und -anmeldung, Freedom-to-Operate, Patentscreening, UWG- und Urheberrechts-Abmahnung (Versand und Reaktion), Open-Source-Compliance, IP-Klausel-Review, Schutzrechts-Fristen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/goae-gebuehrenordnung-aerzte/.claude-plugin/plugin.json
+++ b/goae-gebuehrenordnung-aerzte/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "goae-gebuehrenordnung-aerzte",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Super-Plugin zur GOÄ: private Arztrechnungen prüfen, erstellen, begründen, beanstanden und prozessual verwerten.",
   "author": {
     "name": "Klotzkette"

--- a/grosskanzlei-corporate-ma/.claude-plugin/plugin.json
+++ b/grosskanzlei-corporate-ma/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "grosskanzlei-corporate-ma",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Freistehendes Big-Law-Corporate/M&A-Plugin: Deal-Kommandocenter, Anfänger-/First-Year-Modus, Aktenanlage, Datenraum, Legal DD, Tabellenreview, Liquiditätsvorschau, SPA/APA, W&I, Public M&A, UmwG/StaRUG, CP-Kalender, E-Rechnung/GoBD, PMI.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/handelsrecht-hgb/.claude-plugin/plugin.json
+++ b/handelsrecht-hgb/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "handelsrecht-hgb",
   "displayName": "Handelsrecht HGB",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Reines HGB-Plugin für Handelsrecht: Kaufmann, Handelsregister, Firma, Prokura, Handlungsvollmacht, Handelsgeschäfte, Handelskauf, Handelsvertreter, Makler, Kommission, Fracht, Spedition, Lager, Handelsbücher sowie OHG/KG einschließlich MoPeG-Statuswechsel von GbR zu OHG.",
   "author": {
     "name": "Klotzkette"

--- a/hausarbeitenmacher/.claude-plugin/plugin.json
+++ b/hausarbeitenmacher/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hausarbeitenmacher",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Didaktisches Plugin für juristische Hausarbeiten und Seminararbeiten. Führt sokratisch durch Zivilrecht öffentliches Recht Strafrecht mit Ausfluegen in Europarecht und Rechtstheorie. Adressaten-Strategie ohne Schleimerei. Liefert keine fertigen Lösungen sondern führt zur eigenen Subsumtion.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/immobilienrechtspraxis/.claude-plugin/plugin.json
+++ b/immobilienrechtspraxis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "immobilienrechtspraxis",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Werkzeuge fuer immobilienrechtliche Rechtsabteilungen: musterbasierte Vertragserstellung mit Klauselschutz, Vertragspruefung gegen Playbook, Grundbuchanalyse, Sachverhaltsermittlung, Mieteranfragen, Case Management und AVV-Pruefung. Rechtsprechung nur nach Live-Verifikation.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/insolvenzforderungsanmeldungspruefung/.claude-plugin/plugin.json
+++ b/insolvenzforderungsanmeldungspruefung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insolvenzforderungsanmeldungspruefung",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Freistehendes Plugin für die Insolvenzforderungsanmeldungsprüfung: Intake, § 174 InsO, Belege, Grund, Betrag, Rang, vbuH, Nachforderungen, Tabellenimport, Prüfungstermin, Bestreiten, Feststellung, Tabellenauszug und Verteilung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/insolvenzplan-starug-planwerkstatt/.claude-plugin/plugin.json
+++ b/insolvenzplan-starug-planwerkstatt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insolvenzplan-starug-planwerkstatt",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Freistehendes Plugin für Insolvenzplan und StaRUG-Restrukturierungsplan: Intake, Sanierungskonzept, Vergleichsrechnung, Gruppen, Klassen, darstellender und gestaltender Teil, Anlagen, Abstimmung, Cram-down, Minderheitenschutz, Gericht und Planvollzug.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/insolvenzrecht/.claude-plugin/plugin.json
+++ b/insolvenzrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insolvenzrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Insolvenzrechtliche Skills zu Zahlungsunfähigkeit, Überschuldung, Antragspflicht und Gläubigerantrag.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/insolvenzverwaltung/.claude-plugin/plugin.json
+++ b/insolvenzverwaltung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insolvenzverwaltung",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Freistehendes Insolvenzverwaltungs-Plugin aus Sicht von Insolvenzverwalter, Sachwalter und vorläufiger Verwaltung: Regelverfahren, Eigenverwaltung, Schutzschirm, Anfechtung, § 15b InsO, Masse, Forderungsprüfung, Insolvenzplan, StaRUG-Planwerkstatt, Gutachten, Berichte und Schlussrechnung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/jurastudium/.claude-plugin/plugin.json
+++ b/jurastudium/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jurastudium",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Studium und Referendariat – Prüfungsgespräch nach AG-Tradition, Subsumtionslehre, Methodenlehre (Zivilrecht, Strafrecht, Öffentliches Recht), Rechtsgeschichte, Lernstrategien, Lösungsschemata, Gutachtenstil, Klausurkorrektur, Lernplanung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/juristische-sprache-deutsch-als-zweitsprache/.claude-plugin/plugin.json
+++ b/juristische-sprache-deutsch-als-zweitsprache/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "juristische-sprache-deutsch-als-zweitsprache",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin fuer Menschen im deutschen Recht mit anderer Herkunftssprache: einfache Erklaerungen, Juristendeutsch, Bescheide, Schriftsaetze, Grammatik, Fristen und Verfahrenslogik.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/jveg-kostenpruefer/.claude-plugin/plugin.json
+++ b/jveg-kostenpruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jveg-kostenpruefer",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Freistehender JVEG-Kostenprüfer für Zeugenentschädigung, Vorschuss, Fahrtkosten, Übernachtung, Verdienstausfall, Sachverständigen- und Dolmetscherkosten, Fristen, Festsetzung, Beschwerde und belegfeste Rechenprotokolle.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kanzlei-allgemein/.claude-plugin/plugin.json
+++ b/kanzlei-allgemein/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanzlei-allgemein",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Kanzlei-Allgemein-Plugin (fusioniert mit Cowork): edles Kommandocenter Mandatsannahme/GwG Klage/Replik Vertrag Rechtsprechung Handelsregister beA-Journal Rechnung UStVA Fristenbuch Timesheet RVG Versand-Vor-Check Posteingang Mandantenakte Mahnwesen Tagesbrief Geburtstage Weihnachtskarten.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kanzlei-builder-hub/.claude-plugin/plugin.json
+++ b/kanzlei-builder-hub/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanzlei-builder-hub",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Findet, prüft und installiert Community-Skills mit Security-Review-Gate vor dem Deployment in die Kanzleiumgebung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kartellrecht-marktabgrenzung-pruefung/.claude-plugin/plugin.json
+++ b/kartellrecht-marktabgrenzung-pruefung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kartellrecht-marktabgrenzung-pruefung",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Kritische kartellrechtliche Pruefinstanz fuer Marktabgrenzungen nach Paragraf 18 GWB sowie Art. 101 und 102 AEUV: SSNIP-Test, Nachfrage- und Angebotsumstellung, raeumlicher Markt, Evidenz, Konsistenz, Red Flags und Marktbeherrschung. Rechtsprechung nur nach Live-Verifikation.",
   "author": {
     "name": "Klotzkette"

--- a/ki-governance/.claude-plugin/plugin.json
+++ b/ki-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ki-governance",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "EU-KI-VO + DSGVO – Use-Case-Triage, KI-Inventar, AIA/DPIA, Vendor-Review, Drift-Monitoring der KI-Richtlinie.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/ki-richtlinie-kanzleien/.claude-plugin/plugin.json
+++ b/ki-richtlinie-kanzleien/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ki-richtlinie-kanzleien",
   "displayName": "KI-Richtlinie fuer Kanzleien und Rechtsabteilungen",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Erstellt und pflegt eine berufsrechtskonforme KI-Nutzungsrichtlinie für Kanzleien und Rechtsabteilungen mit Anwaelten und Syndikus-Anwaelten. Beruht auf BRAO, BORA, DSGVO, KI-Verordnung sowie BRAK- und DAV-Hinweisen.",
   "author": {
     "name": "Klotzkette"

--- a/ki-vo-ai-act-pruefer/.claude-plugin/plugin.json
+++ b/ki-vo-ai-act-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ki-vo-ai-act-pruefer",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Mechanik-Workflow zur KI-VO (EU 2024/1689): KI-System-Definition, Rollen, Risikoklassen, Hochrisiko-Diagnose, GPAI, Art. 43-Konformitätsbewertung, CE/EU-DB, Marktbeobachtung und Konformitäts-Evidence-Pack.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/krankenhausrecht/.claude-plugin/plugin.json
+++ b/krankenhausrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "krankenhausrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Super-Plugin für deutsches Krankenhausrecht: Planung, Finanzierung, Entgelte, Reform, Qualität, MD-Prüfung, Klinikbetrieb und Rechtsstreit.",
   "author": {
     "name": "Klotzkette"

--- a/krisenfrueherkennung-starug/.claude-plugin/plugin.json
+++ b/krisenfrueherkennung-starug/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "krisenfrueherkennung-starug",
   "displayName": "Krisenfrüherkennung und StaRUG-Management",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Krisenfrüherkennung und Krisenmanagement nach StaRUG: Pflicht zum 24-Monats-Frühwarnsystem nach § 1 StaRUG, § 102 StaRUG Warnpflicht der Berater, Geschäftsführerhaftung, drohende Zahlungsunfähigkeit, integrierte Planung, Restrukturierungsplan und Stabilisierungsanordnung.",
   "author": {
     "name": "Klotzkette"

--- a/legistik-werkstatt/.claude-plugin/plugin.json
+++ b/legistik-werkstatt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legistik-werkstatt",
-  "version": "58.1.0",
+  "version": "59.0.0",
   "description": "Legistik-Werkstatt für Ministerien, Bundestag, Fraktionen/Opposition, Länder, Landtage und Normgeber. Baut Referenten- und Kabinettsentwürfe, Vorlagen aus der Mitte, Änderungs-/Entschließungsanträge, Rechtsverordnungen und Satzungen mit Begründung, Synopse, XML und Prüfpfaden.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/liquiditaetsplanung/.claude-plugin/plugin.json
+++ b/liquiditaetsplanung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "liquiditaetsplanung",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Liquiditaetsplanung nach deutschem Recht: 3-Wochen-Vorschau, 13/26/52-Wochen-Forecast, Excel-Export, Quote/Luecken-Ampel, Dokumentationspaket und Schnittstellen zu Fortbestehensprognose und Insolvenzrecht. Rechtsprechung nur nach Live-Verifikation.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/lobbyregister-bundestag/.claude-plugin/plugin.json
+++ b/lobbyregister-bundestag/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lobbyregister-bundestag",
   "displayName": "Lobbyregister Bundestag",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Lobbyregister-Bundestag-Superplugin mit 50 geführten Skills für Registrierungspflicht, Ausnahmen, Registereintrag, Regelungsvorhaben, Stellungnahmen, Finanzdaten, Aktualisierung, Verhaltenskodex, Meldung von Verstoessen und Fristen nach LobbyRG.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/mandantenanfragen-assistent/.claude-plugin/plugin.json
+++ b/mandantenanfragen-assistent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mandantenanfragen-assistent",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Assistent für Anwaltskanzleien zur Erstantwort auf Mandantenanfragen per E-Mail: dankt foermlich übernimmt die Anrede aus der eingehenden E-Mail nennt die telefonische Terminvergabe bittet um Sachverhalt per E-Mail oder bietet eine Telefon-Transkription mit DSGVO-Einwilligungshinweis an.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/markenrecht-fashion-luxus/.claude-plugin/plugin.json
+++ b/markenrecht-fashion-luxus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markenrecht-fashion-luxus",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Markenrecht-Boutique für Luxus-Modehaeuser - DPMA/EUIPO Alicante/USPTO Lanham Act via NYC-Korrespondenz, alle Markenarten (Wort/Bild/Slogan/Sound/Duft/3D/Position/Haptik/Anti-KI), Widerspruch, Löschung, Verletzung, Produktpiraterie, Selektivvertrieb.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/meinungspruefer/.claude-plugin/plugin.json
+++ b/meinungspruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meinungspruefer",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Meinungsprüfer für Äußerungsrecht: Meinung oder Tatsache, Beleidigung, üble Nachrede, Verleumdung, § 188 StGB, Art. 5 GG, Art. 10 EMRK, Art. 11 GRCh, EGMR/EuGH, OLG-Praxis, US-Supreme-Court-Vergleich, Zivilrecht, Plattformen, Social Media, Arbeitsplatz, Schule und kommunale Machtkritik.",
   "author": {
     "name": "Klotzkette"

--- a/memorandums-ersteller/.claude-plugin/plugin.json
+++ b/memorandums-ersteller/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorandums-ersteller",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Wandelt Mandantenunterlagen in ein juristisches Memorandum mit Vier-Teile-Gliederung — Sachverhalt mit Quellenreferenz; Ein-Satz-Fragen; Ein-Satz-Antworten; rechtliche Ausführungen mit Pinpoint-Zitierung. Optional Piercing-Questions. Rechtsgebietsneutral. Alias Memorandumsmacher.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/methodenlehre-buergerliches-recht/.claude-plugin/plugin.json
+++ b/methodenlehre-buergerliches-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "methodenlehre-buergerliches-recht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Methodenlehre und Rechtsanwendung im deutschen buergerlichen Recht aus Anwaltsperspektive. Gutachtenstil. Anspruchsgrundlagen-Reihenfolge. Auslegung Wortlaut System Historie Telos pragmatisch ohne starren Vorrang. Verfassungs- und unionsrechtskonforme Auslegung. Lueckenfuellung. Verjährung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/mietrecht/.claude-plugin/plugin.json
+++ b/mietrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mietrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Mietrecht für Mieter und Vermieter mit ausschließlich amtlichen Mietspiegel-Quellen pro Bundesland und für Top- und Universitaetsstaedte. Datenerhebung Mieterhoehungs-Widerspruch Mietsenkungsverlangen Nebenkostenprüfung und Erstellung Mieteranfragen Klageentwurf zum Amtsgericht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/mittelstand-corporate-ma/.claude-plugin/plugin.json
+++ b/mittelstand-corporate-ma/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mittelstand-corporate-ma",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Freistehendes Mittelstandsmandat-Corporate/M&A-Plugin: Deal-Kommandocenter, Aktenanlage, Datenraum, Legal DD, Tabellenreview, Liquiditätsvorschau, SPA/APA, W&I, Public M&A, Umwandlung, StaRUG/Insolvenzplan, CP-Kalender, E-Rechnung/GoBD, PMI.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/nachbarschaftsstreit-pruefer/.claude-plugin/plugin.json
+++ b/nachbarschaftsstreit-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nachbarschaftsstreit-pruefer",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Nachbarrecht und Nachbarschaftsstreit: Überbau, Überhang, Äste/Wurzeln, Grenzbaum, Zaun/Mauer/Hecke, Immissionen, Vertiefung, Notweg, Hammerschlagsrecht, Beweise, Aufforderung, Klage und Vergleich.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/nda-abgleich/.claude-plugin/plugin.json
+++ b/nda-abgleich/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nda-abgleich",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Gleicht NDA-Entwurf der Gegenseite gegen eigenen Standard ab und setzt Haltelinien chirurgisch im Word-Aenderungsmodus durch. Ampelmatrix ROT/GELB/GRUEN. Ausgabe .docx mit echten Tracked Changes. Keine Absatzlöschungen, keine Klausel-Neufassungen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/normenkontrolle-bauleitplanung/.claude-plugin/plugin.json
+++ b/normenkontrolle-bauleitplanung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "normenkontrolle-bauleitplanung",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Freistehendes Plugin für die Prüfung und Anfechtung von Bebauungsplänen, Flächennutzungsplänen und örtlichen Bauvorschriften nach § 47 VwGO vor BayVGH und OVG. Mandatsperspektive Antragstellervertretung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/normenkontrollrat-nkr/.claude-plugin/plugin.json
+++ b/normenkontrollrat-nkr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "normenkontrollrat-nkr",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin fuer den Nationalen Normenkontrollrat (NKR): Pruefung von Referentenentwuerfen Formulierungshilfen und Gesetzentwuerfen auf Erfuellungsaufwand Erforderlichkeit Verhaeltnismaessigkeit One-in-one-out Digitalcheck Mittelstandsfreundlichkeit und Praktikabilitaet im Vollzug.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/parteienrecht-parteiorganisation/.claude-plugin/plugin.json
+++ b/parteienrecht-parteiorganisation/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parteienrecht-parteiorganisation",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Parteienrechts- und Parteiorganisations-Plugin für formale Parteiarbeit: Parteiengesetz, Satzung, Mitgliederrechte, Parteitage, Kreis- und Bezirksversammlungen, Kandidatenaufstellung, Wahlvorschläge, Parteigerichte, Spenden, Rechenschaft, Abgeordnetenrecht und Wahlleiterkommunikation.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/patentrecherche/.claude-plugin/plugin.json
+++ b/patentrecherche/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "patentrecherche",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Patentrecherche für Patentanwaelte agentisch in Espacenet Google Patents DPMAregister DEPATISnet EPO Register WIPO USPTO. Stand der Technik Neuheit § 3 PatG Art. 54 EPUe erfinderische Tätigkeit § 4 PatG Art. 56 EPUe Problem-Solution-Approach FTO CPC IPC INPADOC Recherchebericht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/patentrecht/.claude-plugin/plugin.json
+++ b/patentrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "patentrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Großes Patentrechts-Plugin für Erfindungsaufnahme, Patentanmeldung, Anspruchsentwurf, Recherche, Neuheit, erfinderische Tätigkeit, FTO, Abmahnung, Claim Chart, Vorbenutzungsrecht, Lizenz, Erfinderbenennung, Einspruch, Nichtigkeit, Register und Fristen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/phishing-vorfall-pruefer/.claude-plugin/plugin.json
+++ b/phishing-vorfall-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "phishing-vorfall-pruefer",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Freistehender Phishing-Vorfall-Prüfer für Online-Banking: BGB § 675u, § 675v, § 675w, pushTAN, Call-ID-Spoofing, grobe Fahrlässigkeit, Beweislast, Bankpflichten, Schlichtung und Klage.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/private-equity-praxis/.claude-plugin/plugin.json
+++ b/private-equity-praxis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "private-equity-praxis",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Private-Equity-Praxis-Plugin für deutsche Kanzleien, Investoren, Fonds, Family Offices und Unternehmen: Fund Formation, KAGB/AIF, ELTIF, Deal Execution, Private Credit, Schuldschein, LMA, NPL, Portfolio, Exit und Distressed.",
   "author": {
     "name": "Klotzkette"

--- a/produktrecht/.claude-plugin/plugin.json
+++ b/produktrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "produktrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Produktrechtliche Skills für Launch-Review, Impressumspflicht nach DDG und PAngV sowie UWG-Bewertungen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/prozessrecht/.claude-plugin/plugin.json
+++ b/prozessrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prozessrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Prozessrechtliche Skills für Mandate, Fristen, Mahnbescheid, Eilverfahren, Vollstreckung und Schriftsätze.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/rechtsberatungsstelle/.claude-plugin/plugin.json
+++ b/rechtsberatungsstelle/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rechtsberatungsstelle",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Pro-Bono- und Rechtsberatungsstellen (RDG-konform): Mandantenintake, Fristenkontrolle, Übergabe am Semesterende, mandantenfreundliche Briefe.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/regulatorisches-recht/.claude-plugin/plugin.json
+++ b/regulatorisches-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "regulatorisches-recht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Aufsichtsrecht – KWG, ZAG, WpHG, GwG, EnWG, TKG, HeilMWerbG, Umsatzsteuer-Voranmeldung, Inkasso/RDG, Regulator-Feeds, Wochendigest.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/robotik-recht/.claude-plugin/plugin.json
+++ b/robotik-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "robotik-recht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Robotik-Recht Deutschland/EU: Maschinenverordnung, KI-VO, Produkthaftung, ProdSG, Datenschutz, CRA, Data Act, CE, Marktüberwachung, Unfälle, Rückruf, Verträge und Robotik-Testakte.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/schriftform-und-textform-bgb/.claude-plugin/plugin.json
+++ b/schriftform-und-textform-bgb/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "schriftform-und-textform-bgb",
   "displayName": "Schriftform und Textform im BGB",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Formerfordernisse im deutschen Zivilrecht: Schriftform, Textform, qES, Zugang, beA/ERV und Prozessordnungen. Mit Checklisten, Dokumentation und Rechtsprechung nur nach Live-Verifikation.",
   "author": {
     "name": "Klotzkette"

--- a/selbstvertreter-amtsgericht/.claude-plugin/plugin.json
+++ b/selbstvertreter-amtsgericht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "selbstvertreter-amtsgericht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Selbstvertretung vor dem Amtsgericht ohne Anwalt: Anfänger-Workflow, Fristen, Zuständigkeit, §23 GVG/§511 ZPO-Grenzen, Klage/Erwiderung/Replik, Beweise, PKH, Termin, Sanity-Check, Rechtsprechungschat, Berufung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/selbstvertreter-sozialgericht/.claude-plugin/plugin.json
+++ b/selbstvertreter-sozialgericht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "selbstvertreter-sozialgericht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Selbstvertretung vor dem Sozialgericht ohne Anwalt: Anfänger-Workflow, Widerspruch, Klage, Eilantrag, Pflegegrad, Krankenkasse, Bürgergeld, EM-Rente, GdB, Belege, Gutachten, Kostenfreiheit, Sanity-Check, Rechtsprechungschat, Berufung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/steuerrecht-anwalt-und-berater/.claude-plugin/plugin.json
+++ b/steuerrecht-anwalt-und-berater/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "steuerrecht-anwalt-und-berater",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Steuerrecht für Anwalt (anw- FAO § 9) und Steuerberater (stb-): Einspruch Klage FG Aussenprüfung Selbstanzeige, Grundsteuer, Grunderwerbsteuer, Share Deals, Signing Closing, BWA SuSa Lohnbuchhaltung Jahresabschluss.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/strafbefehl-verteidiger/.claude-plugin/plugin.json
+++ b/strafbefehl-verteidiger/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "strafbefehl-verteidiger",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Freistehendes Strafbefehls-Plugin für Verteidigung gegen Strafbefehl, Einspruch, Akteneinsicht, Tagessätze, Nebenfolgen, Pflichtverteidigung, Wiedereinsetzung, Einstellung, Zeugenstrategie und Hauptverhandlung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/strafzumessung/.claude-plugin/plugin.json
+++ b/strafzumessung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "strafzumessung",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Strafzumessung nach deutschem Strafrecht vom Strafbefehl bis zur grossen Strafkammer. § 46 StGB Strafzumessungstatsachen Tagessatz Geldstrafe Freiheitsstrafe Bewaehrung § 56 § 49 Regelbeispiele besonders schwerer Fall Verstaendigung § 257c StPO TOA § 46a Gesamtstrafe § 55 JGG.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/subsumtions-pruefer/.claude-plugin/plugin.json
+++ b/subsumtions-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "subsumtions-pruefer",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Interaktiver Subsumtions-Workflow für deutsches Recht und Europarecht: Tatbestandsmerkmale zerlegen, Vier-Schritt-Schema anwenden, Rechtsfolgen und Einreden prüfen. Keine Rechtsberatung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/tabellenreview-3d/.claude-plugin/plugin.json
+++ b/tabellenreview-3d/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tabellenreview-3d",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "3D-Tabellenreview als Wuerfel: Spaltenprompts pro Datenpunkt x Zeilenprompts pro Dokument x Arbeitsblatt-Perspektiven (Recht / Steuer / Wirtschaft) gestapelt. Massenprüfung Vertragsstapel M&A-DD Immobilien Vendor-Onboarding mit Excel-Mehrblatt Kreuzblatt-Konsistenz Audit-Trail Belegkette.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/umweltrecht/.claude-plugin/plugin.json
+++ b/umweltrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "umweltrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Freistehendes Umweltrecht-Plugin für BImSchG, TEHG, Abfall, Wasser, Boden, Naturschutz, UIG, Verfahren, Bußgeld, Umwelt-Due-Diligence, Klimaklagen UmwRG, Lieferkettensorgfalt LkSG/CSDDD und ESG-Greenwashing/CSRD.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/urteilsbauer-relationsmacher/.claude-plugin/plugin.json
+++ b/urteilsbauer-relationsmacher/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "urteilsbauer-relationsmacher",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Urteils- und Beschluss-Werkstatt für Amts- Land- und Familienrichter sowie Rechtspfleger. Aktenintake Relation Beweiswürdigung mit Richter-Input Tatbestandsmerkmale Tenor Tatbestand Entscheidungsgründe Rechtsmittelbelehrung. Erzeugt DOCX nach Paragraf 313 ZPO.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/vereinsrecht-vereinsmanager/.claude-plugin/plugin.json
+++ b/vereinsrecht-vereinsmanager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vereinsrecht-vereinsmanager",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Vereinsrechts- und Vereinsmanagement-Plugin für eingetragene und nicht eingetragene Vereine: Gründung, Satzung, Mitgliederversammlung, Vorstand, Protokolle, Beschlüsse, Gemeinnützigkeit, Register, Haftung, Datenschutz, Finanzen, Veranstaltungen und Spezialvereine.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verfassungsrecht/.claude-plugin/plugin.json
+++ b/verfassungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verfassungsrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Deutsches Verfassungsrecht unter dem Grundgesetz aus Sicht einer Spezialkanzlei. Rechtsprechungsgetrieben mit Live-Recherche auf bundesverfassungsgericht.de. Acht Skills für Gesetzgebungskompetenz formelle und materielle Verfassungsmäßigkeit Grundrechte und Verfassungsbeschwerde.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verkehr-infrastrukturrecht/.claude-plugin/plugin.json
+++ b/verkehr-infrastrukturrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verkehr-infrastrukturrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Freistehendes Verkehrs- und Infrastrukturrecht-Plugin für Verkehrsplanung, Planfeststellung, Straßenbahn, Ladeinfrastruktur, Parkraum und Verkehrswende.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verkehrsowi-verteidiger/.claude-plugin/plugin.json
+++ b/verkehrsowi-verteidiger/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verkehrsowi-verteidiger",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Freistehendes VerkehrsOWi-Plugin für Bußgeldbescheid, Anhörung, Einspruch, Punkte, Fahrverbot, Rotlicht, Geschwindigkeit, Abstand, Handy, Alkohol, Drogen, Akteneinsicht, Messakte, Zeugenstrategie und Amtsgericht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verlagsredaktion/.claude-plugin/plugin.json
+++ b/verlagsredaktion/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verlagsredaktion",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Verlagsdesk fuer juristische und fachliche Verlage: Eingangskorb, Manuskript, Redaktion, Rechtecheck, Zitate, Bildrechte, Autorenkommunikation, Heftplanung, Buchprojekte, Satzfahnen, Metadaten, Marketing und Produktionsuebergabe.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/vertragsausfueller/.claude-plugin/plugin.json
+++ b/vertragsausfueller/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vertragsausfueller",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Freistehendes Vertragsausfüller-Plugin: DOCX-Vorlagen und Altverträge strippen, Felder erkennen, Term Sheets mappen, Rückfragen führen, neue Verträge erzeugen und Track-Changes-Fassungen nur nach ausdrücklicher Nachfrage vorbereiten.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/vertragsrecht/.claude-plugin/plugin.json
+++ b/vertragsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vertragsrecht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Vertragsrecht – Lieferanten- und Vertriebsverträge, AGB §§ 305 ff. BGB, NDA, SaaS-/MSA-Review, Renewal-Tracking, Eskalations-Routing, Business-Zusammenfassungen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/wandeldarlehen-lebenszyklus/.claude-plugin/plugin.json
+++ b/wandeldarlehen-lebenszyklus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wandeldarlehen-lebenszyklus",
   "displayName": "Wandeldarlehen-Lebenszyklus (Erstellung bis Cap-Table)",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Begleitet den vollständigen Lebenszyklus eines Wandeldarlehens für GmbH und UG: Vertragserstellung (bilingual/einsprachig), Beurkundungsprüfung, Wandelereignisse, Wandlungsberechnung, Cap-Table-Update, Gesellschafterbeschluss und Notar-Paket.",
   "author": {
     "name": "Klotzkette"

--- a/weg-hausverwaltung/.claude-plugin/plugin.json
+++ b/weg-hausverwaltung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "weg-hausverwaltung",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Operatives WEG- und Hausverwaltungs-Plugin fuer Beschluesse, Eigentuemerversammlung, Protokoll, Beschlusssammlung, Wirtschaftsplan, Jahresabrechnung, Hausgeld, Sonderumlage, Betriebskosten, Handwerker, bauliche Veraenderungen, Steckersolar, Wallbox, Verwalter, Beirat und Anwalt-Eskalation.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/word-legal-ai-plugin-and-skill-for-german-lawyers/.claude-plugin/plugin.json
+++ b/word-legal-ai-plugin-and-skill-for-german-lawyers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "word-legal-ai-plugin-and-skill-for-german-lawyers",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Word Legal AI for German Lawyers: Kaltstart, Kanzleistil, makrofreies Word-Finish, Verträge, Schriftsätze, Memos, Redlines, Klauselbibliothek, Defensive Drafting, Term Sheet, DE-EN Bilingual, US/UK Legal Writing und englische Verträge nach deutschem Recht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/zitierweise-deutsches-recht/.claude-plugin/plugin.json
+++ b/zitierweise-deutsches-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zitierweise-deutsches-recht",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Deutsche juristische Hauszitierweise v4.0: Rechtsprechung nur mit Gericht, Entscheidungsform, Datum, Aktenzeichen und verifizierbarer Quelle; keine BeckRS-, Kommentar- oder Aufsatz-Blindzitate. Literatur nur mit Nutzerquelle oder lizenziertem Live-Zugriff.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/zwangsverwaltung-zvg/.claude-plugin/plugin.json
+++ b/zwangsverwaltung-zvg/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zwangsverwaltung-zvg",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Freistehendes ZVG-Plugin für Zwangsverwaltung und Versteigerung: Beschlagnahme, Besitz, Mieten, Treuhandkonto, Berichte, Verteilung, ZVG-Portal-Recherche, Bieterangebote und Versteigerungsteilnahme.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/zwangsvollstreckung/.claude-plugin/plugin.json
+++ b/zwangsvollstreckung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zwangsvollstreckung",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "Plugin Zwangsvollstreckung §§ 704 ff. ZPO: Mahn-/Vollstreckungsbescheid, PfÜB Bank/Arbeit, § 802l Kontensuche, Vermögensauskunft, Räumung, § 800 ZPO Notar, § 201 InsO, ZVG, EU-Kontenpfändung VO 655/2014, § 765a Härtefall, Schuldnerschutz.",
   "license": "Apache-2.0 OR MIT",
   "author": {


### PR DESCRIPTION
## v59.0.0 — Major-Release-Marker

Bumpt alle 130 Plugins + marketplace.json einheitlich auf **v59.0.0**.

### Codex-Sweep (letzte 24h)
- 28 Codex-Findings (P1/P2) auf PRs #176-#200 inhaltlich umgesetzt
- Alle Review-Threads als resolved markiert
- 11 neue Testakten: Sanierungsgewinn 3x, ElErrHandRegG, Pellbach,
  Vellbruck-Koeln Gesamt-PDF u.a.
- 4 neue Plugins: Private Equity, Battery Storage, Robotik-Recht,
  Normenkontrollrat-NKR
- PDF-Kompaktierung ueber alle Testakten

### Versions-Drift bereinigt
Vorher: 128 Plugins auf 58.0.0, 2 Plugins auf 58.1.0 (Rest aus PR #198)
Nachher: **alle 130 Plugins auf 59.0.0**, marketplace.json synchron

### Validatoren
- validate-testakten-gesamt-pdf.py: OK (139 Testakten)
- validate-yaml-frontmatter.py: OK

### Counts
- 130 Plugins
- 9299 Skills
- 139 Testakten
