### PR TITLE
chore(stand-marker): SKILLS.md / README.md / ASSET_INDEX.md auf v59.0.0

### DIFF
--- a/ASSET_INDEX.md
+++ b/ASSET_INDEX.md
@@ -1,6 +1,6 @@
 # Release-Asset-Index
 
-**Stand:** v58.0.0 — automatisch aktualisierte Asset-Übersicht
+**Stand:** v59.0.0 — automatisch aktualisierte Asset-Übersicht
 
 ## Sammel-Assets
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Dieses Repository trifft **keine Aussage** zur Zulässigkeit eines Einsatzes im 
 | **Skills (SKILL.md)** | 9156 — [Gesamtübersicht](./SKILLS.md) |
 | **Testakten** | 139 |
 | **Fachanwalts-/-anwältinnen-Profile** | 24 |
-| **Plugin-Version / Arbeitsstand** | `v58.0.0` — [latest Release auf GitHub](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest) |
+| **Plugin-Version / Arbeitsstand** | `v59.0.0` — [latest Release auf GitHub](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest) |
 | **Marketplace-Definition** | [`.claude-plugin/marketplace.json`](./.claude-plugin/marketplace.json) |
 
 ### Sammel-Downloads

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -2,7 +2,7 @@
 
 Automatisch generierte Gesamtuebersicht aller **9299 Skills** in **130 Plugins**.
 
-Stand: `v58.1.0`.
+Stand: `v59.0.0`.
 
 ## ⬇️ Alle Skills auf einmal herunterladen
 


### PR DESCRIPTION
## Sanity-Check — drei Stand-Marker auf v59.0.0 nachgezogen

Sanity-Check ergab drei Drifts vs. tatsächlichem Plugin-Versions-Stand: alle 130 `plugin.json` sind bereits auf **59.0.0** (Codex PR #201 release-bump), aber drei Übersichts-Marker hingen hinterher:

| Datei | vorher | nachher |
|---|---|---|
| `SKILLS.md` | `v58.1.0` | `v59.0.0` |
| `README.md` | `v58.0.0` | `v59.0.0` |
| `ASSET_INDEX.md` | `v58.0.0` | `v59.0.0` |

### Sonstiger Sanity-Check (alles grün)

- 130 Plugins FS = 130 Plugins marketplace.json ✓
- 139 Testakten FS = 139 Einträge testakten/README.md ✓
- `validate-plugin-structure` → OK
- `validate-testakten-gesamt-pdf` → OK (139 Testakten)
- Alle 130 plugin.json einheitlich auf v59.0.0 ✓

https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL

---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_