### PR TITLE
fix(beamtenrecht): Quellenanker fuer 17 verbliebene Skills nachziehen

### DIFF
--- a/beamtenrecht/skills/altersteilzeit-93-bbg-blockmodell/SKILL.md
+++ b/beamtenrecht/skills/altersteilzeit-93-bbg-blockmodell/SKILL.md
@@ -51,6 +51,13 @@ Skill fuer Beamte ab dem 55. Lebensjahr, die ueber Altersteilzeit den gleitenden
 - Berechnungstabelle Bezuege und Versorgung mit und ohne Altersteilzeit.
 - Antrag auf Altersteilzeit.
 
-## 6. Beispiel (Kurzfassung)
+## 6. Verifizierte Quellenanker
+
+- § 93 BBG (Altersteilzeit Bund); § 9 BeamtStG i.V.m. landesrechtlichen Altersteilzeitvorschriften.
+- § 6 BeamtVG (ruhegehaltfaehige Dienstzeit Altersteilzeit); § 14 BeamtVG (Versorgungsabschlag).
+- Altersteilzeitzuschlagsverordnung Bund und landesrechtliche Aequivalente.
+- BVerwG zur Altersteilzeit der Beamten — Datum und Az vor Zitat live verifizieren.
+
+## 7. Beispiel (Kurzfassung)
 
 Mandant 57 Jahre, will sechs Jahre Altersteilzeit im Blockmodell (drei Jahre Aktiv, drei Jahre Freistellung). Skill liefert Berechnung Bezuege und Versorgung.

--- a/beamtenrecht/skills/begrenzte-dienstfaehigkeit-27-bbg/SKILL.md
+++ b/beamtenrecht/skills/begrenzte-dienstfaehigkeit-27-bbg/SKILL.md
@@ -50,6 +50,13 @@ Skill fuer Beamte, deren Dienstfaehigkeit eingeschraenkt, aber nicht vollstaendi
 - Antrag oder Widerspruch.
 - Berechnung der reduzierten Bezuege und Versorgungsfolgen.
 
-## 6. Beispiel (Kurzfassung)
+## 6. Verifizierte Quellenanker
+
+- § 27 BBG (begrenzte Dienstfaehigkeit Bund); § 27 BeamtStG i.V.m. Landesrecht.
+- § 26 BBG (Dienstunfaehigkeit) als Vergleichsmassstab; § 6 BeamtVG (anteilige Ruhegehaltfaehigkeit).
+- Vorrang der milderen Massnahme: anderweitige Verwendung und begrenzte Dienstfaehigkeit vor Ruhestandsversetzung.
+- BVerwG zur begrenzten Dienstfaehigkeit und zur Pruefungspflicht anderweitiger Verwendung — Datum und Az vor Zitat live verifizieren.
+
+## 7. Beispiel (Kurzfassung)
 
 Mandantin Polizeikommissarin mit Bandscheibenleiden, Innen- statt Streifendienst denkbar. Dienstherr will Ruhestand verfuegen. Skill liefert Antrag auf begrenzte Dienstfaehigkeit und Pruefraster anderweitiger Verwendung.

--- a/beamtenrecht/skills/beihilfe-chronische-krankheit/SKILL.md
+++ b/beamtenrecht/skills/beihilfe-chronische-krankheit/SKILL.md
@@ -45,6 +45,13 @@ Skill fuer Beihilfeberechtigte mit schwerer chronischer Krankheit, die wegen hoh
 - Antrag auf Reduzierung der Belastungsgrenze.
 - Pruefraster Behandlung — Beihilfefaehigkeit — Eigenbehalt.
 
-## 6. Beispiel (Kurzfassung)
+## 6. Verifizierte Quellenanker
+
+- BBhV; Chroniker-Richtlinie des Gemeinsamen Bundesausschusses (G-BA) vom 22.01.2004 in jeweils geltender Fassung.
+- SGB V (Belastungsgrenze und chronisch krank); SGB XI (Pflegebeduerftigkeit) ergaenzend zur Beihilfe.
+- Landesrechtliche Beihilfeverordnungen mit eigenen Eigenbehaltsregelungen.
+- BVerwG zur Eigenbehaltsbefreiung bei schwerwiegender chronischer Erkrankung — Az vor Zitat live verifizieren.
+
+## 7. Beispiel (Kurzfassung)
 
 Mandantin Multiple Sklerose, monatliche Immunmodulatoren, Krankengymnastik, Hilfsmittel. Skill liefert Antrag auf Befreiung von Eigenbehalten und Pruefung der Beihilfefaehigkeit des Spezialmedikaments.

--- a/beamtenrecht/skills/beihilfe-heilbehandlung-ausland/SKILL.md
+++ b/beamtenrecht/skills/beihilfe-heilbehandlung-ausland/SKILL.md
@@ -46,6 +46,13 @@ Skill fuer Beihilfeberechtigte, die eine Behandlung im Ausland in Anspruch nehme
 - Antrag auf Beihilfe mit Rechnungen und aerztlicher Begruendung.
 - Pruefraster Beihilfefaehigkeit im Ausland.
 
-## 6. Beispiel (Kurzfassung)
+## 6. Verifizierte Quellenanker
+
+- Richtlinie 2011/24/EU vom 09.03.2011 (Patientenrechte in der grenzueberschreitenden Gesundheitsversorgung).
+- EuGH, 23.10.2003 - C-56/01 (Inizan); EuGH, 16.05.2006 - C-372/04 (Watts); EuGH, 19.04.2007 - C-444/05 (Stamatelaki).
+- BBhV; landesrechtliche Beihilfeverordnungen; Auslandsdienstkrankenversicherungsregelungen.
+- BVerwG zur Beihilfefaehigkeit von Auslandsbehandlungen — Datum und Az vor Zitat live verifizieren.
+
+## 7. Beispiel (Kurzfassung)
 
 Mandant laesst Hueftgelenkoperation in einer Wiener Klinik durchfuehren; Rechnung 18.500 Euro. Skill liefert Pruefung der Beihilfefaehigkeit nach Patientenrichtlinie und Begrenzung auf Inlandsniveau.

--- a/beamtenrecht/skills/beihilfe-implantatfaehige-hoergeraete/SKILL.md
+++ b/beamtenrecht/skills/beihilfe-implantatfaehige-hoergeraete/SKILL.md
@@ -48,6 +48,13 @@ Skill fuer Beihilfeberechtigte, denen die Beihilfestelle bei der Erstattung hoch
 - Widerspruchsschrift mit medizinischer Begruendung.
 - Antrag auf Erstattung in voller Hoehe.
 
-## 6. Beispiel (Kurzfassung)
+## 6. Verifizierte Quellenanker
+
+- BBhV insbesondere Anlage 6 (Hilfsmittel und Festbetraege); landesrechtliche Beihilfeverordnungen mit eigenen Hilfsmittelverzeichnissen.
+- Festbetragsregelung als Regelgrenze; medizinische Notwendigkeit als Massstab fuer beihilfefaehige Mehrkosten.
+- BVerwG zur Beihilfefaehigkeit hochwertiger Hilfsmittel und zur Pruefung medizinischer Notwendigkeit — Datum und Az vor Zitat live verifizieren.
+- Hilfsmittelrichtlinie des G-BA und einschlaegige HNO- und audiologische Leitlinien als Begruendungsgrundlage.
+
+## 7. Beispiel (Kurzfassung)
 
 Mandant beidseitige Schwerhoerigkeit; HNO empfiehlt Geraet mit Bluetooth und Spezialakustik fuer Berufstaetigkeit als Richter (Verhandlung in grossen Saelen). Kostenvoranschlag 5.800 Euro, Festbetrag 1.500 Euro. Skill liefert Widerspruch mit Begruendung der Mehrkosten als medizinisch notwendig.

--- a/beamtenrecht/skills/dienstunfaehigkeit-amtsaerztliches-gutachten/SKILL.md
+++ b/beamtenrecht/skills/dienstunfaehigkeit-amtsaerztliches-gutachten/SKILL.md
@@ -48,6 +48,14 @@ Skill fuer Beamte im Verfahren zur Feststellung der Dienstunfaehigkeit, insbeson
 - Widerspruch gegen Untersuchungsaufforderung.
 - Schriftsatz gegen Ruhestandsbescheid.
 
-## 6. Beispiel (Kurzfassung)
+## 6. Verifizierte Quellenanker
+
+- §§ 26, 44, 110 BBG; § 26 BeamtStG i.V.m. Landesrecht.
+- Art. 2 Abs. 1, Art. 1 Abs. 1 GG (Persoenlichkeitsrecht) als Schranke der Untersuchungsanordnung.
+- Anforderung an Bestimmtheit der Untersuchungsaufforderung: konkreter Anlass, Untersuchungsstelle, Umfang, Folgen unterlassener Mitwirkung.
+- BVerwG zur Bestimmtheit der Untersuchungsaufforderung und zum Vorrang des amtsaerztlichen Gutachtens — Datum und Az vor Zitat live verifizieren.
+- Akteneinsicht und Kenntnisnahme des Gutachtens nach § 110 BBG sowie landesrechtlichen Aequivalenten.
+
+## 7. Beispiel (Kurzfassung)
 
 Mandant erhaelt pauschale Aufforderung zur Untersuchung "wegen wiederholter Erkrankung". Skill liefert Widerspruch gegen Aufforderung wegen mangelnder Bestimmtheit und Pruefraster.

--- a/beamtenrecht/skills/dienstunfall-anerkennung-45-beamtvg/SKILL.md
+++ b/beamtenrecht/skills/dienstunfall-anerkennung-45-beamtvg/SKILL.md
@@ -48,6 +48,13 @@ Skill fuer Beamte mit Dienstunfaellen oder dem Verdacht, dass eine gesundheitlic
 - Schriftliche Dienstunfallmeldung.
 - Pruefraster fuer Spaetfolgenmeldungen.
 
-## 6. Beispiel (Kurzfassung)
+## 6. Verifizierte Quellenanker
+
+- § 31 BeamtVG (Dienstunfallbegriff); § 31 Abs. 2 BeamtVG (Wegeunfall); § 45 BeamtVG (Meldefristen zwei Jahre / zehn Jahre).
+- §§ 30 bis 47 BeamtVG (Unfallfuersorge insgesamt).
+- Massgeblich Lehre der rechtlich wesentlichen Mitursache; konstante Linie des BVerwG zur Kausalitaetspruefung.
+- BVerwG zum Dienstunfallbegriff und zur Kausalitaetsfrage — Datum und Az vor Zitat live verifizieren.
+
+## 7. Beispiel (Kurzfassung)
 
 Mandantin Lehrerin stuerzt im Klassenzimmer; zunaechst nur Hautabschuerfung, drei Jahre spaeter Bandscheibenschaden mit gutachterlich nachgewiesener Mitursache. Skill liefert Spaetfolgenmeldung innerhalb der Zehn-Jahres-Frist mit Kausalitaetsbegruendung.

--- a/beamtenrecht/skills/elternzeit-versorgungsanwartschaft/SKILL.md
+++ b/beamtenrecht/skills/elternzeit-versorgungsanwartschaft/SKILL.md
@@ -45,6 +45,13 @@ Skill fuer Beamte, die Elternzeit nehmen oder genommen haben und die Auswirkunge
 - Versorgungsausblick mit und ohne Beruecksichtigung der Elternzeit.
 - Beratungsschreiben Mandantin.
 
-## 6. Beispiel (Kurzfassung)
+## 6. Verifizierte Quellenanker
+
+- § 6 BeamtVG (ruhegehaltfaehige Dienstzeiten); § 50a, § 50b BeamtVG (Kindererziehungszuschlag und Kindererziehungsergaenzungszuschlag).
+- § 6 BEEG (Elternzeit ohne Bezuege); § 80 BBG, § 92 BBG; § 43 BeamtStG i.V.m. Landesrecht (Teilzeit waehrend Elternzeit).
+- BVerfG zur Beruecksichtigung von Kindererziehungszeiten in der Beamtenversorgung — Datum und Az vor Zitat in amtlicher Quelle live pruefen.
+- Versorgungsausgleichsgesetz bei Scheidung waehrend oder nach Elternzeit; § 12 VersAusglG (Beamtenversorgung als Anrecht).
+
+## 7. Beispiel (Kurzfassung)
 
 Mandantin Beamtin A12, drei Kinder, je drei Jahre Elternzeit. Skill liefert Berechnung der ruhegehaltfaehigen Zeiten und Hinweise auf Kindererziehungszuschlag.

--- a/beamtenrecht/skills/erholungsurlaub-verfall-eugh-c518-20/SKILL.md
+++ b/beamtenrecht/skills/erholungsurlaub-verfall-eugh-c518-20/SKILL.md
@@ -47,6 +47,16 @@ Skill fuer Beamte, denen Erholungsurlaub aus zurueckliegenden Urlaubsjahren nich
 - Antrag auf Urlaubsabgeltung.
 - Pruefraster Mitwirkungsobliegenheit und Uebertragungszeitraum.
 
-## 6. Beispiel (Kurzfassung)
+## 6. Verifizierte Quellenanker
+
+- Richtlinie 2003/88/EG vom 04.11.2003 (Arbeitszeitrichtlinie), Art. 7 Mindesturlaub vier Wochen.
+- EuGH, 20.01.2009 - C-350/06 und C-520/06 (Schultz-Hoff und Stringer): kein Verfall des unionsrechtlichen Mindesturlaubs bei langfristiger Krankheit.
+- EuGH, 22.11.2011 - C-214/10 (KHS / Schulte): 15-Monats-Frist nach Ende des Urlaubsjahres als zulaessige Uebertragungsgrenze.
+- EuGH, 06.11.2018 - C-684/16 (Max-Planck-Gesellschaft / Shimizu) und C-619/16 (Kreuziger): Mitwirkungsobliegenheit des Dienstherrn als Verfallsvoraussetzung.
+- EuGH, 22.09.2022 - C-518/20 und C-727/20 (XP und AR / Fraport und Stadt Wuppertal): Bestaetigung Mitwirkungsobliegenheit bei langfristiger Erkrankung.
+- Normen Beamtenrecht: § 89 BBG; § 208 SGB IX (Schwerbehindertenzusatzurlaub); Erholungsurlaubsverordnung und landesrechtliche Aequivalente.
+- BVerwG zur Uebertragung der EuGH-Linie in das Beamtenrecht — Datum und Az vor Zitat live verifizieren.
+
+## 7. Beispiel (Kurzfassung)
 
 Mandant 18 Monate krank, Eintritt in den Ruhestand wegen Dienstunfaehigkeit. Insgesamt 42 Tage Resturlaub. Skill liefert Argumentation, dass mindestens unionsrechtlicher Mindesturlaub fortbesteht und abzugelten ist.

--- a/beamtenrecht/skills/heilfuersorge-vs-beihilfe-vollzugsdienst/SKILL.md
+++ b/beamtenrecht/skills/heilfuersorge-vs-beihilfe-vollzugsdienst/SKILL.md
@@ -46,6 +46,13 @@ Skill fuer Beamte in der Heilfuersorge (Bundespolizei, Bundeswehr, Justizvollzug
 - Antrag auf Erstattung Sondermassnahme.
 - Beratungsschreiben zu Ueberleitung in Ruhestand.
 
-## 6. Beispiel (Kurzfassung)
+## 6. Verifizierte Quellenanker
+
+- Heilfuersorgevorschriften Bund (z. B. Bundespolizei, Bundeswehr, Justizvollzug des Bundes) und landesrechtliche Heilfuersorgeerlasse.
+- BBhV; landesrechtliche Beihilfeverordnungen fuer Uebergang in den Ruhestand.
+- § 70 BBG (Fuersorgepflicht); § 78 BBG; § 45 BeamtStG.
+- BVerwG zum Verhaeltnis Heilfuersorge und Beihilfe — Az vor Zitat live verifizieren.
+
+## 7. Beispiel (Kurzfassung)
 
 Polizeihauptkommissar tritt mit 62 in den Ruhestand. Skill liefert Hinweise auf rechtzeitigen Beihilfeantrag, Anwartschaftsversicherung der PKV und Erstattungsumfang fuer Brillen.

--- a/beamtenrecht/skills/krankheitsbedingte-urlaubsuebertragung/SKILL.md
+++ b/beamtenrecht/skills/krankheitsbedingte-urlaubsuebertragung/SKILL.md
@@ -46,6 +46,14 @@ Skill fuer Beamte mit langjaehriger Erkrankung und entstehenden Resturlaubsanspr
 - Berechnungstabelle Resturlaub.
 - Antrag auf Gewaehrung oder Abgeltung.
 
-## 6. Beispiel (Kurzfassung)
+## 6. Verifizierte Quellenanker
+
+- Richtlinie 2003/88/EG Art. 7; EuGH C-350/06 (Schultz-Hoff), C-214/10 (KHS), C-684/16 (Max-Planck), C-518/20 (Fraport / Stadt Wuppertal).
+- 15-Monats-Frist als zulaessige Uebertragungsobergrenze fuer den unionsrechtlichen Mindesturlaub.
+- § 89 BBG; § 208 SGB IX; Erholungsurlaubsverordnung und landesrechtliche Aequivalente.
+- Abgeltungspflicht bei Beendigung des Beamtenverhaeltnisses fuer den unionsrechtlich nicht verfallenen Mindesturlaub.
+- BVerwG zur Uebertragung der Schultz-Hoff-Linie ins Beamtenverhaeltnis — Az vor Zitat live verifizieren.
+
+## 7. Beispiel (Kurzfassung)
 
 Mandantin 28 Monate Krankheit, in 2022 zehn Tage Urlaub genommen. Skill liefert Berechnung des unionsrechtlichen Mindesturlaubs fuer 2022, 2023 und 2024 unter Beruecksichtigung des Verfalls 15 Monate nach Urlaubsjahr.

--- a/beamtenrecht/skills/nebentaetigkeit-99-bbg-anzeige-genehmigung/SKILL.md
+++ b/beamtenrecht/skills/nebentaetigkeit-99-bbg-anzeige-genehmigung/SKILL.md
@@ -50,6 +50,13 @@ Skill fuer Beamte, die eine Nebentaetigkeit aufnehmen wollen oder eine Versagung
 - Anzeige- oder Genehmigungsantrag.
 - Widerspruch gegen Versagung.
 
-## 6. Beispiel (Kurzfassung)
+## 6. Verifizierte Quellenanker
+
+- §§ 97 bis 105 BBG (Nebentaetigkeitsrecht Bund); § 40 BeamtStG i.V.m. Landesrecht.
+- Bundesnebentaetigkeitsverordnung (BNV); landesrechtliche Nebentaetigkeitsverordnungen.
+- Hoechstgrenze fuer Nebentaetigkeitsverguetungen mit Ablieferungspflicht an den Dienstherrn bei oeffentlicher Nebentaetigkeit.
+- BVerwG zur Genehmigung und Versagung von Nebentaetigkeiten — Datum und Az vor Zitat live verifizieren.
+
+## 7. Beispiel (Kurzfassung)
 
 Mandant Hochschuldozent (Beamter) plant Vortragstaetigkeit fuer einen Wirtschaftspruefer. Skill liefert Genehmigungsantrag, Pruefraster Interessenkonflikt und ggf. Begrenzung der Honorarablieferung.

--- a/beamtenrecht/skills/politische-maessigung-60-bbg/SKILL.md
+++ b/beamtenrecht/skills/politische-maessigung-60-bbg/SKILL.md
@@ -44,6 +44,14 @@ Skill fuer Beamte, denen die Verletzung der Maessigungspflicht vorgeworfen wird 
 - Verteidigungs-Memo.
 - Stellungnahme im Disziplinarverfahren.
 
-## 6. Beispiel (Kurzfassung)
+## 6. Verifizierte Quellenanker
+
+- § 60 BBG; § 33 BeamtStG (Pflicht zur Maessigung und Zurueckhaltung im politischen Bereich).
+- Art. 5 Abs. 1 GG (Meinungsfreiheit) und Art. 5 Abs. 3 GG (Wissenschaftsfreiheit) als Schranken-Schranke der Maessigungspflicht.
+- Art. 33 Abs. 5 GG (hergebrachte Grundsaetze des Berufsbeamtentums); Art. 21 GG (Parteienprivileg).
+- BVerfG zur Meinungsfreiheit der Beamten und zur Maessigungspflicht — Datum und Az vor Zitat live verifizieren.
+- Statusabhaengige Differenzierung in der Rechtsprechung: strengere Massstaebe fuer Polizei und Lehrkraefte, weitere Spielraeume fuer wissenschaftliches Personal.
+
+## 7. Beispiel (Kurzfassung)
 
 Mandant Studiendirektor postet politische Kommentare zu Migrationsfragen auf Twitter unter Realname und mit Hinweis auf Schulort. Skill liefert Pruefraster Statusbezug, Meinungsfreiheit und Verhaeltnismaessigkeit moeglicher Disziplinarmassnahmen.

--- a/beamtenrecht/skills/ptbs-polizei-anerkennung-dienstunfall/SKILL.md
+++ b/beamtenrecht/skills/ptbs-polizei-anerkennung-dienstunfall/SKILL.md
@@ -47,6 +47,14 @@ Skill fuer Polizei- und Justizvollzugsbeamte, Feuerwehrleute und Soldaten, die w
 - Dienstunfallmeldung mit psychiatrischem Gutachten.
 - Hilfsantrag auf Anerkennung als Berufskrankheit.
 
-## 6. Beispiel (Kurzfassung)
+## 6. Verifizierte Quellenanker
+
+- §§ 30, 31, 45 BeamtVG; § 31 Abs. 3 BeamtVG i.V.m. der Berufskrankheitenverordnung (BKV) fuer den Hilfsantrag Berufskrankheit.
+- ICD-10 F43.1 als Diagnosegrundlage; DSM-5 als ergaenzendes Diagnosesystem.
+- Anforderung an psychiatrisches Gutachten: Diagnose, Symptomverlauf, Verbindung zum auslosenden Ereignis, Differentialdiagnose.
+- BVerwG zur Anerkennung psychischer Erkrankungen als Dienstunfall und zur Abgrenzung Berufskrankheit — Datum und Az vor Zitat live verifizieren.
+- Bei Auslandsverwendung Soldaten und Bundespolizei Auslandsverwendungsgesetz und Einsatzversorgungsgesetz ergaenzend pruefen.
+
+## 7. Beispiel (Kurzfassung)
 
 Polizeihauptmeister entdeckt erhaengten Vermissten; entwickelt PTBS. Skill liefert Dienstunfallmeldung und Kausalitaetsdarstellung.

--- a/beamtenrecht/skills/reaktivierung-29-bbg-rechtsanspruch/SKILL.md
+++ b/beamtenrecht/skills/reaktivierung-29-bbg-rechtsanspruch/SKILL.md
@@ -48,6 +48,13 @@ Skill fuer ehemals wegen Dienstunfaehigkeit in den Ruhestand versetzte Beamte, d
 - Antrag auf Reaktivierung.
 - Widerspruchsschrift gegen Reaktivierungsanordnung.
 
-## 6. Beispiel (Kurzfassung)
+## 6. Verifizierte Quellenanker
+
+- § 29 BBG (Reaktivierung Bund); § 29 BeamtStG i.V.m. Landesrecht.
+- Voraussetzung amtsaerztlich attestierte Wiederherstellung der Dienstfaehigkeit; Zehn-Jahres-Frist nach Ruhestandsversetzung als Regelgrenze.
+- BVerwG zum Reaktivierungsanspruch und zu dienstlichen Belangen — Datum und Az vor Zitat live verifizieren.
+- Altersgrenze Regelaltersgrenze als absolute Schranke; nach Erreichen keine Reaktivierung mehr.
+
+## 7. Beispiel (Kurzfassung)
 
 Mandant wurde 2019 wegen depressiver Episode in den Ruhestand versetzt; nunmehr stabilisiert. Skill liefert Reaktivierungsantrag mit amtsaerztlichem Gutachten und Hinweis auf Anspruch.

--- a/beamtenrecht/skills/verfassungstreue-7-bbg-reichsbuerger/SKILL.md
+++ b/beamtenrecht/skills/verfassungstreue-7-bbg-reichsbuerger/SKILL.md
@@ -48,6 +48,15 @@ Skill fuer Beamte, denen mangelnde Verfassungstreue vorgeworfen wird, oder fuer 
 - Pruefraster Mitgliedschaft — Aeusserung — Handlung — Bewertung.
 - Verteidigungsbausteine im Disziplinarverfahren.
 
-## 6. Beispiel (Kurzfassung)
+## 6. Verifizierte Quellenanker
+
+- § 7 Abs. 1 Nr. 2 BBG; § 7 Abs. 1 Nr. 2 BeamtStG (Eignungsvoraussetzung Verfassungstreue).
+- § 33 Abs. 1 BeamtStG; § 60 Abs. 1 BBG (laufende Treuepflicht).
+- BVerfG, 22.05.1975 - 2 BvL 13/73 (sog. Radikalenbeschluss / Verfassungstreue-Beschluss).
+- BVerwG, 02.12.2021 - 2 A 7.21 (Reichsbuerger-/Verfassungstreue-Fall im Bundesdienst).
+- BVerwG, 10.10.2024 - 2 C 15.23 (Verfassungstreueanforderungen im juristischen Vorbereitungsdienst).
+- EGMR-Rechtsprechung zur Vereinbarkeit der Verfassungstreuepflicht mit Art. 10, 11 EMRK — Datum und Az vor Zitat live verifizieren.
+
+## 7. Beispiel (Kurzfassung)
 
 Mandant Polizeibeamter, in Chatgruppen mit Reichsbuergerinhalten beteiligt; eine Aeusserung "BRD ist eine GmbH". Skill liefert Pruefraster mit Indizienliste, Anhoerungsstrategie und Disziplinargewichtung.

--- a/beamtenrecht/skills/versetzung-gegen-willen-28-bbg/SKILL.md
+++ b/beamtenrecht/skills/versetzung-gegen-willen-28-bbg/SKILL.md
@@ -46,6 +46,14 @@ Skill fuer Beamte, denen eine Versetzung in eine andere Behoerde oder in ein and
 - Anhoerungsantwort.
 - Widerspruchsschrift.
 
-## 6. Beispiel (Kurzfassung)
+## 6. Verifizierte Quellenanker
+
+- § 28 BBG (Versetzung Bund); § 15 BeamtStG i.V.m. landesrechtlichen Versetzungsvorschriften.
+- §§ 130 ff. BBG (Umbildung von Koerperschaften); Sonderlagen mit Versetzung kraft Gesetzes.
+- Anhoerungspflicht des Beamten als Verfahrenserfordernis; § 28 VwVfG / Landesgesetze.
+- Verhaeltnismaessigkeitsgrundsatz: Pruefung milderer Mittel Umsetzung und Abordnung vor Versetzung.
+- BVerwG zur Versetzung gegen den Willen und zur Beruecksichtigung persoenlicher Verhaeltnisse — Datum und Az vor Zitat live verifizieren.
+
+## 7. Beispiel (Kurzfassung)
 
 Mandantin Behoerdenmitarbeiterin in Bonn, soll nach Berlin versetzt werden; pflegebedürftige Mutter und schulpflichtige Tochter. Skill liefert Anhoerungsantwort mit Geltendmachung persoenlicher Belange und Argumente fuer Umsetzung statt Versetzung.


### PR DESCRIPTION
Nachzieht-PR zu v61.1.0: Quellenanker für die 17 Skills, die bei Codex' Konsolidierung **ohne** Verifizierte-Quellenanker-Sektion blieben (weil sie ausserhalb der vier Recherche-Files lagen).

## 17 ergänzte Skills

### Urlaub und Elternzeit (4)
- `erholungsurlaub-verfall-eugh-c518-20`
- `krankheitsbedingte-urlaubsuebertragung`
- `elternzeit-versorgungsanwartschaft`
- `altersteilzeit-93-bbg-blockmodell`

### Beihilfe und Heilfuersorge (4)
- `beihilfe-heilbehandlung-ausland`
- `beihilfe-chronische-krankheit`
- `heilfuersorge-vs-beihilfe-vollzugsdienst`
- `beihilfe-implantatfaehige-hoergeraete`

### Dienstunfall und Krankheit (5)
- `dienstunfall-anerkennung-45-beamtvg`
- `ptbs-polizei-anerkennung-dienstunfall`
- `begrenzte-dienstfaehigkeit-27-bbg`
- `reaktivierung-29-bbg-rechtsanspruch`
- `dienstunfaehigkeit-amtsaerztliches-gutachten`

### Nebenpflichten und Statusrecht (4)
- `nebentaetigkeit-99-bbg-anzeige-genehmigung`
- `politische-maessigung-60-bbg`
- `verfassungstreue-7-bbg-reichsbuerger`
- `versetzung-gegen-willen-28-bbg`

## Was reinkam

**EuGH-Linie Urlaub** (verifiziert):
- C-350/06 (Schultz-Hoff), C-214/10 (KHS), C-684/16 (Max-Planck) und C-619/16 (Kreuziger), C-518/20 und C-727/20 (Fraport / Stadt Wuppertal)
- Richtlinie 2003/88/EG Art. 7

**EuGH-Linie Beihilfe-Ausland**:
- Richtlinie 2011/24/EU
- C-56/01 (Inizan), C-372/04 (Watts), C-444/05 (Stamatelaki)

**Verfassungstreue**:
- BVerfG 22.05.1975 - 2 BvL 13/73 (Radikalenbeschluss / Verfassungstreue-Beschluss)
- BVerwG 02.12.2021 - 2 A 7.21 (Reichsbuerger-Fall)
- BVerwG 10.10.2024 - 2 C 15.23 (juristischer Vorbereitungsdienst)
  — die letzten beiden uebernommen aus Codex' bestehender Anker-Bibliothek im Plugin.

**Normverweise**: BBG, BeamtStG, BBesG, BeamtVG, BBhV, BEEG, SGB IX, SGB V, SGB XI, BNV, BKV, Chroniker-RL G-BA, Patientenrichtlinie 2011/24/EU.

## Was bewusst NICHT erfunden

BVerwG-Az im Beamtenrecht (Dienstunfallbegriff, Reaktivierungsanspruch, Bestimmtheit der Untersuchungsaufforderung etc.) sind durchgaengig als **"Datum und Az vor Zitat live verifizieren"** markiert — entsprechend der Codex-Konvention im Plugin und CLAUDE.md ("Halluzinierte Az verboten").

## Ergebnis

Alle 50 von mir uebernommenen Spezial-Skills haben jetzt eine Sektion **6. Verifizierte Quellenanker**. Zusammen mit Codex' 33 angereicherten Skills jetzt **50 von 125** Plugin-Skills mit konkreten Ankern (war: 33).

Validator gruen (`node scripts/validate-plugin-structure.mjs`).

---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_