### PR TITLE
chore: Lizenzfeld in 18 plugin.json ergaenzen (Apache-2.0 OR MIT)

### DIFF
--- a/apothekenrecht/.claude-plugin/plugin.json
+++ b/apothekenrecht/.claude-plugin/plugin.json
@@ -2,6 +2,7 @@
   "name": "apothekenrecht",
   "version": "61.1.0",
   "description": "Super-Plugin für Apothekenrecht: Betriebserlaubnis, ApBetrO, Versand, E-Rezept, BtM, Retaxation, Aufsicht und Compliance.",
+  "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"
   },

--- a/bav-strategie-konzern/.claude-plugin/plugin.json
+++ b/bav-strategie-konzern/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "displayName": "Betriebliche Altersversorgung Strategie Konzern",
   "version": "61.1.0",
   "description": "Strategische Beratung zur betrieblichen Altersversorgung in Konzernen: Pensionsmodelle alle fuenf Durchführungswege CTA Pension Buyouts Drei-Stufen-Theorie Versorgungssystem-Harmonisierung internationale Benefits Restrukturierung DB-zu-DC im Duesseldorfer Boutique-Stil.",
+  "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"
   }

--- a/beamtenrecht/.claude-plugin/plugin.json
+++ b/beamtenrecht/.claude-plugin/plugin.json
@@ -2,6 +2,7 @@
   "name": "beamtenrecht",
   "version": "61.1.0",
   "description": "Beamtenrecht für Bund, Länder und Richterdienst: Status, Laufbahn, Besoldung, Versorgung, Konkurrentenstreit, Disziplinarrecht, Dienstunfähigkeit, Richterlaufbahn, Landesrecht und verständliche Mandatsführung.",
+  "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"
   }

--- a/bgb-at-pruefer/.claude-plugin/plugin.json
+++ b/bgb-at-pruefer/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "displayName": "BGB AT Prüfer",
   "version": "61.1.0",
   "description": "Großes Prüfplugin zum BGB Allgemeiner Teil: Vertragsschluss, Willenserklärung, Zugang, Geschäftsfähigkeit, Form, qES, beA, § 130e ZPO, § 46h ArbGG, Anfechtung, Stellvertretung, Fristen und Verjährung.",
+  "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"
   }

--- a/bgb-bt-pruefer/.claude-plugin/plugin.json
+++ b/bgb-bt-pruefer/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "displayName": "BGB BT Prüfer",
   "version": "61.1.0",
   "description": "Großer BGB-BT-Prüfer für Schuldrecht Besonderer Teil: Kauf, Miete, Pacht, Leihe, Darlehen, Dienst, Werk, Bau, Reise, Makler, Auftrag, Geschäftsbesorgung, Bürgschaft, Schuldversprechen, GoA, Bereicherung, Delikt und Rückabwicklung.",
+  "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"
   },

--- a/bundesnetzagentur-verfahren/.claude-plugin/plugin.json
+++ b/bundesnetzagentur-verfahren/.claude-plugin/plugin.json
@@ -2,6 +2,7 @@
   "name": "bundesnetzagentur-verfahren",
   "version": "61.1.0",
   "description": "Großes Regulierungs-Plugin für anwaltliche Arbeit mit der Bundesnetzagentur in Energie, Telekommunikation, Post, Eisenbahn und Digital Services.",
+  "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"
   },

--- a/bundeswehrrecht-wehrrecht/.claude-plugin/plugin.json
+++ b/bundeswehrrecht-wehrrecht/.claude-plugin/plugin.json
@@ -2,6 +2,7 @@
   "name": "bundeswehrrecht-wehrrecht",
   "version": "61.1.0",
   "description": "Super-Plugin für Soldatenrecht, Wehrbeschwerde, Disziplinarrecht, Wehrpflicht, Reservisten, Versorgung und Bundeswehrverwaltung.",
+  "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"
   },

--- a/dsa-dma-digitalregulierung/.claude-plugin/plugin.json
+++ b/dsa-dma-digitalregulierung/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "displayName": "DSA DMA und Digitalregulierung EU",
   "version": "61.1.0",
   "description": "Digitalregulierung der EU: DSA (VO 2022/2065) und DMA (VO 2022/1925) plus Data Act DGA AI Act NIS-2 DORA CRA eIDAS 2.0 DDG P2B-VO und § 19a GWB. Gatekeeper-Schwellen VLOP-Einordnung Risikobewertung Art. 34 Forschungsdatenzugang Art. 40 Account-Sperre Art. 20-23 Zustellung Art. 13 DSA Klagewege.",
+  "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"
   }

--- a/ecommerce-recht/.claude-plugin/plugin.json
+++ b/ecommerce-recht/.claude-plugin/plugin.json
@@ -2,6 +2,7 @@
   "name": "ecommerce-recht",
   "version": "61.1.0",
   "description": "Super-Plugin für Online-Shops, Plattformen, Marktplätze und digitale Verbraucherprozesse.",
+  "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"
   },

--- a/factoring-recht/.claude-plugin/plugin.json
+++ b/factoring-recht/.claude-plugin/plugin.json
@@ -2,6 +2,7 @@
   "name": "factoring-recht",
   "version": "61.1.0",
   "description": "Super-Plugin für Factoring, Forderungskauf, Aufsichtsrecht, Vertragsgestaltung, Debitorenkommunikation, Insolvenz- und Sanierungsfragen.",
+  "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"
   },

--- a/goae-gebuehrenordnung-aerzte/.claude-plugin/plugin.json
+++ b/goae-gebuehrenordnung-aerzte/.claude-plugin/plugin.json
@@ -2,6 +2,7 @@
   "name": "goae-gebuehrenordnung-aerzte",
   "version": "61.1.0",
   "description": "Super-Plugin zur GOÄ: private Arztrechnungen prüfen, erstellen, begründen, beanstanden und prozessual verwerten.",
+  "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"
   },

--- a/handelsrecht-hgb/.claude-plugin/plugin.json
+++ b/handelsrecht-hgb/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "displayName": "Handelsrecht HGB",
   "version": "61.1.0",
   "description": "Reines HGB-Plugin für Handelsrecht: Kaufmann, Handelsregister, Firma, Prokura, Handlungsvollmacht, Handelsgeschäfte, Handelskauf, Handelsvertreter, Makler, Kommission, Fracht, Spedition, Lager, Handelsbücher sowie OHG/KG einschließlich MoPeG-Statuswechsel von GbR zu OHG.",
+  "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"
   },

--- a/kartellrecht-marktabgrenzung-pruefung/.claude-plugin/plugin.json
+++ b/kartellrecht-marktabgrenzung-pruefung/.claude-plugin/plugin.json
@@ -2,6 +2,7 @@
   "name": "kartellrecht-marktabgrenzung-pruefung",
   "version": "61.1.0",
   "description": "Kritische kartellrechtliche Pruefinstanz fuer Marktabgrenzungen nach Paragraf 18 GWB sowie Art. 101 und 102 AEUV: SSNIP-Test, Nachfrage- und Angebotsumstellung, raeumlicher Markt, Evidenz, Konsistenz, Red Flags und Marktbeherrschung. Rechtsprechung nur nach Live-Verifikation.",
+  "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"
   },

--- a/krankenhausrecht/.claude-plugin/plugin.json
+++ b/krankenhausrecht/.claude-plugin/plugin.json
@@ -2,6 +2,7 @@
   "name": "krankenhausrecht",
   "version": "61.1.0",
   "description": "Super-Plugin für deutsches Krankenhausrecht: Planung, Finanzierung, Entgelte, Reform, Qualität, MD-Prüfung, Klinikbetrieb und Rechtsstreit.",
+  "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"
   },

--- a/krisenfrueherkennung-starug/.claude-plugin/plugin.json
+++ b/krisenfrueherkennung-starug/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "displayName": "Krisenfrüherkennung und StaRUG-Management",
   "version": "61.1.0",
   "description": "Krisenfrüherkennung und Krisenmanagement nach StaRUG: Pflicht zum 24-Monats-Frühwarnsystem nach § 1 StaRUG, § 102 StaRUG Warnpflicht der Berater, Geschäftsführerhaftung, drohende Zahlungsunfähigkeit, integrierte Planung, Restrukturierungsplan und Stabilisierungsanordnung.",
+  "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"
   }

--- a/private-equity-praxis/.claude-plugin/plugin.json
+++ b/private-equity-praxis/.claude-plugin/plugin.json
@@ -2,6 +2,7 @@
   "name": "private-equity-praxis",
   "version": "61.1.0",
   "description": "Private-Equity-Praxis-Plugin für deutsche Kanzleien, Investoren, Fonds, Family Offices und Unternehmen: Fund Formation, KAGB/AIF, ELTIF, Deal Execution, Private Credit, Schuldschein, LMA, NPL, Portfolio, Exit und Distressed.",
+  "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"
   }

--- a/schriftform-und-textform-bgb/.claude-plugin/plugin.json
+++ b/schriftform-und-textform-bgb/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "displayName": "Schriftform und Textform im BGB",
   "version": "61.1.0",
   "description": "Formerfordernisse im deutschen Zivilrecht: Schriftform, Textform, qES, Zugang, beA/ERV und Prozessordnungen. Mit Checklisten, Dokumentation und Rechtsprechung nur nach Live-Verifikation.",
+  "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"
   }

--- a/us-copyright-registrierung-verlag/.claude-plugin/plugin.json
+++ b/us-copyright-registrierung-verlag/.claude-plugin/plugin.json
@@ -2,6 +2,7 @@
   "name": "us-copyright-registrierung-verlag",
   "version": "61.1.0",
   "description": "US-Copyright-Registrierung für deutsche Verlage: eCO-Account, Standard Application, Gebühren, Deposit, Shipping Slip, Versand aus Deutschland, Monitoring und Archivierung.",
+  "license": "Apache-2.0 OR MIT",
   "author": {
     "name": "Klotzkette"
   }


### PR DESCRIPTION
Hallo, und erstmal danke fuer dieses Repo. Die Adaption auf die deutsche Praxis ist mit viel Sorgfalt gemacht. Besonders die durchgaengige BGH-Zitierweise und die Laien-Anwalt-Triage mit gestaffelten Warnstufen fand ich stark.

Beim Stoebern ist mir eine Kleinigkeit aufgefallen, die ich gern direkt als PR mitbringe statt nur als Issue:

114 der 132 plugin.json tragen bereits "license": "Apache-2.0 OR MIT". 18 Plugins haben das Feld noch nicht, obwohl die README die Doppellizenz fuers ganze Projekt erklaert. Dieser PR ergaenzt nur diese 18 Manifeste, jeweils eine Zeile, exakt im Format der uebrigen. Inhaltlich aendert sich nichts, die Manifeste werden nur mit der bereits erklaerten Lizenz in Einklang gebracht. Fuer alle, die einzelne Plugins forken, ist die explizite Angabe im Manifest hilfreich.

Betroffen: apothekenrecht, bav-strategie-konzern, beamtenrecht, bgb-at-pruefer, bgb-bt-pruefer, bundesnetzagentur-verfahren, bundeswehrrecht-wehrrecht, dsa-dma-digitalregulierung, ecommerce-recht, factoring-recht, goae-gebuehrenordnung-aerzte, handelsrecht-hgb, kartellrecht-marktabgrenzung-pruefung, krankenhausrecht, krisenfrueherkennung-starug, private-equity-praxis, schriftform-und-textform-bgb, us-copyright-registrierung-verlag.

Alle 18 Dateien bleiben valides JSON, Einrueckung unveraendert.

Falls es dir hilft, schaue ich mir gern noch zwei Kleinigkeiten an, ganz wie du magst:
- references/zitierweise.md wird aus vielen Skills relativ referenziert, liegt aber nur im Repo-Root. Bei Einzelinstallation eines Plugins ist der Verweis dann nicht aufgeloest. Liesse sich durch Mitbuendeln pro Plugin oder einen README-Hinweis loesen.
- Per-Plugin-Versionierung, falls du irgendwann vom Gleichschritt-Bump weg moechtest.

Beides nur als Angebot, kein Muss. Danke nochmal und viele Gruesse.
