### PR TITLE
fix(codex #202): ApBetrO Paragrafen-Mapping + 110m2-Gesamtflaeche + 312k BGB Anwendungsbereich

### DIFF
--- a/apothekenrecht/skills/apothekenbetriebsordnung-grundpflichten/SKILL.md
+++ b/apothekenrecht/skills/apothekenbetriebsordnung-grundpflichten/SKILL.md
@@ -25,29 +25,34 @@ Eingaben:
 
 ## Rechtlicher Rahmen
 
-- **§§ 1a–6 ApBetrO:** Begriffsbestimmungen, Leiterpflichten, Personal, Räume, Ausstattung.
-- **§ 4 ApBetrO:** Räume — Offizin, Labor, Lager, Nachtdienstraum, Beratungszone, Behindertenzugang.
-- **§ 5 ApBetrO:** Ausstattung — Mindestgeräte, Software, Kühlkette.
-- **§ 6 ApBetrO:** Personal — Apothekerleiter, Vertretung, Personalmindestbesatz, Schulungen.
-- **§§ 7–8 ApBetrO:** Prüfung der Ausgangsstoffe und Endprodukte.
-- **§§ 11–12 ApBetrO:** Information, Beratung, Plausibilitätsprüfung beim Abgabevorgang.
-- **§ 14 ApBetrO:** Lagerhaltung, FIFO, Temperaturkontrolle.
-- **§ 21 ApBetrO:** Qualitätsmanagement-System (QMS), Pflicht zur SOP-Dokumentation.
-- **§ 25 ApBetrO:** Apothekenübliche Waren (Abgrenzungskatalog).
-- **§§ 34 ff. ApBetrO:** Krankenhausapotheken.
+- **§ 1a ApBetrO:** Begriffsbestimmungen.
+- **§ 2 ApBetrO:** Apothekenleiter (Aufgaben, Verantwortung, Vertretung).
+- **§ 2a ApBetrO:** Qualitätsmanagementsystem (QMS) — Pflicht zur SOP-Dokumentation, Selbstinspektion.
+- **§ 3 ApBetrO:** Apothekenpersonal (Apotheker, PTA, PKA; Vertretung; Schulungen).
+- **§ 4 ApBetrO:** Beschaffenheit, Größe und Einrichtung der Apothekenbetriebsräume; Mindestgrundfläche.
+- **§ 5 ApBetrO:** Hygienemaßnahmen.
+- **§ 6 ApBetrO:** Allgemeine Vorschriften über die Herstellung und Prüfung.
+- **§§ 7–8 ApBetrO:** Rezeptur und Defektur.
+- **§ 11 ApBetrO:** Sonderregelungen für die Abgabe (z.B. Notfall, Versand).
+- **§ 12 ApBetrO:** Verschreibung und Abgabe (Form, Plausibilitätsprüfung am Rezept).
+- **§ 16 ApBetrO:** Lagerung — Ordnung, Trennung, Temperaturkontrolle, Kühlkette.
 - **§ 17 ApBetrO:** Erwerb und Abgabe von Arzneimitteln.
 - **§ 18 ApBetrO:** Dokumentationspflichten Rezeptur, Defektur, BtM.
+- **§ 20 ApBetrO:** Information und Beratung beim Abgabevorgang.
+- **§ 21 ApBetrO:** Apothekenübliche Dienstleistungen (z.B. pharmazeutische Dienstleistungen).
+- **§ 25 ApBetrO:** Apothekenübliche Waren (Abgrenzungskatalog).
+- **§§ 34 ff. ApBetrO:** Krankenhausapotheken (Personal § 28, Räume § 29).
 
 ## Workflow / Schritt für Schritt
 
-1. **Räume:** Offizin mindestens 50 m², Labor mindestens 8 m², Nachtdienstraum, separates Lager, abschliessbarer BtM-Schrank.
-2. **Personal:** Apothekerleitung anwesend oder vertretungsbefugt (§ 7 ApoG, § 2 ApBetrO). PTA-Tätigkeit unter Apothekeraufsicht.
-3. **QMS:** Schriftliches QM-Handbuch, SOPs für alle relevanten Prozesse (Annahme, Lagerung, Abgabe, Beratung, Notfall, Defektur, Rezeptur, Reklamation, Rückruf).
-4. **Beratung:** Pflicht zur Information und Beratung bei jeder Abgabe (§ 20 ApBetrO). Bei Rx zusätzlich Plausibilitätsprüfung.
-5. **Dokumentation:** Prüfprotokoll für jede Rezeptur und jede Defektur. BtM-Buchführung (siehe Skill `btm-rezept-betaeubungsmittel-dokumentation`).
-6. **Lagerhaltung:** Temperaturkontrolle dokumentiert; Kühlkette nachweisbar (siehe Skill `kuehlkette-temperaturmonitoring-gdp`).
-7. **Sortiment:** Trennung Rx, OTC, apothekenpflichtig, apothekenüblich (§ 25 ApBetrO). Keine Drogeriewaren über apothekenüblichen Katalog hinaus.
-8. **Hygiene:** Reinigung dokumentiert, Hygieneplan nach RKI-Empfehlung.
+1. **Räume (§ 4 ApBetrO):** Offizin, Laboratorium, ausreichender Lagerraum und Nachtdienstzimmer; Gesamt-Grundfläche der Betriebsräume mindestens 110 Quadratmeter (§ 4 Abs. 2 Satz 3 ApBetrO). Keine fixe Einzelflächenvorgabe pro Raum; Laboratorium mit Abzug/Absaugvorrichtung. Behindertenzugang; abschliessbarer BtM-Schrank.
+2. **Personal (§ 3 ApBetrO, § 7 ApoG):** Apothekerleitung anwesend oder vertretungsbefugt. PTA-Tätigkeit unter Apothekeraufsicht; Vertretungsregelung dokumentiert.
+3. **QMS (§ 2a ApBetrO):** Schriftliches QM-Handbuch, SOPs für alle relevanten Prozesse (Annahme, Lagerung, Abgabe, Beratung, Notfall, Defektur, Rezeptur, Reklamation, Rückruf); regelmäßige Selbstinspektion.
+4. **Beratung (§ 20 ApBetrO):** Pflicht zur Information und Beratung bei jeder Abgabe. Bei Rx zusätzlich Plausibilitätsprüfung nach § 12 ApBetrO (Vollständigkeit der Verschreibung, Dosierung, Wechselwirkungen).
+5. **Dokumentation (§ 18 ApBetrO):** Prüfprotokoll für jede Rezeptur und jede Defektur. BtM-Buchführung (siehe Skill `btm-rezept-betaeubungsmittel-dokumentation`).
+6. **Lagerhaltung (§ 16 ApBetrO):** Trennung, FIFO, Temperaturkontrolle dokumentiert; Kühlkette nachweisbar (siehe Skill `kuehlkette-temperaturmonitoring-gdp`).
+7. **Sortiment (§ 25 ApBetrO):** Trennung Rx, OTC, apothekenpflichtig, apothekenüblich. Keine Drogeriewaren über apothekenüblichen Katalog hinaus.
+8. **Hygiene (§ 5 ApBetrO):** Reinigung dokumentiert, Hygieneplan nach RKI-Empfehlung.
 9. **Revisionsfähigkeit:** Alle Dokumente an einem Ort, drei Jahre Aufbewahrung (BtM zehn Jahre, § 13 BtMVV).
 
 ## Trade-off-Matrix

--- a/ecommerce-recht/skills/kuendigungsbutton-312k-bgb/SKILL.md
+++ b/ecommerce-recht/skills/kuendigungsbutton-312k-bgb/SKILL.md
@@ -32,11 +32,12 @@ description: "Kündigungsbutton § 312k BGB: prüft die einschlägigen Vorausset
 
 ## Workflow / Schritt für Schritt
 
-1. **Anwendungsbereich prüfen.** Verbraucher? Online-Abschluss möglich? Entgeltliche Dauerschuldverhältnis?
+1. **Anwendungsbereich prüfen.** Verbraucher? Ermöglicht der Unternehmer den Abschluss des Vertragstyps über eine Webseite (es kommt nicht darauf an, ob der konkrete Kundenvertrag online geschlossen wurde — § 312k Abs. 1 BGB stellt auf die generelle Verfügbarkeit des Abschlussweges ab)? Entgeltliches Dauerschuldverhältnis?
 2. **Buttontext prüfen.** "Verträge hier kündigen" oder gleichwertig, gut lesbar, ohne weitere Login-Hürde direkt nach Klick erreichbar.
 3. **Bestätigungsseite prüfen.** Vollständige Angaben: Identifizierung des Vertrags, Art der Kündigung, Datum/Uhrzeit, eindeutiger Bestätigungs-Button.
 4. **Bestätigung per E-Mail.** Unmittelbar nach Klick, mit Zeitstempel.
-5. **Bestandskunden.** Pflicht gilt auch für Altverträge, soweit Vertrag online abgeschlossen wurde.
+5. **Bestandskunden.** Pflicht gilt auch für Altverträge und für offline geschlossene Verträge des gleichen Typs, sobald der Unternehmer den Abschluss über die Webseite anbietet (§ 312k Abs. 1 BGB stellt auf den angebotenen Abschlussweg ab, nicht auf den konkreten Vertragsschluss).
+   - Konkret: Wer Online-Neuabschluss anbietet, muss den Kündigungsbutton auch für offline geworbene Kunden und für im Laden/per Post geschlossene Verträge bereitstellen, wenn es derselbe Vertragstyp ist.
 6. **Login-Hürde unzulässig.** OLG Düsseldorf und andere haben Login-Pflicht zwischen Button und Bestätigung als unzulässig eingestuft.
 7. **Beweissicherung.** Screenshots, Versionierung der Seite, Log-Files.
 8. **Abmahnung.** Modifizierte Unterlassungserklärung mit Vertragsstrafenklausel.
@@ -49,6 +50,7 @@ description: "Kündigungsbutton § 312k BGB: prüft die einschlägigen Vorausset
 | Button mit Login-Pflicht | Login entfernen; nur Identifikationsdaten abfragen |
 | B2B-Abo | § 312k nicht anwendbar |
 | Hybrid B2C/B2B | Pflicht für B2C-Bereich; Schaltflächentexte differenzieren |
+| Hybrid Online/Offline (Vertragstyp wird online angeboten) | Kündigungsbutton-Pflicht erfasst auch offline geschlossene Verträge desselben Typs (§ 312k Abs. 1 BGB) |
 | Bestätigungsmail fehlt | sofort einrichten |
 
 ## Praxistipps
@@ -56,7 +58,7 @@ description: "Kündigungsbutton § 312k BGB: prüft die einschlägigen Vorausset
 - Buttontext muss eindeutig sein. "Vertrag kündigen" reicht; "Abomanagement" reicht nicht.
 - Bestätigungsseite darf weitere Angaben verlangen – aber nur soweit zur Identifizierung erforderlich (Name, Kundennummer, E-Mail).
 - Aufgabenverteilung zwischen Frontend und Backend: Sofortige Bestätigungsmail muss auch bei Systemstörungen funktionieren – Monitoring.
-- Bestandskunden: § 312k findet auch auf Altverträge Anwendung, wenn sie online geschlossen wurden – kein Bestandsschutz.
+- Bestandskunden: § 312k Abs. 1 BGB stellt auf den durch den Unternehmer eröffneten Abschlussweg ab. Wird derselbe Vertragstyp über die Webseite angeboten, gilt der Kündigungsbutton auch für Altverträge und offline geschlossene Verträge – kein Bestandsschutz und keine Beschränkung auf den konkreten Online-Abschluss.
 - Abmahnungen erfolgen häufig durch Verbraucherzentralen (NRW, Bundesverband VZBV).
 
 ## Mustertexte


### PR DESCRIPTION
## 3 Codex-Findings (P2) auf PR #202 (Boost-Sweep)

### 1. apothekenrecht/apothekenbetriebsordnung-grundpflichten
**Codex P2 — Sektions-Mapping**
- Personal: § 3 ApBetrO (nicht § 6)
- QMS: § 2a ApBetrO (nicht § 21)
- Lagerung/Temperatur: § 16 ApBetrO (nicht § 14)
- Beratung: § 20 ApBetrO (Skill war hier korrekt, jetzt durchgaengig referenziert)

**Codex P2 — Erfundene Raum-Mindestgroessen**
- Falsch: Offizin 50m2 / Labor 8m2
- Korrekt: [§ 4 Abs. 2 Satz 3 ApBetrO](https://www.gesetze-im-internet.de/apobetro_1987/__4.html) — Gesamt-Grundflaeche der Betriebsraeume min. 110 m2; keine Einzelvorgabe pro Raum.

### 2. ecommerce-recht/kuendigungsbutton-312k-bgb
**Codex P2 — Anwendungsbereich nicht auf online-Vertraege beschraenken**
- [§ 312k Abs. 1 BGB](https://www.gesetze-im-internet.de/bgb/__312k.html) stellt auf den vom Unternehmer eroeffneten Abschlussweg ab, nicht auf den konkreten Vertragsschluss.
- Konsequenz: Wer Online-Neuabschluss anbietet, muss Kuendigungsbutton auch fuer offline geworbene Kunden / im Laden geschlossene Vertraege desselben Typs bereitstellen.

### Validatoren
- validate-yaml-frontmatter.py: OK
- validate-testakten-gesamt-pdf.py: OK (139 Testakten)
