### PR TITLE
feat(roemisches-recht): 50 Skills Konkurs Seehandel Buergschaft Testament Buergerrecht

### DIFF
--- a/roemisches-recht/skills/rom-110-vollstreckungsrecht-personal-und-vermoegen/SKILL.md
+++ b/roemisches-recht/skills/rom-110-vollstreckungsrecht-personal-und-vermoegen/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: rom-110-vollstreckungsrecht-personal-und-vermoegen
+description: "Personalexekution und Vermoegensexekution im roemischen Recht. Skill behandelt die historische Entwicklung von der manus iniectio des Zwoelftafelgesetzes ueber das nexum zur praetorischen Vermoegensvollstreckung Trennung personale Haftung Schuldknechtschaft und Pfaendung Vermoegen. Liefert Quellenmatrix Digestenstellen und Pruefraster."
+---
+
+# Rom 110 Vollstreckungsrecht Personal Und Vermoegen
+
+## Aufgabe
+
+Skill fuer die roemisch-rechtliche Pruefung von Vollstreckungslagen und ihrer historischen Entwicklung.
+
+## Historische Entwicklung
+
+### Manus iniectio (XII Tafeln)
+- Aelteste Form der Personalvollstreckung.
+- XII Tafeln III: nach urteilsmaessiger Feststellung des Anspruchs durfte der Glaeubiger den Schuldner nach 30 Tagen Frist physisch ergreifen ("manum inicere").
+- Schuldner konnte ueber den Tiber verkauft werden (trans Tiberim) oder getoetet werden — letzteres in der Praxis selten.
+
+### Nexum (5. bis 3. Jh. v. Chr.)
+- Schuldknechtschaft als Sicherungsgeschaeft mit eigenem Akt (per aes et libram).
+- Lex Poetelia Papiria de nexis (326 v. Chr. oder 313 v. Chr.; Datum vor Zitat verifizieren) hob das nexum als Personalvollstreckung weitgehend auf — Wende zur Vermoegensvollstreckung.
+
+### Praetorische Vermoegensvollstreckung
+- Missio in bona: Einweisung des Glaeubigers in das Vermoegen.
+- Bonorum venditio: Versteigerung des Gesamtvermoegens.
+- Bonorum distractio: spaeter Einzelvermoegensverwertung.
+
+## Verhaeltnis zu modernen Begriffen
+
+- Heutige Personalvollstreckung beschraenkt auf Erzwingungs- und Beugehaft (§ 888 ZPO, § 901 ZPO).
+- Vermoegensvollstreckung ueber ZPO Buch 8.
+- Insolvenzverfahren als Universalexekution geht zurueck auf bonorum venditio.
+
+## Pruefraster
+
+1. Welches Stadium des roemischen Vollstreckungsrechts?
+2. Quellenstelle (Gaius, Institutiones, Digesten)?
+3. Welche praetorischen Aktionen sind einschlaegig?
+4. Heutige Fortwirkung?
+
+## Output
+
+- Quellenmatrix.
+- Vergleichende Synopse roemisch / heute.
+- Memo fuer rechtshistorische Hausarbeit.

--- a/roemisches-recht/skills/rom-111-cessio-bonorum-lex-iulia/SKILL.md
+++ b/roemisches-recht/skills/rom-111-cessio-bonorum-lex-iulia/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: rom-111-cessio-bonorum-lex-iulia
+description: "Cessio bonorum nach der Lex Iulia: freiwillige Vermoegensabtretung des Schuldners an die Glaeubiger als Vorlaeufer der Privatinsolvenz mit Restschuldbefreiungswirkung. Skill behandelt die Voraussetzungen die Privilegien des cedens und die Folgen fuer kuenftiges Vermoegen (beneficium competentiae). Liefert Quellenmatrix."
+---
+
+# Rom 111 Cessio Bonorum Lex Iulia
+
+## Aufgabe
+
+Skill fuer die cessio bonorum als Vorlaeufer der heutigen Privatinsolvenz.
+
+## Rechtsquelle
+
+- Lex Iulia de cessione bonorum (vermutlich 17 v. Chr. unter Augustus; Datum vor Zitat verifizieren).
+- D. 42.3 (Justinianische Digesten, Buch 42, Titel 3 — De cessione bonorum).
+- Gaius, Institutiones III.78 ff. (Hinweise).
+
+## Voraussetzungen
+
+- Schuldner ist in unverschuldete wirtschaftliche Notlage geraten ("non sua culpa").
+- Bietet sein gesamtes Vermoegen den Glaeubigern an.
+- Erklaerung vor dem Magistrat.
+
+## Rechtsfolgen
+
+- Glaeubiger erhalten Vermoegen zur Versteigerung.
+- Schuldner entgeht der entehrenden bonorum venditio mit infamia.
+- Beneficium competentiae: schuldner haftet kuenftig nur, soweit er ohne Beeintraechtigung seines Lebensunterhalts zahlen kann.
+- Schuldner behaelt persoenliche Freiheit (Schutz vor manus iniectio).
+
+## Fortwirkung
+
+- Vorbild fuer das moderne Restschuldbefreiungsverfahren (§ 286 ff. InsO).
+- Idee der Restschuldfreiheit nach Vermoegensabgabe.
+
+## Pruefraster
+
+1. Liegt unverschuldete Notlage vor?
+2. Wurde Vermoegen vollstaendig angeboten?
+3. Praetorische Anordnung erfolgt?
+4. Beneficium competentiae greift?
+
+## Output
+
+- Quellenmatrix.
+- Vergleichende Synopse zur heutigen Restschuldbefreiung.

--- a/roemisches-recht/skills/rom-112-missio-in-bona-praetorische-vermoegensergreifung/SKILL.md
+++ b/roemisches-recht/skills/rom-112-missio-in-bona-praetorische-vermoegensergreifung/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: rom-112-missio-in-bona-praetorische-vermoegensergreifung
+description: "Missio in bona: praetorische Einweisung des Glaeubigers in das Vermoegen des Schuldners. Skill behandelt die Voraussetzungen die Rolle des magister bonorum den Aufschub von 30 oder 60 Tagen sowie die Folge der bonorum venditio. Klaert das Verhaeltnis zur missio in possessionem rei servandae causa. Liefert Quellenmatrix."
+---
+
+# Rom 112 Missio In Bona Praetorische Vermoegensergreifung
+
+## Aufgabe
+
+Skill fuer die missio in bona als praetorisches Vollstreckungsinstrument.
+
+## Rechtsquelle
+
+- D. 42.4 (De rebus auctoritate iudicis possidendis seu vendundis).
+- D. 42.5 (De rebus auctoritate iudicis possidendis).
+- Praetorisches Edikt: edictum de bonis possidendis.
+
+## Tatbestand
+
+- Schuldner: indefensus (verweigert Verteidigung), latitans (versteckt sich), absent ohne Vertretung, oder Konkursverdacht.
+- Praetor erlaesst missio-Dekret.
+
+## Verfahren
+
+### Phase 1: Missio in bona possessionemque
+- Glaeubiger werden in den Besitz des Vermoegens eingewiesen.
+- Sie sind nicht Eigentuemer, sondern Sicherheitsverwahrer.
+
+### Phase 2: Edictum proscriptionis
+- Oeffentliche Bekanntmachung; weitere Glaeubiger angeordnet aufzutreten.
+- Wartefrist 30 Tage (bei lebenden Schuldnern), 15 Tage (bei verstorbenen).
+
+### Phase 3: Bonorum venditio
+- Versteigerung des Gesamtvermoegens als universitas.
+- Bonorum emptor erwirbt das Gesamtvermoegen.
+
+## Abgrenzung missio in possessionem rei servandae causa
+
+- Sicherungsmissio fuer einzelnes Vermoegensobjekt zur Vermeidung des Verlusts (z. B. einsturzgefaehrdete Haus, missio damni infecti).
+
+## Pruefraster
+
+1. Tatbestand der missio in bona erfuellt?
+2. Welche Glaeubigerstellung?
+3. Bonorum venditio bevorsteht oder vollzogen?
+4. Quellenmatrix in D. 42.4 / 42.5?
+
+## Output
+
+- Quellenmatrix.
+- Memo zur historischen Bedeutung.

--- a/roemisches-recht/skills/rom-113-bonorum-venditio-versteigerung-und-bonorum-emptor/SKILL.md
+++ b/roemisches-recht/skills/rom-113-bonorum-venditio-versteigerung-und-bonorum-emptor/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: rom-113-bonorum-venditio-versteigerung-und-bonorum-emptor
+description: "Bonorum venditio: Versteigerung des Schuldnervermoegens als universitas an einen einzelnen Erwerber (bonorum emptor). Skill klaert das Verfahren die Rolle des bonorum emptor als Gesamtrechtsnachfolger und die infamia-Wirkung fuer den Schuldner. Liefert Quellenmatrix."
+---
+
+# Rom 113 Bonorum Venditio Versteigerung Und Bonorum Emptor
+
+## Aufgabe
+
+Skill fuer die bonorum venditio.
+
+## Rechtsquelle
+
+- D. 42.4-42.5.
+- Gaius, Institutiones III.77 ff., IV.35 (actio Rutiliana).
+
+## Verfahren
+
+- Magister bonorum wird vom Glaeubigerkreis bestellt.
+- Magister erstellt Verkaufsvorschlaege (proscriptio).
+- Versteigerung an den Hoechstbietenden: bonorum emptor.
+- Erwerber muss Glaeubiger anteilig quotal befriedigen.
+
+## Rechtsstellung des bonorum emptor
+
+- Erwerb der universitas mit allen Aktiv- und Passivverbindlichkeiten.
+- Gesamtrechtsnachfolge im praetorischen Sinn (nicht zivilrechtlich, sondern bonitarisch).
+- Klagebefugnisse nach actio Rutiliana, actio Serviana, actio utiles.
+
+## Infamia-Folge
+
+- Schuldner wird infamis (ehrlos).
+- Ausschluss von politischen Aemtern, Senatorenamt, Zeugenstellung in gewissen Verfahren.
+- Vermeidung der infamia durch cessio bonorum nach Lex Iulia.
+
+## Vergleich zur modernen Konkurseroeffnung
+
+- Konkurseroeffnung als Universalexekution: Insolvenzverwalter erhaelt Verwaltungs- und Verfuegungsbefugnis (§ 80 InsO).
+- Heute keine infamia, aber gewerberechtliche Folgen (Geschaeftsfuehrer-Verbote).
+
+## Pruefraster
+
+1. Magister bonorum bestellt?
+2. Versteigerungsverfahren ordnungsgemaess?
+3. Bonorum emptor identifiziert?
+4. Anteilige Befriedigung?
+5. Infamia-Folge eingetreten?
+
+## Output
+
+- Quellenmatrix.
+- Vergleichende Synopse.

--- a/roemisches-recht/skills/rom-114-bonorum-distractio-vermoegenseinzelverkauf/SKILL.md
+++ b/roemisches-recht/skills/rom-114-bonorum-distractio-vermoegenseinzelverkauf/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: rom-114-bonorum-distractio-vermoegenseinzelverkauf
+description: "Bonorum distractio: spaeter eingefuehrter Einzelverkauf der Vermoegensgegenstaende anstelle der Gesamtversteigerung. Skill behandelt die Voraussetzungen das Schonungsprivileg fuer Senatoren und die Entwicklung zum modernen Einzelvollstreckungsmodus. Liefert Quellenmatrix."
+---
+
+# Rom 114 Bonorum Distractio Vermoegenseinzelverkauf
+
+## Aufgabe
+
+Skill fuer die bonorum distractio.
+
+## Rechtsquelle
+
+- Senatusconsultum (Daten und Inhalte vor Zitat verifizieren).
+- D. 42.7 (De curatore bonis dando).
+
+## Tatbestand
+
+- Bonorum distractio als alternative zur bonorum venditio.
+- Eingefuehrt mit der Begruendung der Schonung des sozialen Standes des Schuldners.
+
+## Verfahren
+
+- Bestellung eines curator bonorum.
+- Einzelverkauf der Vermoegensgegenstaende.
+- Schuldner bleibt Eigentuemer der nicht verkauften Gegenstaende.
+- Keine bonorum emptor-Konstruktion; kein Gesamtrechtsnachfolge-Geschehen.
+- Keine infamia (jedenfalls in der senatorischen Variante).
+
+## Privilegierte Personenkreise
+
+- Senatoren und ehrenwerte Personen.
+- Erblasser eines verstorbenen Schuldners (zum Schutz der Erben).
+
+## Heutige Fortwirkung
+
+- Vorbild der Einzelvollstreckung in das Vermoegen statt Universalexekution.
+- Heute ZPO Buch 8.
+
+## Pruefraster
+
+1. Senatorischer Status oder Erbenschutz?
+2. Curator bonorum bestellt?
+3. Einzelverkauf moeglich?
+4. Restvermoegen beim Schuldner?
+
+## Output
+
+- Quellenmatrix.
+- Memo zur Sozialfunktion.

--- a/roemisches-recht/skills/rom-115-actio-pauliana-glaeubigeranfechtung/SKILL.md
+++ b/roemisches-recht/skills/rom-115-actio-pauliana-glaeubigeranfechtung/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: rom-115-actio-pauliana-glaeubigeranfechtung
+description: "Actio Pauliana: praetorische Gläubigeranfechtungsklage zur Rueckgaengigmachung gläubigerbenachteiligender Vermögensverschiebungen des Schuldners. Skill behandelt die Tatbestaende (consilium fraudis eventus damni scientia des Dritten) den Klagegegenstand und die Restitution. Vorlaeufer von § 138 BGB und §§ 129 ff. InsO sowie AnfG. Liefert Quellenmatrix und Pruefraster."
+---
+
+# Rom 115 Actio Pauliana Glaeubigeranfechtung
+
+## Aufgabe
+
+Skill fuer die actio Pauliana als historisches Pendant zur modernen Insolvenzanfechtung.
+
+## Rechtsquelle
+
+- D. 42.8 (Quae in fraudem creditorum facta sunt ut restituantur).
+- Praetorisches Edikt: edictum de fraudibus.
+- Zentrale Stellen: D. 42.8.1 (Ulpian), D. 42.8.10 (Ulpian), D. 42.8.25 (Paulus).
+
+## Tatbestand
+
+### Eventus damni
+- Vermoegensminderung des Schuldners durch das angefochtene Geschaeft.
+- Schuldner ist insolvent oder wird durch das Geschaeft insolvent.
+
+### Consilium fraudis (subjektiv Schuldnerseite)
+- Schuldner handelte in Glaeubigerschaedigungsabsicht oder zumindest mit positivem Wissen um seine Insolvenz und der Konsequenz fuer die Glaeubiger.
+- Bewusstsein der Schaedigung genuegt; Absicht nicht erforderlich (Ulpian D. 42.8.1).
+
+### Scientia oder conscientia fraudis (Drittseite)
+- Bei entgeltlichen Geschaeften muss der Dritte das consilium fraudis des Schuldners kennen oder bei Sorgfalt erkennen koennen.
+- Bei unentgeltlichen Geschaeften (Schenkung) entfaellt das Erfordernis — der unentgeltliche Erwerber wird ohne Wissen erfasst.
+
+## Klagebefugte
+
+- Magister bonorum (im Konkursverfahren).
+- Curator bonorum.
+- Einzelne Glaeubiger nach Konkurseroeffnung.
+
+## Frist
+
+- Annus utilis ab scientia bonorum venditionis.
+
+## Rechtsfolge
+
+- Restitution: der Dritte muss das Erlangte zurueckgeben.
+- Bei Untergang ggf. Wertersatz.
+- Bei Mehrfachverfuegungen Verfolgung der Kette moeglich.
+
+## Vergleich zum modernen Recht
+
+### AnfG (Anfechtungsgesetz)
+- § 3 Vorsatzanfechtung.
+- § 4 unentgeltliche Leistung.
+- §§ 6, 7 Anfechtbarkeit nahestehender Personen.
+
+### InsO (Insolvenzordnung)
+- § 129 InsO Anfechtbarkeit von Rechtshandlungen.
+- § 131 InsO inkongruente Deckung.
+- § 132 InsO unmittelbare Glaeubigerbenachteiligung.
+- § 133 InsO Vorsatzanfechtung (10-Jahres-Frist).
+- § 134 InsO unentgeltliche Leistung (4-Jahres-Frist).
+
+### BGB
+- § 138 Abs. 1 BGB Sittenwidrigkeit (bei besonders krasser Glaeubigerschaedigung).
+
+## Pruefraster
+
+1. Eventus damni vorhanden?
+2. Consilium fraudis nachweisbar?
+3. Scientia des Dritten (oder unentgeltliches Geschaeft)?
+4. Klageberechtigung?
+5. Annus utilis nicht abgelaufen?
+6. Quellenmatrix D. 42.8 erstellen.
+
+## Output
+
+- Quellenmatrix mit Digestenstellen.
+- Vergleichende Synopse zu AnfG und §§ 129 ff. InsO.
+- Memo fuer rechtshistorische und insolvenzrechtliche Fragen.
+- Pruefraster fuer Hausarbeit oder Schriftsatz.

--- a/roemisches-recht/skills/rom-116-actio-pauliana-voraussetzungen-und-beweisrecht/SKILL.md
+++ b/roemisches-recht/skills/rom-116-actio-pauliana-voraussetzungen-und-beweisrecht/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: rom-116-actio-pauliana-voraussetzungen-und-beweisrecht
+description: "Actio Pauliana — Voraussetzungen und Beweisrecht im Detail. Skill vertieft die Beweislastfragen bei consilium fraudis Wissensanrechnung und Indizienlehre Pflichten des Glaeubigers und Mitwirkung des Dritten. Behandelt die Sondervorschriften fuer Vermoegensverschleierung waehrend laufender Vollstreckung. Liefert Pruefraster."
+---
+
+# Rom 116 Actio Pauliana Voraussetzungen Und Beweisrecht
+
+## Aufgabe
+
+Skill fuer die Beweislastfragen bei der actio Pauliana.
+
+## Beweislast
+
+- Glaeubiger traegt die Beweislast fuer:
+  - eventus damni
+  - consilium fraudis des Schuldners
+  - scientia oder conscientia des Dritten (bei entgeltlich)
+
+## Indizienbeweis
+
+- Verkauf zu marktnotorisch zu niedrigem Preis: Indiz fuer scientia.
+- Verkauf unter Freunden in zeitlicher Naehe zur Insolvenz.
+- Verschwiegene Geschaefte ueber Mittelsmaenner.
+
+## Vermutungen
+
+- Bei Verfuegungen an Familienangehoerige greifen verstaerkte Indizien (vergleichbar modernen AnfG-Vorschriften zu nahestehenden Personen).
+- D. 42.8.10.16 (Ulpian) zum Anscheinsbeweis bei Schenkung an Verwandte.
+
+## Sondervorschriften
+
+- Verschleierung waehrend laufender Vollstreckung: erleichterte Beweisfuehrung.
+- Geschaeftspartner als Reflexbeteiligter.
+
+## Vergleich zu modernem Recht
+
+- §§ 133, 138 Abs. 2 BGB iVm §§ 286 ZPO Beweislast.
+- AnfG § 3 Abs. 2: Vermutung der scientia bei nahestehenden Personen.
+- InsO § 133 Abs. 1 Satz 2: Vermutung der Kenntnis bei drohender Zahlungsunfaehigkeit.
+
+## Pruefraster
+
+1. Welche Tatbestaende muessen bewiesen werden?
+2. Welche Indizien stehen zur Verfuegung?
+3. Greifen Vermutungen?
+4. Welcher Quellenanker (D. 42.8)?
+
+## Output
+
+- Beweisstrategie-Memo.
+- Indizienmatrix.
+- Vergleichende Synopse.

--- a/roemisches-recht/skills/rom-117-interdictum-fraudatorium-und-restitutio-in-integrum/SKILL.md
+++ b/roemisches-recht/skills/rom-117-interdictum-fraudatorium-und-restitutio-in-integrum/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: rom-117-interdictum-fraudatorium-und-restitutio-in-integrum
+description: "Interdictum fraudatorium und restitutio in integrum: weitere praetorische Schutzinstrumente gegen Glaeubigerschaedigung. Skill behandelt die Voraussetzungen den Eilcharakter des interdictum und die Verzahnung mit der actio Pauliana. Liefert Quellenmatrix."
+---
+
+# Rom 117 Interdictum Fraudatorium Und Restitutio In Integrum
+
+## Aufgabe
+
+Skill fuer interdictum fraudatorium und restitutio in integrum.
+
+## Interdictum fraudatorium
+
+- Praetorisches Eilinstrument zur Sicherung des Status quo.
+- Inhalt: der Praetor verbietet dem Empfaenger des fraudulenten Vermoegens die weitere Verfuegung.
+- D. 42.8 ergaenzt um diese Verfahrensseite.
+
+## Restitutio in integrum
+
+- "Wiedereinsetzung in den vorigen Stand".
+- Praetorisches Gesamtinstitut, das den Schuldigen oder Geschaedigten in seinen vorherigen Vermoegenszustand zurueckversetzt.
+- Faelle: minderjaehriger Vertragspartner (ob aetatem), arglistige Taeuschung (ob dolum), Furcht (ob metum), Glaeubigerbenachteiligung (ob fraudem).
+- D. 4.6 (De in integrum restitutionibus).
+
+## Verzahnung
+
+- Restitutio in integrum ob fraudem ist die uebergeordnete Lehre.
+- Actio Pauliana ist die spezifische Aktion fuer Glaeubigeranfechtung.
+- Interdictum fraudatorium sichert den Anspruch waehrend der Verfahrensdauer.
+
+## Vergleich zu modernem Recht
+
+- Einstweilige Verfuegung nach §§ 935 ff. ZPO als Sicherungsinstrument.
+- Anfechtungsklage nach AnfG als Hauptverfahren.
+- Restitutio-Wirkung in § 143 InsO (Rueckgewaehrungsanspruch nach Insolvenzanfechtung).
+
+## Pruefraster
+
+1. Welches Instrument einschlaegig?
+2. Schutzbedarf wegen Vermoegensentzug?
+3. Beweislage hinreichend?
+
+## Output
+
+- Quellenmatrix.
+- Vergleichende Synopse.

--- a/roemisches-recht/skills/rom-118-paulianische-anfechtung-fortwirkung-anfg-inso/SKILL.md
+++ b/roemisches-recht/skills/rom-118-paulianische-anfechtung-fortwirkung-anfg-inso/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: rom-118-paulianische-anfechtung-fortwirkung-anfg-inso
+description: "Fortwirkung der paulianischen Anfechtung in AnfG und InsO. Skill behandelt die dogmengeschichtliche Linie von der actio Pauliana ueber das BGB-AnfG (1879/1994) bis zu den §§ 129 ff. InsO. Klaert die Strukturparallelen und Abweichungen bei Vorsatzanfechtung Inkongruenz und unentgeltlichen Leistungen. Liefert Synopse und Pruefraster."
+---
+
+# Rom 118 Paulianische Anfechtung Fortwirkung Anfg Inso
+
+## Aufgabe
+
+Skill fuer die rechtshistorische und dogmengeschichtliche Vergleichung.
+
+## Strukturparallelen
+
+| actio Pauliana | AnfG | InsO |
+|---|---|---|
+| consilium fraudis | Vorsatz Schuldner § 3 | Vorsatz § 133 |
+| scientia des Dritten | Kenntnis Dritter § 3 | Kenntnis § 133 |
+| unentgeltliches Geschaeft (keine scientia noetig) | § 4 | § 134 |
+| nahestehende Personen Vermutung | § 6 | § 138 |
+| annus utilis | 4-10 Jahre Frist | 4-10 Jahre Frist |
+| Restitution durch bonorum emptor | Rueckgewaehr § 11 AnfG | Rueckgewaehr § 143 InsO |
+
+## Abweichungen
+
+### Vorsatz vs. consilium
+- Roemisches Recht: Bewusstsein der Schaedigung.
+- Modernes Recht: Glaeubigerbenachteiligungsvorsatz.
+
+### Frist
+- annus utilis: ein "nutzbares" Jahr ab Kenntnis.
+- AnfG / InsO: bis 10 Jahre (Vorsatzanfechtung).
+
+### Inkongruenz
+- Roemisches Recht: nicht ausdifferenziert.
+- InsO § 131: eigene Kategorie.
+
+## Rezeption
+
+- Glossatoren des 12./13. Jh. (Bologna) bearbeiteten D. 42.8 systematisch.
+- Pandektisten (Savigny, Windscheid) entwickelten die actio Pauliana zur "allgemeinen Glaeubigeranfechtungsklage".
+- BGB-Gesetzgeber 1900 verzichtete auf Aufnahme ins BGB, weil AnfG (1879) bereits geregelt.
+- AnfG 1879 als selbstaendiges Gesetz; Reformen 1899, 1994 (im Zuge der Insolvenzrechtsreform).
+
+## Pruefraster
+
+1. Welcher Tatbestand?
+2. Welche Frist?
+3. Beweislage?
+4. Rechtsfolge Restitution?
+5. Quellenmatrix.
+
+## Output
+
+- Synopse-Tabelle.
+- Memo zur Rezeptionsgeschichte.
+- Schriftsatzbaustein.

--- a/roemisches-recht/skills/rom-119-konkursrechtliche-stellung-des-magister-bonorum/SKILL.md
+++ b/roemisches-recht/skills/rom-119-konkursrechtliche-stellung-des-magister-bonorum/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: rom-119-konkursrechtliche-stellung-des-magister-bonorum
+description: "Konkursrechtliche Stellung des magister bonorum und des curator bonorum. Skill behandelt die Bestellung Aufgaben Vertretungsbefugnisse Klagebefugnisse und das Verhaeltnis zum modernen Insolvenzverwalter. Liefert Quellenmatrix."
+---
+
+# Rom 119 Konkursrechtliche Stellung Des Magister Bonorum
+
+## Aufgabe
+
+Skill fuer die Stellung des magister bonorum und curator bonorum als historische Insolvenzverwalter.
+
+## Magister bonorum
+
+- Bestellt von den Glaeubigern.
+- Hauptaufgabe: Vorbereitung und Durchfuehrung der bonorum venditio.
+- Klagebefugnis: actio Rutiliana, actio Serviana, actio utiles, actio Pauliana.
+- D. 42.5; Gaius IV.35.
+
+## Curator bonorum
+
+- Bestellt vom Praetor.
+- Hauptaufgabe: Verwaltung des Vermoegens bei bonorum distractio.
+- Verwaltungsbefugnisse weitergehend als der magister, weil Einzelverkauf laenger dauert.
+- D. 42.7.
+
+## Vergleich zum modernen Insolvenzverwalter
+
+- §§ 56 ff. InsO Bestellung durch Insolvenzgericht.
+- Verwaltungs- und Verfuegungsbefugnis § 80 InsO.
+- Klagebefugnis fuer Insolvenzanfechtung § 129 ff. InsO.
+- Strukturparallel zum curator bonorum.
+
+## Vertretungsbefugnis
+
+- Pro creditoribus bei magister.
+- Pro debitore et creditoribus bei curator (treuhaenderisch).
+
+## Pruefraster
+
+1. Welche Person und Funktion?
+2. Welche Befugnisse?
+3. Welche Aktionen stehen zur Verfuegung?
+4. Quellenmatrix.
+
+## Output
+
+- Quellenmatrix.
+- Vergleichende Synopse.

--- a/roemisches-recht/skills/rom-120-konkurs-und-glaeubigerquoten-rangfolge/SKILL.md
+++ b/roemisches-recht/skills/rom-120-konkurs-und-glaeubigerquoten-rangfolge/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: rom-120-konkurs-und-glaeubigerquoten-rangfolge
+description: "Konkurs und Glaeubigerquoten im roemischen Recht. Skill behandelt die Rangfolge der Glaeubiger Pfandglaeubiger (creditores pignoraticii) bevorrechtigte Glaeubiger (privilegium personae) und die quotale Befriedigung. Vergleicht mit moderner InsO-Rangordnung. Liefert Pruefraster."
+---
+
+# Rom 120 Konkurs Und Glaeubigerquoten Rangfolge
+
+## Aufgabe
+
+Skill fuer die roemisch-rechtliche Glaeubigerrangordnung.
+
+## Pfandglaeubiger
+
+- Hypothecarii / pignoraticii creditores hatten Vorrang bei Sachen mit dinglicher Sicherung.
+- Hypothek / Pfand musste vor allgemeiner Glaeubigerverteilung bedient werden.
+- D. 20.1 ff. Hypothecarius creditor.
+
+## Bevorrechtigte Glaeubiger (privilegium personae)
+
+- Krasse Beispiele:
+  - Beerdigungskosten ("funeris causa").
+  - Ehevermoegen der Witwe (dos).
+  - Pflegevormundschaft fuer Muendelvermoegen.
+  - Steuerforderungen des Fiscus.
+
+## Quotale Verteilung
+
+- Allgemeine Glaeubiger erhielten nach Sicherung und Vorrechten den Rest quotal.
+- Magister bonorum berechnete die Quote.
+- Bonorum emptor war verpflichtet, anteilig zu zahlen — typische Quote 50-90 Prozent, abhaengig vom Erloes.
+
+## Vergleich zu InsO
+
+| roemisch | InsO |
+|---|---|
+| hypothecarii | Absonderung § 50 InsO |
+| privilegium personae | Massevorrang § 53 InsO |
+| Funeralia | Beerdigungskosten als Massekosten |
+| Steuerforderungen Fiscus | Insolvenzforderungen mit besonderem Vorrang? Nicht mehr (KO-Reform 1994) |
+| dos | Ehegueterrecht heute zivilrechtlich |
+| quotal | Insolvenzforderungen quotale Verteilung § 187 InsO |
+
+## Pruefraster
+
+1. Welche Glaeubigerstellung?
+2. Sicherungsrecht vorhanden?
+3. Privilegium personae anwendbar?
+4. Quote zu berechnen?
+
+## Output
+
+- Quellenmatrix.
+- Vergleichende Synopse.

--- a/roemisches-recht/skills/rom-121-restitutio-in-integrum-ob-aetatem-vermoegensschutz/SKILL.md
+++ b/roemisches-recht/skills/rom-121-restitutio-in-integrum-ob-aetatem-vermoegensschutz/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: rom-121-restitutio-in-integrum-ob-aetatem-vermoegensschutz
+description: "Restitutio in integrum ob aetatem: Schutz Minderjaehriger im roemischen Recht vor wirtschaftlichen Nachteilen aus eigenen Vertraegen. Skill behandelt die Voraussetzungen die Folgen die Lex Plaetoria de circumscriptione adolescentium und die Fortwirkung im modernen Minderjaehrigenschutz. Liefert Quellenmatrix."
+---
+
+# Rom 121 Restitutio In Integrum Ob Aetatem Vermoegensschutz
+
+## Aufgabe
+
+Skill fuer Minderjaehrigenschutz im roemischen Recht.
+
+## Rechtsquelle
+
+- Lex Plaetoria de circumscriptione adolescentium (Daten und Inhalt vor Zitat verifizieren).
+- Praetorische restitutio in integrum ob aetatem.
+- D. 4.4 (De minoribus viginti quinque annis).
+
+## Tatbestand
+
+- Adolescens (junger Mann unter 25 Jahre).
+- Vermoegensnachteil durch eigenes Geschaeft.
+- Geschaeft an sich wirksam, aber praetorische Restitution moeglich.
+
+## Voraussetzungen
+
+- Antrag innerhalb einer Frist (annus utilis nach Volljaehrigkeit).
+- Nachweis des Vermoegensnachteils.
+
+## Rechtsfolge
+
+- Aufhebung der wirtschaftlichen Nachteile.
+- Rueckgaengigmachung des Geschaefts.
+
+## Verhaeltnis zur cura minorum
+
+- Mit 25 Jahren konnte ein cura minorum bestellt werden, um vorbeugend zu schuetzen (Lex Iulia et Titia).
+
+## Fortwirkung
+
+- Heute §§ 104 ff. BGB Geschaeftsfaehigkeit.
+- § 108 ff. BGB: schwebende Unwirksamkeit Minderjaehrigenvertraege.
+- § 1644 BGB Gerichtliche Genehmigung.
+
+## Pruefraster
+
+1. Adolescens-Status?
+2. Vermoegensnachteil?
+3. Frist gewahrt?
+4. Restitution moeglich?
+
+## Output
+
+- Quellenmatrix.
+- Vergleichende Synopse.

--- a/roemisches-recht/skills/rom-122-seehandel-lex-rhodia-de-iactu/SKILL.md
+++ b/roemisches-recht/skills/rom-122-seehandel-lex-rhodia-de-iactu/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: rom-122-seehandel-lex-rhodia-de-iactu
+description: "Lex Rhodia de iactu: Generalhavarie im roemischen Seehandelsrecht. Skill behandelt die Voraussetzungen und Rechtsfolgen der Pflicht zur anteiligen Schadenstragung bei Werfen von Gut in Seenot. Vorlaeufer der modernen Grossen Havarie (York-Antwerp Rules HGB §§ 588 ff.). Liefert Quellenmatrix und Pruefraster."
+---
+
+# Rom 122 Seehandel Lex Rhodia De Iactu
+
+## Aufgabe
+
+Skill fuer die lex Rhodia de iactu als historisches Pendant der modernen Grossen Havarie.
+
+## Rechtsquelle
+
+- D. 14.2 (Justinianische Digesten, Buch 14, Titel 2 — De lege Rhodia de iactu).
+- Insbesondere D. 14.2.1 (Paulus), D. 14.2.2 (Iulianus), D. 14.2.4 (Callistratus).
+- Stammt aus der griechisch-hellenistischen Praxis der Insel Rhodos.
+
+## Tatbestand
+
+- Seenot.
+- Werfen (iactus) eines Teils der Ladung ueber Bord zur Rettung des Restes (Schiff plus restliche Ladung).
+- Entscheidung des magister navis (Schiffskapitaen) ist verbindlich.
+
+## Rechtsfolge
+
+- Geschaedigter Befrachter erhaelt anteiligen Ausgleich von allen geretteten Beteiligten:
+  - Reeder (fuer das Schiff).
+  - Andere Befrachter (fuer ihre geretteten Sachen).
+- Quote bemisst sich nach Wert der geretteten Sachen.
+
+## Verfahrensgang
+
+- Aktiv: actio locati gegen Reeder; Reeder erhebt actio conducti gegen die uebrigen Befrachter.
+- Beweisfuehrung: Schiffslogbuch (Tabula), Zeugen, Schiffspriester.
+
+## Vergleich zu modernem Recht
+
+### Grosse Havarie HGB
+- §§ 588-617 HGB (Stand vor Seehandelsreform 2013): geregelt im 7. Abschnitt Grosse Havarie.
+- Nach Reform 2013 ueber Verweisungstechnik auf York-Antwerp Rules.
+
+### York-Antwerp Rules
+- Internationale Privatcodifizierung der Havarie-Grosse-Regeln.
+- York Antwerp Rules 1994, ueberarbeitet 2004, 2016.
+- Lloyd's Open Form.
+
+## Pruefraster
+
+1. Seenot und iactus-Tatbestand?
+2. Entscheidung des magister navis?
+3. Wertberechnung der geretteten Sachen?
+4. Quote pro rata?
+5. Beweismittel?
+
+## Output
+
+- Quellenmatrix mit D. 14.2.
+- Vergleichende Synopse zu York-Antwerp Rules und HGB.
+- Memo fuer rechtshistorische Hausarbeit.

--- a/roemisches-recht/skills/rom-123-fenus-nauticum-seedarlehen/SKILL.md
+++ b/roemisches-recht/skills/rom-123-fenus-nauticum-seedarlehen/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: rom-123-fenus-nauticum-seedarlehen
+description: "Fenus nauticum: Seedarlehen als roemisches Vorlaeufer der Seeversicherung. Skill behandelt die Sondervorschriften zur Risikotragung das Darlehensverhaeltnis mit aussergewoehnlich hoher Zinsenobergrenze und die Beendigung bei Schiffsuntergang. Liefert Quellenmatrix."
+---
+
+# Rom 123 Fenus Nauticum Seedarlehen
+
+## Aufgabe
+
+Skill fuer das fenus nauticum als Risikofinanzierungsinstrument der Antike.
+
+## Rechtsquelle
+
+- D. 22.2 (De nautico fenore).
+- D. 45.1.122.1 zu Bezahlung.
+- Cicero, Pro Murena, mit Andeutungen zur Praxis.
+
+## Tatbestand
+
+- Darlehen (mutuum) zum Seetransport von Gut.
+- Sondervorschrift: Risiko liegt beim Darlehensgeber.
+- Bei Schiffsuntergang erlischt die Darlehensschuld.
+- Bei sicherer Ankunft schuldet der Darlehensnehmer Hauptbetrag plus Zinsen.
+
+## Zinsen
+
+- Allgemeine Zinsobergrenze 12 Prozent pro Jahr (centesima usura) gilt bei fenus nauticum nicht.
+- Sonderhoehe wegen Risikotragung — historisch 30 Prozent fuer eine einfache Mittelmeerfahrt belegt.
+- Sondervorschrift D. 22.2.
+
+## Beendigung
+
+- Bei Schiffsuntergang (perit res): Darlehen erlischt.
+- Bei sicherer Ankunft: Hauptbetrag plus Zinsen geschuldet.
+
+## Fortwirkung
+
+- Versicherung war damit funktional als Element des Darlehens vorhanden.
+- Spaeteres Vorbild fuer die mittelalterlichen "Bottomry Bonds".
+- Heute strikte Trennung von Darlehen und Versicherung.
+
+## Pruefraster
+
+1. Darlehensvertrag?
+2. Risiko auf Darlehensgeber?
+3. Zinsenrahmen?
+4. Untergang oder Ankunft?
+
+## Output
+
+- Quellenmatrix.
+- Vergleichende Synopse.

--- a/roemisches-recht/skills/rom-124-actio-exercitoria-reederhaftung/SKILL.md
+++ b/roemisches-recht/skills/rom-124-actio-exercitoria-reederhaftung/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: rom-124-actio-exercitoria-reederhaftung
+description: "Actio exercitoria: Klage gegen den Reeder (exercitor navis) fuer Verbindlichkeiten aus Handlungen seines magister navis. Skill behandelt die Voraussetzungen die Vollhaftung des Reeders und den Vergleich zum modernen Schifffahrtsrecht. Liefert Quellenmatrix."
+---
+
+# Rom 124 Actio Exercitoria Reederhaftung
+
+## Aufgabe
+
+Skill fuer die actio exercitoria.
+
+## Rechtsquelle
+
+- D. 14.1 (De exercitoria actione).
+- Insbesondere D. 14.1.1 (Ulpian).
+- Praetorisches Edikt.
+
+## Tatbestand
+
+- Exercitor navis: Reeder, der das Schiff fuer eigene Rechnung betreibt.
+- Magister navis: Schiffskapitaen, der im Namen des Reeders Vertraege schliesst.
+- Vertraege des magister navis verpflichten den Reeder unmittelbar gegenueber Dritten.
+
+## Rechtsfolge
+
+- Vollhaftung des Reeders fuer Vertraege des magister navis.
+- Voller Haftungsumfang (in solidum), nicht beschraenkt auf Sondervermoegen.
+
+## Bedeutung
+
+- Erste Form einer "indirekten Vertretung" im Geschaeftsverkehr.
+- Praetorisches Edikt schliesst die Luecke des traditionellen Aktions-Systems, das nur unmittelbare Vertragsparteien zulaesst.
+
+## Vergleich zu modernem Recht
+
+- § 53 HGB Prokurist.
+- Schiffshaftung nach Seerechtlichem Verteilungsgesetz (SeeRVG) mit Haftungsbeschraenkung.
+- Heute Vertretung durch Schiffskapitaen typischerweise im Rahmen der allgemeinen Vertretungsvorschriften.
+
+## Pruefraster
+
+1. Reeder im roemisch-rechtlichen Sinn?
+2. Magister navis bestellt?
+3. Geschaeft im Rahmen der Schiffsaufgabe?
+4. Schaden?
+
+## Output
+
+- Quellenmatrix.
+- Vergleichende Synopse.

--- a/roemisches-recht/skills/rom-125-actio-institoria-prokuristenhaftung/SKILL.md
+++ b/roemisches-recht/skills/rom-125-actio-institoria-prokuristenhaftung/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: rom-125-actio-institoria-prokuristenhaftung
+description: "Actio institoria: Klage gegen den Geschaeftsherrn (dominus) fuer Verbindlichkeiten aus Handlungen seines institor (Prokuristen). Skill behandelt die Voraussetzungen und die Sonderfaelle bei Sklaven und Familienangehoerigen als institor. Liefert Quellenmatrix."
+---
+
+# Rom 125 Actio Institoria Prokuristenhaftung
+
+## Aufgabe
+
+Skill fuer die actio institoria als Pendant der actio exercitoria im Land-/Stadthandel.
+
+## Rechtsquelle
+
+- D. 14.3 (De institoria actione).
+- Insbesondere D. 14.3.1 (Ulpian), D. 14.3.5 (Ulpian).
+- Praetorisches Edikt.
+
+## Tatbestand
+
+- Institor: vom dominus eingesetzter Verwalter eines Handelsgeschaefts (taberna, officina).
+- Vertraege des institor verpflichten den dominus unmittelbar.
+
+## Sonderfaelle
+
+- Institor als Sklave: dominus haftet aus actio institoria voll.
+- Institor als Hausunterworfener (filius familias): pater familias haftet.
+- Institor als Freier: dominus haftet, aber actio institoria nur, soweit Vertrag im Rahmen des Geschaeftsbereichs.
+
+## Vergleich zu modernem Recht
+
+- § 49 HGB Prokura.
+- § 54 HGB Handlungsvollmacht.
+- §§ 164 ff. BGB Stellvertretung.
+
+## Pruefraster
+
+1. Institor bestellt?
+2. Geschaeftsbereich abgegrenzt?
+3. Vertrag im Rahmen?
+
+## Output
+
+- Quellenmatrix.
+- Vergleichende Synopse.

--- a/roemisches-recht/skills/rom-126-receptum-nautarum-cauponum-stabulariorum/SKILL.md
+++ b/roemisches-recht/skills/rom-126-receptum-nautarum-cauponum-stabulariorum/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: rom-126-receptum-nautarum-cauponum-stabulariorum
+description: "Receptum nautarum cauponum stabulariorum: praetorische Schaerfung der Haftung von Reedern Gastwirten und Stallbetreibern fuer eingebrachtes Gut. Skill behandelt die receptum-Erklaerung die Haftungsgrundlage als custodia und das Verhaeltnis zur actio depositi. Liefert Quellenmatrix."
+---
+
+# Rom 126 Receptum Nautarum Cauponum Stabulariorum
+
+## Aufgabe
+
+Skill fuer die strenge praetorische Schaerfung der Haftung der nautae cauponum stabulariorum.
+
+## Rechtsquelle
+
+- D. 4.9 (Nautae caupones stabularii ut recepta restituant).
+- Insbesondere D. 4.9.1 (Ulpian), D. 4.9.3 (Pomponius).
+- Praetorisches Edikt: edictum nautarum.
+
+## Tatbestand
+
+- Nauta: Schiffer / Reeder.
+- Caupo: Gastwirt.
+- Stabularius: Stallbetreiber.
+- Receptum: die Sache wird vom Betreiber zur Aufbewahrung angenommen.
+
+## Haftung
+
+- Strikte Erfolgshaftung (custodia-Haftung).
+- Verschulden nicht erforderlich; Schaden auch bei Diebstahl durch Dritte zu vertreten.
+- Befreiung nur bei vis maior (hoeherer Gewalt) oder vis cui resisti non potest.
+
+## Vergleich zu modernem Recht
+
+- §§ 701-704 BGB Gastwirtshaftung (Sachen, die der Gast einbringt).
+- §§ 421-429 HGB Frachtfuehrerhaftung.
+- §§ 481 ff. BGB Reisevertragsrecht.
+- §§ 538-541 BGB Mietersachen.
+
+## Pruefraster
+
+1. Vorlieger der nautae/caupones/stabularii-Stellung?
+2. Receptum-Erklaerung?
+3. Schaden eingetreten?
+4. Vis maior gegeben?
+
+## Output
+
+- Quellenmatrix.
+- Vergleichende Synopse.

--- a/roemisches-recht/skills/rom-127-magister-navis-und-mehrere-reeder/SKILL.md
+++ b/roemisches-recht/skills/rom-127-magister-navis-und-mehrere-reeder/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: rom-127-magister-navis-und-mehrere-reeder
+description: "Magister navis und Mehrfachreederschaft im roemischen Seerecht. Skill behandelt die rechtliche Stellung des Schiffskapitaens bei mehreren Reedern (exercitores) Beschluss- und Vertretungsregeln Gesamtschuldnerschaft und Innenausgleich. Liefert Quellenmatrix."
+---
+
+# Rom 127 Magister Navis Und Mehrere Reeder
+
+## Aufgabe
+
+Skill fuer die Mehrfachreederschaft.
+
+## Rechtsquelle
+
+- D. 14.1 (De exercitoria actione).
+- D. 17.2 (Pro socio - Vergesellschaftung).
+
+## Konstellation
+
+- Mehrere Reeder besitzen ein Schiff gemeinschaftlich oder als societas.
+- Magister navis wird von der Mehrheit oder dem Hauptbeteiligten bestellt.
+
+## Vertretungsregeln
+
+- Magister navis vertritt die exercitores in solidum.
+- Gegen jeden Reeder kann actio exercitoria erhoben werden.
+- Innenausgleich nach Anteilen.
+
+## Rechtsfolge
+
+- Gesamtschuldnerstellung der exercitores.
+- Voller Schadensersatzanspruch des Dritten gegen jeden einzelnen.
+
+## Innenausgleich
+
+- Pro Anteil am Schiff.
+- Gleichschritt mit actio pro socio bei Vergesellschaftung.
+
+## Vergleich zu modernem Recht
+
+- § 426 BGB Gesamtschuldnerausgleich.
+- §§ 705 ff. BGB GbR.
+- §§ 484 ff. HGB Schiffsgemeinschaft (aufgehoben durch Seehandelsreform 2013).
+
+## Pruefraster
+
+1. Wie viele exercitores?
+2. Magister navis bestellt?
+3. Geschaeftsbereich?
+4. Innenausgleich?
+
+## Output
+
+- Quellenmatrix.
+- Memo zur Schiffsgemeinschaft.

--- a/roemisches-recht/skills/rom-128-seerouten-ostia-alexandria-und-importzoll/SKILL.md
+++ b/roemisches-recht/skills/rom-128-seerouten-ostia-alexandria-und-importzoll/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: rom-128-seerouten-ostia-alexandria-und-importzoll
+description: "Roemische Seerouten und Importzollordnung. Skill behandelt die historische Rechtspraxis des roemischen Welthandels Routen wie Ostia-Alexandria die portoria-Zoelle und die Aufsicht durch die Procuratoren des Fiscus. Liefert Quellenmatrix."
+---
+
+# Rom 128 Seerouten Ostia Alexandria Und Importzoll
+
+## Aufgabe
+
+Skill fuer die roemische Importzollordnung im Welthandel.
+
+## Hauptrouten
+
+- Ostia (Tiber-Muendung) - Alexandria (Aegypten): Getreide, Papyrus.
+- Ostia - Karthago: Olivenoel.
+- Ostia - Hispania: Garum, Salz, Metalle.
+- Ostia - Indien: Pfeffer, Edelsteine, Seide (ueber das Rote Meer).
+
+## Portoria
+
+- Zoll auf importierte und exportierte Gueter.
+- Hoehe: typischerweise 2,5 Prozent (XL = quadragesima Galliarum), zum Teil hoeher.
+- Indienhandel: 25 Prozent (vicesima quinta).
+
+## Aufsicht
+
+- Procuratores des Fiscus.
+- Conductores publicanorum (Steuerpaechter).
+
+## Rechtspraxis
+
+- Importeur deklarierte Ware bei der Zollstelle.
+- Quittung (chirographum).
+- Bei Schmuggel: Konfiskation plus Strafzahlung.
+
+## Quellen
+
+- Plinius der Aeltere, Naturalis Historia.
+- Periplus Maris Erythraei (anonymes Werk ca. 1. Jh. n. Chr.).
+- D. 39.4 (De publicanis et vectigalibus et commissis).
+
+## Pruefraster
+
+1. Welche Route?
+2. Welche Ware?
+3. Welcher Zollsatz?
+4. Welche Deklaration?
+
+## Output
+
+- Quellenmatrix.
+- Memo zur roemischen Wirtschaftsgeschichte.

--- a/roemisches-recht/skills/rom-129-getreidehandel-cura-annonae/SKILL.md
+++ b/roemisches-recht/skills/rom-129-getreidehandel-cura-annonae/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: rom-129-getreidehandel-cura-annonae
+description: "Cura annonae: roemische Verwaltung des Getreidehandels und der Versorgung der Hauptstadt. Skill behandelt die Praefectus annonae die staatlich gefoerderten Reedereien (navicularii) und die Privilegien fuer Getreidetransporte. Liefert Quellenmatrix."
+---
+
+# Rom 129 Getreidehandel Cura Annonae
+
+## Aufgabe
+
+Skill fuer die cura annonae.
+
+## Rechtsquelle
+
+- D. 50.5 (De vacatione et excusatione munerum).
+- D. 50.6 (De iure immunitatis).
+- Codex Theodosianus, Buch 13 und 14.
+
+## Cura annonae
+
+- Staatliche Verantwortung fuer Getreideversorgung Roms (und spaeter Konstantinopels).
+- Praefectus annonae als zustaendiger Beamter.
+
+## Navicularii
+
+- Privatreedereien mit staatlich genehmigtem Getreidetransport.
+- Privilegien:
+  - Steuerbefreiung.
+  - Befreiung von munera (kommunale Lasten).
+  - Verminderte Strafen bei Schiffshavarien.
+
+## Annona civica
+
+- Kostenlose Getreidedistribution an arme Buerger (anfangs Subventionssystem, spaeter Vollversorgung).
+
+## Strafe bei Verstoessen
+
+- Veruntreuung des Staatsgetreides: schwerere Strafen, einschliesslich Todesstrafe in Sondertaeterklassen.
+
+## Pruefraster
+
+1. Welche Funktion?
+2. Welche Privilegien?
+3. Welche Pflichten?
+
+## Output
+
+- Quellenmatrix.
+- Memo zur Lebensmittelversorgung als oeffentliche Aufgabe.

--- a/roemisches-recht/skills/rom-130-import-aus-orient-aurum-silberbarren/SKILL.md
+++ b/roemisches-recht/skills/rom-130-import-aus-orient-aurum-silberbarren/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: rom-130-import-aus-orient-aurum-silberbarren
+description: "Roemischer Importhandel mit dem Orient: Gold Silber Seide Edelsteine Pfeffer. Skill behandelt die rechtlichen Sondervorschriften zum Edelmetall- und Luxusguterimport die hohen Zoelle (vicesima quinta) und die Aufsicht. Liefert Quellenmatrix."
+---
+
+# Rom 130 Import Aus Orient Aurum Silberbarren
+
+## Aufgabe
+
+Skill fuer den roemischen Luxusgueterimport.
+
+## Hauptgueter
+
+- Pfeffer und Gewuerze aus Indien.
+- Seide aus China (ueber die Seidenstrasse oder das Rote Meer).
+- Edelsteine und Perlen aus Indien.
+- Elfenbein und Sklaven aus Afrika.
+- Bernstein aus Skandinavien.
+
+## Zollsatz
+
+- Indienhandel: 25 Prozent (vicesima quinta).
+- Andere Luxusgueter: ebenfalls erhoeht.
+
+## Edelmetallabfluss
+
+- Plinius der Aeltere beklagt den Aurum-Abfluss in den Orient.
+- Schaetzungen: 100 Mio. Sesterzen Goldabfluss pro Jahr nach Indien.
+
+## Rechtliche Sondervorschriften
+
+- Zollkontrolle in den Roten Meer-Haefen (Berenike, Myos Hormos).
+- Verlust bei See-Untergang durch fenus nauticum versichert.
+- Schmuggel mit drakonischen Strafen.
+
+## Quellen
+
+- Plinius, Naturalis Historia.
+- Periplus Maris Erythraei.
+- Muziris Papyrus (2. Jh. n. Chr.): konkrete Vertragsabwicklung eines Indienhandels.
+
+## Pruefraster
+
+1. Welches Importgut?
+2. Welcher Zoll?
+3. Welche Risikoversicherung?
+4. Welche Aufsicht?
+
+## Output
+
+- Quellenmatrix.
+- Memo zur roemischen Wirtschaftsbilanz.

--- a/roemisches-recht/skills/rom-131-seeunglueck-versicherung-und-risiko/SKILL.md
+++ b/roemisches-recht/skills/rom-131-seeunglueck-versicherung-und-risiko/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: rom-131-seeunglueck-versicherung-und-risiko
+description: "Seeunglueck Versicherung und Risiko im roemischen Seerecht. Skill behandelt die Risikoverteilung bei Seetransporten lex Rhodia fenus nauticum receptum nautarum und die Frage was bei Untergang oder Verlust geschuldet ist. Liefert Pruefraster."
+---
+
+# Rom 131 Seeunglueck Versicherung Und Risiko
+
+## Aufgabe
+
+Skill fuer die Risikoverteilung bei Seeunfaellen.
+
+## Risiken
+
+- Untergang (perit res).
+- Generalhavarie (iactus).
+- Diebstahl und Piraterie.
+- Verspaetung.
+
+## Risikotraeger nach Vertragsart
+
+| Vertragstyp | Risiko traegt | Quellenstelle |
+|---|---|---|
+| fenus nauticum | Darlehensgeber | D. 22.2 |
+| locatio conductio (Beförderung) | je nach Verschulden | D. 14.2 |
+| Generalhavarie | alle Beteiligten anteilig | D. 14.2 lex Rhodia |
+| receptum nautarum | Reeder | D. 4.9 |
+
+## Versicherungsfunktional
+
+- Klassische Seeversicherung gab es nicht als eigenes Vertragsinstitut.
+- Risikoverteilung durch fenus nauticum, lex Rhodia, receptum nautarum erfuellte aequivalente Funktionen.
+
+## Vergleich zu modernem Recht
+
+- Heute Versicherungsvertragsgesetz und Seehandelsrecht.
+- Lloyd's Of London entwickelte ab 1688 das moderne Schiffsversicherungswesen.
+
+## Pruefraster
+
+1. Welcher Vertragstyp?
+2. Welches Risiko realisiert?
+3. Welche Befreiungsgruende?
+4. Welche Schadenshoehe?
+
+## Output
+
+- Quellenmatrix.
+- Memo zum funktionalen Versicherungsersatz.

--- a/roemisches-recht/skills/rom-132-actio-tributoria-handelssklave-sondervermoegen/SKILL.md
+++ b/roemisches-recht/skills/rom-132-actio-tributoria-handelssklave-sondervermoegen/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: rom-132-actio-tributoria-handelssklave-sondervermoegen
+description: "Actio tributoria: Klage gegen den dominus fuer Verbindlichkeiten aus Handelsgeschaeften seines Sklaven (servus negotiator) der mit peculium und Wissen des dominus Handel trieb. Skill behandelt das Verhaeltnis zu actio de peculio und actio institoria. Liefert Quellenmatrix."
+---
+
+# Rom 132 Actio Tributoria Handelssklave Sondervermoegen
+
+## Aufgabe
+
+Skill fuer die actio tributoria als praetorische Sonderaktion.
+
+## Rechtsquelle
+
+- D. 14.4 (De tributoria actione).
+- Praetorisches Edikt.
+
+## Tatbestand
+
+- Sklave (servus) oder filius familias handelt mit Wissen und Duldung des dominus.
+- Sklave benutzt sein peculium (Sondervermoegen) fuer Handelsgeschaefte.
+- Glaeubiger des Sklaven verlangt anteilige Befriedigung aus dem peculium.
+
+## Rechtsfolge
+
+- Dominus muss den Glaeubiger anteilig aus dem peculium befriedigen.
+- Dominus selbst als Glaeubiger der eigenen Sklaven steht nicht besser; pari passu mit anderen.
+
+## Abgrenzung
+
+- Actio de peculio: Klage in Hoehe des Peculium-Werts ohne Quotenpflicht.
+- Actio tributoria: Quote bei mehreren Glaeubigern, mit Berechnung "in tributum".
+
+## Vergleich zu modernem Recht
+
+- Heute Trennung in juristische Person und Geschaeftsfuehrer.
+- Schaedigungshaftung im Konzern (Existenzvernichtungshaftung BGH II ZR 256/02).
+
+## Pruefraster
+
+1. Sklavenhandel mit peculium?
+2. Wissen des dominus?
+3. Welche Aktion?
+4. Quote berechnen.
+
+## Output
+
+- Quellenmatrix.
+- Memo zur Sklavenhandelspraxis.

--- a/roemisches-recht/skills/rom-133-stellio-und-schmuggel-roemische-zollordnung/SKILL.md
+++ b/roemisches-recht/skills/rom-133-stellio-und-schmuggel-roemische-zollordnung/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: rom-133-stellio-und-schmuggel-roemische-zollordnung
+description: "Stellio und Schmuggel im roemischen Reich: Strafregeln fuer Zoll-, Steuer- und Warendelikte. Skill behandelt die Strafe der Vermoegenseinziehung (commissum) Strafverfahren und Aufsichtsbehoerden. Liefert Quellenmatrix."
+---
+
+# Rom 133 Stellio Und Schmuggel Roemische Zollordnung
+
+## Aufgabe
+
+Skill fuer Schmuggelrechtsregeln im Roemischen Reich.
+
+## Rechtsquelle
+
+- D. 39.4 (De publicanis et vectigalibus et commissis).
+- D. 47.20 (Stellionatus).
+- Codex Theodosianus, Buch 4 und 13.
+
+## Tatbestand
+
+- Stellionatus: Vermoegensdelikte, die kein anderes Delikt erfuellen (Generalklausel).
+- Schmuggel: Nichtdeklaration zollpflichtiger Ware.
+
+## Strafe
+
+- Commissum: Konfiskation der nicht deklarierten Ware.
+- Zusaetzliche Geldstrafen.
+- Bei Wiederholung: harte Koerperstrafen bis Verbannung.
+
+## Verfahren
+
+- Vor dem procurator des Fiscus.
+- Konfiskation durch das Aerar oder Fiscus.
+
+## Aufsicht
+
+- Conductores publicanorum (Steuerpaechter) waren wirtschaftlich an Aufdeckung interessiert.
+
+## Vergleich zu modernem Recht
+
+- § 263 StGB Betrug.
+- §§ 369 ff. AO Steuerhinterziehung.
+- Zollkodex der EU.
+
+## Pruefraster
+
+1. Welche Ware betroffen?
+2. Welche Zollordnung?
+3. Welche Strafe?
+
+## Output
+
+- Quellenmatrix.
+- Memo zur roemischen Steueraufsicht.

--- a/roemisches-recht/skills/rom-134-buergschaftstypen-sponsio-fidepromissio-fideiussio/SKILL.md
+++ b/roemisches-recht/skills/rom-134-buergschaftstypen-sponsio-fidepromissio-fideiussio/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: rom-134-buergschaftstypen-sponsio-fidepromissio-fideiussio
+description: "Buergschaftstypen im roemischen Recht: sponsio fidepromissio und fideiussio. Skill behandelt die historische Entwicklung von der altzivilen sponsio ueber die fidepromissio fuer Peregrini bis zur klassischen fideiussio Justinians. Liefert Quellenmatrix."
+---
+
+# Rom 134 Buergschaftstypen Sponsio Fidepromissio Fideiussio
+
+## Aufgabe
+
+Skill fuer die drei Hauptformen der roemischen Buergschaft.
+
+## Sponsio
+
+- Aelteste Form, beschraenkt auf cives Romani.
+- Per stipulationem geschlossen.
+- Aktionierbar nur fuer Glaeubiger gegen Buergen (sponsor).
+- Konnte nicht vererbt werden.
+- Geltung erloschen mit dem Tod des Hauptschuldners.
+
+## Fidepromissio
+
+- Hellenistisch beeinflusste Form, offen fuer Peregrini.
+- Geringere Strenge.
+- Erhielt sich neben der sponsio.
+
+## Fideiussio
+
+- Klassische Form ab dem Prinzipat.
+- Offen fuer alle.
+- Vererbbar.
+- Galt nicht nur fuer Stipulations-Verbindlichkeiten.
+- Justinian machte fideiussio zur einzigen Standardform.
+
+## Rechtsquelle
+
+- Gaius, Institutiones III.115-127.
+- D. 46.1 (De fideiussoribus et mandatoribus).
+
+## Sonderbestimmungen
+
+- Lex Furia (limitierte Buergenzahl).
+- Lex Cicereia (Buergeninformation).
+- Lex Cornelia (limitierte Buergschaftshoehe).
+
+## Vergleich zu modernem Recht
+
+- §§ 765-778 BGB Buergschaft.
+- § 766 BGB Schriftform.
+- § 768 BGB Einreden der Buergen.
+
+## Pruefraster
+
+1. Welche Buergschaftsform?
+2. Welcher Personenkreis?
+3. Welche Akzessorietaetsfragen?
+
+## Output
+
+- Quellenmatrix.
+- Vergleichende Synopse.

--- a/roemisches-recht/skills/rom-135-beneficium-divisionis-und-excussionis/SKILL.md
+++ b/roemisches-recht/skills/rom-135-beneficium-divisionis-und-excussionis/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: rom-135-beneficium-divisionis-und-excussionis
+description: "Beneficium divisionis und beneficium excussionis: Buergenprivilegien im roemischen Recht. Skill behandelt die Aufteilungsbefugnis bei mehreren Buergen (divisionis) und das Vorausklagebefugnis gegen den Hauptschuldner (excussionis). Liefert Quellenmatrix."
+---
+
+# Rom 135 Beneficium Divisionis Und Excussionis
+
+## Aufgabe
+
+Skill fuer die zwei klassischen Buergenprivilegien.
+
+## Beneficium divisionis
+
+- Mehrere fideiussores hafteten nicht in solidum, sondern jeder anteilig.
+- Eingefuehrt durch Justinians Novelle (Datum vor Zitat verifizieren).
+- Vorher hafteten alle Buergen in solidum.
+
+## Beneficium excussionis
+
+- Buerge konnte verlangen, dass Glaeubiger zuerst den Hauptschuldner verklage.
+- Eingefuehrt durch Justinians Novelle 4.
+- Voraussetzung: Hauptschuldner ist greifbar und solvent.
+
+## Verzicht
+
+- Beide Privilegien konnten im Vertrag verzichtet werden.
+
+## Vergleich zu modernem Recht
+
+- § 771 BGB Einrede der Vorausklage (Pendant beneficium excussionis).
+- § 769 BGB Mitbuergschaft (gesamtschuldnerisch, anders als roemisches Recht).
+
+## Pruefraster
+
+1. Mehrere Buergen?
+2. Verzicht erfolgt?
+3. Hauptschuldner greifbar?
+
+## Output
+
+- Quellenmatrix.
+- Vergleichende Synopse.

--- a/roemisches-recht/skills/rom-136-intercessio-frauen-senatusconsultum-velleianum/SKILL.md
+++ b/roemisches-recht/skills/rom-136-intercessio-frauen-senatusconsultum-velleianum/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: rom-136-intercessio-frauen-senatusconsultum-velleianum
+description: "Intercessio der Frauen und das Senatusconsultum Velleianum: Verbot der Buergschaft durch Frauen fuer fremde Schulden. Skill behandelt das senatusconsultum von ca. 46 n. Chr. die Schutzfunktion und die Umgehung. Liefert Quellenmatrix."
+---
+
+# Rom 136 Intercessio Frauen Senatusconsultum Velleianum
+
+## Aufgabe
+
+Skill fuer das SC Velleianum.
+
+## Rechtsquelle
+
+- Senatusconsultum Velleianum (ca. 46 n. Chr. unter Claudius oder Nero; Datum vor Zitat verifizieren).
+- D. 16.1 (Ad senatusconsultum Velleianum).
+- Insbesondere D. 16.1.1 (Paulus).
+
+## Tatbestand
+
+- Intercessio (Buergschaft, Schuldbeitritt oder Vermoegensgabe) durch eine Frau zugunsten eines Dritten.
+
+## Rechtsfolge
+
+- Frau erhielt eine exceptio (Einrede), wenn der Glaeubiger gegen sie klagte.
+- Verpflichtung war nicht nichtig, aber unklagbar.
+- Schutz der Frau vor Ueberforderung.
+
+## Umgehungen
+
+- Wenn die Frau bei klarer Kenntnis bewusst intercessio ueblichkeitsgemaess uebernommen hat.
+- Wenn der Glaeubiger nach Aufklaerung erneute Bestaetigung erhielt.
+
+## Vergleich zu modernem Recht
+
+- BGH-Linie zu Ehegattenbuergschaften: § 138 BGB Sittenwidrigkeit bei kraesser ueberforderung (BGH IX ZR 56/93 Buergschaft Vermoegenslose).
+- BVerfG zur Ehegattenbuergschaft (Beschluss vom 19.10.1993, Az 1 BvR 567/89): Schutzpflicht des Staates.
+
+## Pruefraster
+
+1. Frauenintercessio?
+2. Wirksame exceptio?
+3. Bestaetigung erfolgt?
+
+## Output
+
+- Quellenmatrix.
+- Vergleichende Synopse zur modernen Buergschaftsproblematik.

--- a/roemisches-recht/skills/rom-137-pignus-conventum-hypotheca-praxisfaelle/SKILL.md
+++ b/roemisches-recht/skills/rom-137-pignus-conventum-hypotheca-praxisfaelle/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: rom-137-pignus-conventum-hypotheca-praxisfaelle
+description: "Pignus conventum und hypotheca: dingliche Sicherheiten im roemischen Recht. Skill behandelt die Unterschiede zwischen pignus mit Besitzuebergabe und hypotheca ohne Besitzuebergabe sowie typische Praxisfaelle landwirtschaftliche Geraete (invecta et illata). Liefert Quellenmatrix."
+---
+
+# Rom 137 Pignus Conventum Hypotheca Praxisfaelle
+
+## Aufgabe
+
+Skill fuer pignus und hypotheca als dingliche Sicherungsrechte.
+
+## Pignus
+
+- Verpfaendung mit Besitzuebergabe.
+- Glaeubiger erhaelt Realbesitz.
+- Bei Nichterfuellung Verkaufsbefugnis.
+
+## Hypotheca
+
+- Verpfaendung ohne Besitzuebergabe.
+- Hauptschuldner behaelt Sache.
+- Glaeubiger erhielt actio Serviana, actio quasi-Serviana, actio hypothecaria.
+
+## Sondertyp invecta et illata
+
+- Im Mietvertrag (locatio conductio rei): das vom Paechter eingebrachte Inventar (Geraete, Mobiliar) hatte stillschweigend Pfandqualitaet zugunsten des Vermieters.
+- D. 20.2.
+
+## Rangordnung
+
+- Praetorische Privilegien (fiscus, vom Mann verschuldete Mitgift).
+- Mehrere Pfandrechte: prior tempore potior iure.
+
+## Vergleich zu modernem Recht
+
+- §§ 1204 ff. BGB Pfandrecht beweglicher Sachen.
+- §§ 1113 ff. BGB Hypothek (an Grundstuecken).
+- § 562 BGB Vermieterpfandrecht (Pendant invecta et illata).
+- § 559 BGB Verpfaendung in der Mietsache.
+
+## Pruefraster
+
+1. Welche Sicherungsform?
+2. Besitzuebergabe erfolgt?
+3. Rangverhaeltnis?
+
+## Output
+
+- Quellenmatrix.
+- Vergleichende Synopse.

--- a/roemisches-recht/skills/rom-138-mandatum-pecuniae-credendae-bankvertrag/SKILL.md
+++ b/roemisches-recht/skills/rom-138-mandatum-pecuniae-credendae-bankvertrag/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: rom-138-mandatum-pecuniae-credendae-bankvertrag
+description: "Mandatum pecuniae credendae: Kreditbuergschaftsvertrag im roemischen Recht als Vorlaeufer der Bankkredit-Garantie. Skill behandelt die Konstruktion das Verhaeltnis zur Buergschaft und zum Auftrag. Liefert Quellenmatrix."
+---
+
+# Rom 138 Mandatum Pecuniae Credendae Bankvertrag
+
+## Aufgabe
+
+Skill fuer mandatum pecuniae credendae.
+
+## Rechtsquelle
+
+- D. 17.1 (Mandati vel contra).
+- Insbesondere D. 17.1.6.3 (Ulpian).
+
+## Tatbestand
+
+- A (Buerge) gibt B (Glaeubiger) den Auftrag, dem C (Schuldner) Geld zu leihen.
+- Wirtschaftlich: A garantiert die Rueckzahlung durch C.
+
+## Rechtsfolge
+
+- Wenn C nicht zahlt, hat B actio mandati contraria gegen A auf Ausgleich.
+- Im Verhaeltnis A-B: mandatum (Auftrag mit Aufwendungsersatz).
+- Im Verhaeltnis B-C: regulaeres mutuum (Darlehen).
+
+## Funktionale Aequivalenz zur Buergschaft
+
+- Wirtschaftlich Buergschaftsersatz.
+- Vorteil: A behielt die Stellung des Auftraggebers, kein Buergenprivilegien-System.
+
+## Vergleich zu modernem Recht
+
+- § 311 BGB iVm § 765 BGB Buergschaft.
+- § 651 BGB Schuldbeitritt.
+- Garantievertrag (eigenstaendige Schuld).
+
+## Pruefraster
+
+1. Mandatum oder mutuum?
+2. Aufwendungsersatz?
+3. Garantiezweck?
+
+## Output
+
+- Quellenmatrix.
+- Vergleichende Synopse.

--- a/roemisches-recht/skills/rom-139-versicherung-und-risiko-im-roemischen-recht/SKILL.md
+++ b/roemisches-recht/skills/rom-139-versicherung-und-risiko-im-roemischen-recht/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: rom-139-versicherung-und-risiko-im-roemischen-recht
+description: "Versicherung und Risikoverteilung im roemischen Recht. Skill behandelt das Fehlen einer eigenstaendigen Versicherungslehre und die funktionalen Ersatzinstrumente fenus nauticum lex Rhodia receptum nautarum gemeinsame Gefahrtragung. Liefert Synopse zur heutigen Versicherungslandschaft."
+---
+
+# Rom 139 Versicherung Und Risiko Im Roemischen Recht
+
+## Aufgabe
+
+Skill fuer Versicherungsersatz im roemischen Recht.
+
+## Fehlen einer Versicherungslehre
+
+- Klassische Roemische Juristen kannten keinen Versicherungsvertrag als typenmaessiges Geschaeft.
+- Risikoverteilung wurde durch andere Vertragstypen funktional erreicht.
+
+## Funktionale Ersatzinstrumente
+
+| Risiko | Ersatzinstrument | Quellenstelle |
+|---|---|---|
+| Seetransport | fenus nauticum | D. 22.2 |
+| Untergang gemeinsamer Ladung | lex Rhodia | D. 14.2 |
+| Gastwirthaftung | receptum nautarum | D. 4.9 |
+| Verkaufsrisiko bis Uebergabe | Gefahrtragungsregeln | D. 18.6 |
+| Sklavenarbeitsschaeden | noxalhaftung | D. 9.4 |
+
+## Begraebnisversicherung
+
+- Collegia funeraticia: Vereinigungen, deren Mitglieder gegen Beitrag eine ordentliche Bestattung erhielten.
+- Vorlaeufer der Sterbeversicherung.
+
+## Vergleich zu modernem Recht
+
+- Modernes Versicherungsrecht setzt einen eigenstaendigen Vertragstypus voraus.
+- Lloyd's Of London ab 1688 als Geburtsstunde der modernen Versicherung.
+- Heute VVG.
+
+## Pruefraster
+
+1. Welches Risiko?
+2. Welches roemische Instrument?
+3. Welche heutige Aequivalenz?
+
+## Output
+
+- Quellenmatrix.
+- Synopse.

--- a/roemisches-recht/skills/rom-140-tutela-fiduciaria-und-pflegevormundschaft-vermoegen/SKILL.md
+++ b/roemisches-recht/skills/rom-140-tutela-fiduciaria-und-pflegevormundschaft-vermoegen/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: rom-140-tutela-fiduciaria-und-pflegevormundschaft-vermoegen
+description: "Tutela fiduciaria und Pflegevormundschaft: Vermoegensverwaltung fuer Minderjaehrige und Frauen im roemischen Recht. Skill behandelt die Stellung des Tutor die actio tutelae direkter und konträrer Klage Schutzbestimmungen gegen Untreue des Tutors. Liefert Quellenmatrix."
+---
+
+# Rom 140 Tutela Fiduciaria Und Pflegevormundschaft Vermoegen
+
+## Aufgabe
+
+Skill fuer Vermoegensvormundschaft.
+
+## Tutela impuberum
+
+- Vormundschaft fuer Minderjaehrige (impuberes) bis 14 Jahre (Knaben) / 12 Jahre (Maedchen).
+- Tutor verwaltet das Vermoegen.
+
+## Tutela mulierum
+
+- Vormundschaft fuer erwachsene Frauen (mulieres sui iuris).
+- Eingeschraenkt auf Vermoegensverfuegungen (auctoritas).
+- Praktisch bedeutungslos ab dem Prinzipat.
+
+## Cura minorum
+
+- Pflegevormundschaft fuer 14-25-Jaehrige.
+- Optional.
+
+## Actio tutelae
+
+- Klage des Muendels gegen Tutor wegen Pflichtverletzung.
+- Actio tutelae directa: Muendel klagt gegen Tutor.
+- Actio tutelae contraria: Tutor klagt gegen Muendel auf Aufwendungsersatz.
+
+## Schutzbestimmungen
+
+- Verbot der Eigengeschaefte des Tutors mit dem Muendelvermoegen.
+- Hypothek auf das Vermoegen des Tutors (tacita hypotheca) zugunsten des Muendels.
+
+## Vergleich zu modernem Recht
+
+- §§ 1773 ff. BGB Vormundschaft.
+- § 1837 BGB Genehmigung durch Vormundschaftsgericht.
+- § 1908i BGB Betreuung.
+
+## Pruefraster
+
+1. Tutela oder cura?
+2. Pflichtverletzung des Tutor?
+3. Klage?
+
+## Output
+
+- Quellenmatrix.
+- Synopse.

--- a/roemisches-recht/skills/rom-141-mandatum-qualificatum-buergschaftsersatz/SKILL.md
+++ b/roemisches-recht/skills/rom-141-mandatum-qualificatum-buergschaftsersatz/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: rom-141-mandatum-qualificatum-buergschaftsersatz
+description: "Mandatum qualificatum: qualifizierte Auftragserteilung als Buergschaftsersatz. Skill behandelt die juristische Konstruktion das Verhaeltnis zur mandatum pecuniae credendae und die Folgen bei Nichterfuellung. Liefert Quellenmatrix."
+---
+
+# Rom 141 Mandatum Qualificatum Buergschaftsersatz
+
+## Aufgabe
+
+Skill fuer mandatum qualificatum.
+
+## Konstruktion
+
+- A erteilt B den Auftrag, einer dritten Person (C) Geld zu leihen.
+- A garantiert wirtschaftlich die Rueckzahlung durch C.
+- Bei Ausfall von C kann B mit der actio mandati contraria gegen A vorgehen.
+
+## Abgrenzungen
+
+- Mandatum simplex: einfacher Auftrag ohne Garantiezweck.
+- Mandatum qualificatum: Garantiezweck im Vordergrund.
+- Mandatum pecuniae credendae: Sonderfall der Geldleihe als Auftragsgegenstand.
+
+## Vergleich zu modernem Recht
+
+- Garantievertrag als selbstaendiges Versprechen (anders als Buergschaft akzessorisch).
+- § 311 Abs. 1 BGB allgemeine Vertragsfreiheit.
+- BGH zum Garantievertrag (st. Rspr.).
+
+## Pruefraster
+
+1. Auftragscharakter klar?
+2. Garantiefunktion?
+3. Aufwendungsersatzanspruch?
+
+## Output
+
+- Quellenmatrix.
+- Synopse.

--- a/roemisches-recht/skills/rom-142-testamentum-calatis-comitiis-und-in-procinctu/SKILL.md
+++ b/roemisches-recht/skills/rom-142-testamentum-calatis-comitiis-und-in-procinctu/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: rom-142-testamentum-calatis-comitiis-und-in-procinctu
+description: "Testamentum calatis comitiis und in procinctu: aelteste Formen des roemischen Testaments. Skill behandelt die Beurkundung vor dem Volk (calatis comitiis) und vor dem Heer (in procinctu) sowie ihre Verdraengung durch das mancipationstestament. Liefert Quellenmatrix."
+---
+
+# Rom 142 Testamentum Calatis Comitiis Und In Procinctu
+
+## Aufgabe
+
+Skill fuer die aeltesten Testamentsformen.
+
+## Rechtsquelle
+
+- Gaius, Institutiones II.101-103.
+- Cicero, De oratore.
+- D. 28 (Justinianische Digesten - De testamentis).
+
+## Testamentum calatis comitiis
+
+- Bezeichnung: "Testament in den einberufenen Versammlungen".
+- Volksversammlung (comitia calata) zweimal im Jahr.
+- Pontifex bestaetigte die letztwillige Verfuegung.
+- Beschraenkt auf cives Romani.
+
+## Testamentum in procinctu
+
+- Bezeichnung: "Testament in der Schlachtordnung".
+- Vor Beginn einer militaerischen Schlacht.
+- Schnelle Form fuer Soldaten ohne formelle Volksversammlung.
+
+## Verdraengung
+
+- Testamentum per aes et libram (Mancipationstestament) wurde ab der mittleren Republik ueblich.
+- Calatis comitiis und in procinctu verloren an Bedeutung.
+
+## Vergleich zu modernem Recht
+
+- Notarielles Testament § 2231 BGB.
+- Eigenhaendiges Testament § 2247 BGB.
+- Nottestament § 2249 BGB.
+
+## Pruefraster
+
+1. Welche Form?
+2. Personenkreis (cives, Soldat)?
+3. Formerfordernisse erfuellt?
+
+## Output
+
+- Quellenmatrix.
+- Synopse.

--- a/roemisches-recht/skills/rom-143-testamentum-per-aes-et-libram-mancipationstestament/SKILL.md
+++ b/roemisches-recht/skills/rom-143-testamentum-per-aes-et-libram-mancipationstestament/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: rom-143-testamentum-per-aes-et-libram-mancipationstestament
+description: "Testamentum per aes et libram: das mancipationstestament als klassische Form. Skill behandelt das Mancipationsritual familiae emptor heredis institutio Nuncupatio und Verdraengung durch das praetorische Tabula-Testament. Liefert Quellenmatrix."
+---
+
+# Rom 143 Testamentum Per Aes Et Libram Mancipationstestament
+
+## Aufgabe
+
+Skill fuer das Mancipationstestament.
+
+## Rechtsquelle
+
+- Gaius, Institutiones II.103 ff.
+- D. 28.1.
+
+## Mancipationsritual
+
+- Beteiligte: testator, libripens (Waagehalter), 5 Zeugen, familiae emptor (Schein-Erbe), heres (eigentlicher Erbe).
+- Familiae emptor uebernimmt formal das Vermoegen mit dem Treuhandauftrag (fiducia), es dem Erben nach Tod des Testators zu uebertragen.
+
+## Heredis institutio
+
+- Einsetzung des Erben.
+- Erforderlich im Eingang des Testaments.
+
+## Nuncupatio
+
+- Muendliche Bestaetigung des testamentum durch den testator.
+
+## Verdraengung
+
+- Praetorisches Tabula-Testament: 7 Zeugen siegeln das Testament; Nuncupatio entfaellt.
+- Justinian: Tabula-Testament mit 7 Zeugen, im Termin oder zerstreut moeglich.
+
+## Vergleich zu modernem Recht
+
+- §§ 2229 ff. BGB Testament.
+- § 2247 BGB eigenhaendiges Testament.
+
+## Pruefraster
+
+1. Mancipationsritual eingehalten?
+2. Heredis institutio?
+3. Zeugen?
+
+## Output
+
+- Quellenmatrix.
+- Synopse.

--- a/roemisches-recht/skills/rom-144-testamentum-praetorium-tabulae-septies-signatae/SKILL.md
+++ b/roemisches-recht/skills/rom-144-testamentum-praetorium-tabulae-septies-signatae/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: rom-144-testamentum-praetorium-tabulae-septies-signatae
+description: "Testamentum praetorium: praetorische Form des Tabula-Testaments mit 7 Siegelzeugen. Skill behandelt die Voraussetzungen die Verbesserung gegenueber dem Mancipationstestament und die Folgen fuer die bonorum possessio secundum tabulas. Liefert Quellenmatrix."
+---
+
+# Rom 144 Testamentum Praetorium Tabulae Septies Signatae
+
+## Aufgabe
+
+Skill fuer das praetorische Tabula-Testament.
+
+## Rechtsquelle
+
+- Praetorisches Edikt (de bonorum possessione secundum tabulas).
+- D. 37.11 (De bonorum possessione contra tabulas).
+- Gaius, Institutiones II.119-122.
+
+## Tatbestand
+
+- Testament in Form von tabulae (Wachstafeln).
+- 7 Zeugen siegeln.
+- Nuncupatio entfaellt.
+
+## Bonorum possessio secundum tabulas
+
+- Praetor gewaehrt dem im Testament eingesetzten Erben die Vermoegensbesitzbestaetigung, auch wenn die strenge zivilrechtliche Form fehlt.
+- "Praetorische Erbschaftseinweisung" mit Wirkung gegen alle ausser den iure civili-Erben.
+
+## Folge
+
+- Praktische Aufweichung der Strenge des mancipationstestaments.
+- Testament als reine Urkundenform setzte sich durch.
+
+## Vergleich zu modernem Recht
+
+- §§ 2231 ff. BGB.
+- § 2356 BGB Erbschein.
+
+## Pruefraster
+
+1. Tabulae-Form?
+2. 7 Zeugen gesiegelt?
+3. Praetorische Bestaetigung erteilt?
+
+## Output
+
+- Quellenmatrix.
+- Synopse.

--- a/roemisches-recht/skills/rom-145-querela-inofficiosi-testamenti-pflichtteil/SKILL.md
+++ b/roemisches-recht/skills/rom-145-querela-inofficiosi-testamenti-pflichtteil/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: rom-145-querela-inofficiosi-testamenti-pflichtteil
+description: "Querela inofficiosi testamenti: roemischer Pflichtteilsschutz. Skill behandelt die Klage des uebergangenen oder ungenuegend bedachten naechsten Verwandten Pflichtteilsbruchteil (portio legitima) Voraussetzungen und Beweislast. Liefert Quellenmatrix."
+---
+
+# Rom 145 Querela Inofficiosi Testamenti Pflichtteil
+
+## Aufgabe
+
+Skill fuer roemischen Pflichtteilsschutz.
+
+## Rechtsquelle
+
+- D. 5.2 (De inofficioso testamento).
+- Codex 3.28.
+- Pliny, Letters.
+
+## Tatbestand
+
+- Testator hat naechsten Verwandten (Kinder, Eltern) im Testament uebergangen oder unter portio legitima bedacht.
+- Pflichtteilsbruchteil: 1/4 dessen, was bei Intestaterbfolge zugefallen waere.
+- Spaeter Justinian: 1/3 bei wenigen Kindern, 1/2 bei mehr als 5 Kindern (Novelle 18).
+
+## Wirkung
+
+- Testament wird vollstaendig fuer ungueltig erklaert ("rescissio testamenti").
+- Anschliessend Intestaterbfolge.
+
+## Voraussetzungen
+
+- Klagebefugnis nur fuer naechste Verwandte.
+- Frist (annus utilis ab Kenntnis).
+
+## Vergleich zu modernem Recht
+
+- §§ 2303 ff. BGB Pflichtteilsrecht.
+- Pflichtteil: 1/2 des gesetzlichen Erbteils als Geldanspruch.
+- Im Unterschied zum roemischen Recht: Testament bleibt wirksam; Pflichtteilberechtigter erhaelt Geld.
+
+## Pruefraster
+
+1. Pflichtteilsberechtigter Personenkreis?
+2. Portio legitima verletzt?
+3. Klage rechtzeitig?
+
+## Output
+
+- Quellenmatrix.
+- Synopse.

--- a/roemisches-recht/skills/rom-146-bonorum-possessio-contra-tabulas/SKILL.md
+++ b/roemisches-recht/skills/rom-146-bonorum-possessio-contra-tabulas/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: rom-146-bonorum-possessio-contra-tabulas
+description: "Bonorum possessio contra tabulas: Vermoegensbesitzbestaetigung des Praetors gegen das Testament. Skill behandelt die Voraussetzungen die Schutzfunktion fuer uebergangene Hauserben (sui heredes) und das Verhaeltnis zur querela inofficiosi testamenti. Liefert Quellenmatrix."
+---
+
+# Rom 146 Bonorum Possessio Contra Tabulas
+
+## Aufgabe
+
+Skill fuer die bonorum possessio contra tabulas.
+
+## Rechtsquelle
+
+- D. 37.4 (De bonorum possessione contra tabulas).
+- Praetorisches Edikt.
+
+## Tatbestand
+
+- Testator hat sui heredes (Hauskinder) uebergangen, ohne sie zu enterben.
+- Praetor gewaehrt den Sui heredes die Vermoegensbesitzbestaetigung gegen das Testament.
+
+## Anforderungen
+
+- Suus heres muss im Testament entweder eingesetzt oder ausdruecklich enterbt sein.
+- Stille Uebergehung loest contra tabulas-Anspruch aus.
+
+## Wirkung
+
+- Testament wird ueberlagert.
+- Suus heres erhaelt Vermoegensbesitz.
+
+## Verhaeltnis zur querela inofficiosi
+
+- BPCT: bei stiller Uebergehung sui heredes.
+- Querela: bei zu geringer Bedachtung naechster Verwandter.
+
+## Vergleich zu modernem Recht
+
+- § 2303 BGB Pflichtteil.
+- § 2306 BGB Beschraenkungen und Beschwerungen.
+
+## Pruefraster
+
+1. Suus heres uebergangen?
+2. Enterbung ausgesprochen?
+3. BPCT beantragt?
+
+## Output
+
+- Quellenmatrix.
+- Synopse.

--- a/roemisches-recht/skills/rom-147-legitimatio-und-erbfaehigkeit-roemischer-buerger/SKILL.md
+++ b/roemisches-recht/skills/rom-147-legitimatio-und-erbfaehigkeit-roemischer-buerger/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: rom-147-legitimatio-und-erbfaehigkeit-roemischer-buerger
+description: "Legitimatio und Erbfaehigkeit im roemischen Recht: wer konnte erben? Skill behandelt die Trennung zivilrechtlicher und praetorischer Erbenstellung Status civitatis als Voraussetzung Sklaven und Peregrini-Sonderregeln. Liefert Quellenmatrix."
+---
+
+# Rom 147 Legitimatio Und Erbfaehigkeit Roemischer Buerger
+
+## Aufgabe
+
+Skill fuer Erbfaehigkeit im roemischen Recht.
+
+## Allgemeine Erbfaehigkeit
+
+- Vorausgesetzt: status libertatis, status civitatis, status familiae.
+- Erbe wurde mit der Geburt erfasst (sui heredes).
+
+## Sklaven
+
+- Eigene Erbfaehigkeit nicht.
+- Konnten als instrumentum hereditatis im Testament eingesetzt werden, sofern manumissio im Testament miterklaert wurde.
+
+## Peregrini
+
+- Roemisches Erbrecht nicht direkt anwendbar.
+- Eigenes ius gentium oder Heimatrecht.
+
+## Sonderfaelle
+
+- Filii familias (Hausunterworfene Kinder): konnten erben, doch der Erwerb fiel an den pater familias.
+- Ab Augustus: peculium castrense und quasi-castrense als Sondervermoegen frei verfuegbar.
+
+## Constitutio Antoniniana 212
+
+- Verleihung des Buergerrechts an fast alle Reichsbewohner.
+- Erbfaehigkeit nun universell im Reich.
+
+## Pruefraster
+
+1. Status der Person?
+2. Vermoegen erbfaehig?
+3. Sonderregeln?
+
+## Output
+
+- Quellenmatrix.
+- Synopse.

--- a/roemisches-recht/skills/rom-148-codicilli-und-nachtragliche-erbverfuegungen/SKILL.md
+++ b/roemisches-recht/skills/rom-148-codicilli-und-nachtragliche-erbverfuegungen/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: rom-148-codicilli-und-nachtragliche-erbverfuegungen
+description: "Codicilli: nachtraegliche letztwillige Verfuegungen im roemischen Recht. Skill behandelt die ad-hoc-Form ihre Bindung an ein bestehendes Testament und die Bedeutung fuer Legate und Fideikommisse. Liefert Quellenmatrix."
+---
+
+# Rom 148 Codicilli Und Nachtragliche Erbverfuegungen
+
+## Aufgabe
+
+Skill fuer codicilli als nachtraegliche letztwillige Verfuegungen.
+
+## Rechtsquelle
+
+- D. 29.7 (De jure codicillorum).
+- Gaius, Institutiones II.270 ff.
+- Justinian Institutionen 2.25.
+
+## Tatbestand
+
+- Codicilli: Zusatzdokument zum Testament.
+- Brief- oder briefaehnliche Form.
+- Bestaetigt durch testamentum (codicilli testamentari) oder ohne Bezug (codicilli ab intestato).
+
+## Inhalt
+
+- Legate.
+- Fideikommisse.
+- Bestimmungen ueber Manumissionen.
+- Keine heredis institutio (das war dem Testament vorbehalten).
+
+## Folge
+
+- Wirksam neben dem Haupttestament.
+- Konnte Testament modifizieren, aber nicht ersetzen.
+
+## Vergleich zu modernem Recht
+
+- §§ 2253-2256 BGB Widerruf des Testaments.
+- § 2247 BGB nachtraegliche Aenderungen durch eigenhaendiges Testament.
+
+## Pruefraster
+
+1. Codicilli vorhanden?
+2. Bezug zum Testament?
+3. Inhalt zulaessig?
+
+## Output
+
+- Quellenmatrix.
+- Synopse.

--- a/roemisches-recht/skills/rom-149-fideicommissa-und-substitutionsformen/SKILL.md
+++ b/roemisches-recht/skills/rom-149-fideicommissa-und-substitutionsformen/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: rom-149-fideicommissa-und-substitutionsformen
+description: "Fideicommissa und Substitutionsformen: Treuhand- und Ersatzerbschaft im roemischen Recht. Skill behandelt die fideicommissum universale die substitutio pupillaris und substitutio vulgaris die Lockerung durch Justinian. Liefert Quellenmatrix."
+---
+
+# Rom 149 Fideicommissa Und Substitutionsformen
+
+## Aufgabe
+
+Skill fuer Treuhand und Ersatzerbschaft.
+
+## Fideicommissa
+
+- Treuhaenderische letztwillige Verfuegung.
+- Erbe oder Legatar wird verpflichtet, einen Vermoegensvorteil an einen Dritten weiterzugeben.
+- Ursprung: Schutzinstrument fuer Personen, die nicht erbfaehig waren (z. B. peregrini, Frauen mit Velleianum-Problem).
+
+## Senatusconsultum Trebellianum (56 n. Chr.)
+
+- Fideikommissar erhielt eigene Klage gegen den Fideikommittenten.
+- Verwandelt fideicommissum in echte Erbschaft.
+
+## Senatusconsultum Pegasianum (75 n. Chr.)
+
+- Quarta Falcidia: Treuhaender (Erbe) durfte 1/4 der Erbschaft fuer sich behalten.
+
+## Substitutio vulgaris
+
+- Ersatzeinsetzung fuer den Fall, dass der eingesetzte Erbe nicht erbt.
+- Reihenfolge.
+
+## Substitutio pupillaris
+
+- Ersatzeinsetzung fuer den Fall, dass das Hauskind (impubes) vor Volljaehrigkeit stirbt.
+
+## Justinian
+
+- Lockerung der Form-Strenge.
+- Fideicommissum universale faellt mit testamentary trust zusammen.
+
+## Vergleich zu modernem Recht
+
+- § 2100 ff. BGB Vor- und Nacherbe.
+- § 2096 BGB Ersatzerbe.
+- Trust im Common Law als funktionales Aequivalent.
+
+## Pruefraster
+
+1. Fideicommissum oder Substitution?
+2. Quarta Falcidia einschlaegig?
+3. Trebellianum-Wirkung?
+
+## Output
+
+- Quellenmatrix.
+- Synopse.

--- a/roemisches-recht/skills/rom-150-civitas-romana-erwerb-und-verlust/SKILL.md
+++ b/roemisches-recht/skills/rom-150-civitas-romana-erwerb-und-verlust/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: rom-150-civitas-romana-erwerb-und-verlust
+description: "Civitas Romana: Erwerb und Verlust des roemischen Buergerrechts. Skill behandelt Geburtserwerb adoptio Manumissio Naturalisationsdekrete capitis deminutio media und maxima sowie das Buergerrecht der Latini iuris Latini iuris veteris. Liefert Quellenmatrix und Pruefraster."
+---
+
+# Rom 150 Civitas Romana Erwerb Und Verlust
+
+## Aufgabe
+
+Skill fuer Erwerb und Verlust der civitas Romana.
+
+## Erwerbsarten
+
+### Geburtserwerb
+- Iure sanguinis: roemischer Vater + roemische Mutter.
+- Iure conubii: rechtsgueltige Ehe (matrimonium).
+- Bei nicht-conubium-faehigen Partnern: Status der Mutter zur Zeit der Empfaengnis.
+
+### Manumissio
+- Sklavenbefreiung durch dominus.
+- Drei klassische Formen: manumissio vindicta (vor Magistrat), censu (Einschreibung in die Zensus-Liste), testamento.
+- Manumittierter Sklave wurde libertus mit eingeschraenkter Buergerstellung.
+
+### Naturalisationsdekret
+- Verleihung durch Volksversammlung, Senat, Kaiser.
+- Vielfach an Soldaten nach 25 Dienstjahren (auxilia).
+
+### Lex Iulia et Plautia (90/89 v. Chr.)
+- Verleihung an Bundesgenossen Italiens nach dem Bundesgenossenkrieg.
+
+### Constitutio Antoniniana (212 n. Chr.)
+- Caracalla verlieh fast allen freien Reichsbewohnern das Buergerrecht.
+
+## Verlust
+
+### Capitis deminutio maxima
+- Verlust der Freiheit (z. B. Kriegsgefangenschaft).
+- Folge: Verlust auch von civitas und familia.
+
+### Capitis deminutio media
+- Verlust der civitas (z. B. Verbannung).
+- Freiheit blieb.
+
+### Capitis deminutio minima
+- Aenderung der Familienstellung (adoptio, Heirat in manus, Verstoss).
+- Buergerschaft blieb.
+
+## Vergleich zu modernem Recht
+
+- § 4 StAG Erwerb der deutschen Staatsangehoerigkeit.
+- §§ 17 ff. StAG Verlust.
+
+## Pruefraster
+
+1. Erwerbsart?
+2. Vorgaengerstatus?
+3. Capitis deminutio eingetreten?
+
+## Output
+
+- Quellenmatrix.
+- Synopse.

--- a/roemisches-recht/skills/rom-151-status-libertatis-status-civitatis-status-familiae/SKILL.md
+++ b/roemisches-recht/skills/rom-151-status-libertatis-status-civitatis-status-familiae/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: rom-151-status-libertatis-status-civitatis-status-familiae
+description: "Status-Lehre: status libertatis status civitatis status familiae als drei Achsen der roemischen Personenrechtsstellung. Skill behandelt das Zusammenspiel die rechtlichen Konsequenzen und die Wechselwirkungen mit Eigentums- und Erbrecht. Liefert Quellenmatrix."
+---
+
+# Rom 151 Status Libertatis Status Civitatis Status Familiae
+
+## Aufgabe
+
+Skill fuer die roemische Status-Lehre.
+
+## Drei Achsen
+
+### Status libertatis
+- Frei oder Sklave.
+- Sklaven sind res, nicht personae.
+- Befreite (liberti) haben eingeschraenkte Buergerstellung.
+
+### Status civitatis
+- Cives Romani (Vollbuerger).
+- Latini (eingeschraenkte Buergerrechte).
+- Peregrini (Auslaender, oft mit eigenem Heimatrecht).
+- Dediticii (Unterworfene ohne Buergerrechte).
+
+### Status familiae
+- Pater familias (Hausvater, sui iuris).
+- Filius familias (Hausunterworfene Kinder).
+- Sklaven im Haus (servi).
+
+## Wechselwirkungen
+
+- Cives Romani sui iuris: volle Rechtsstellung.
+- Cives Romani filii familias: vermoegensrechtlich gebunden, aber buergerrechtlich frei.
+- Liberti: cives, aber mit operae-Pflichten gegenueber dem ehemaligen dominus.
+
+## Folgen fuer Vermoegen und Erbrecht
+
+- Filius familias kann nicht selbststaendig Eigentum erwerben (Erwerb faellt an pater).
+- Sklaven erwerben fuer den dominus.
+- Cives Romani peregrini-Ehe: Kinder folgen dem niedrigeren Status.
+
+## Rechtsquelle
+
+- Gaius, Institutiones I.9-200.
+- D. 1.5-1.7.
+
+## Pruefraster
+
+1. Welcher status libertatis?
+2. Welcher status civitatis?
+3. Welcher status familiae?
+4. Folgen fuer das konkrete Geschaeft?
+
+## Output
+
+- Quellenmatrix.
+- Status-Diagramm.

--- a/roemisches-recht/skills/rom-152-civis-romanus-vs-latinus-vs-peregrinus/SKILL.md
+++ b/roemisches-recht/skills/rom-152-civis-romanus-vs-latinus-vs-peregrinus/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: rom-152-civis-romanus-vs-latinus-vs-peregrinus
+description: "Civis Romanus vs. Latinus vs. Peregrinus: drei Buergerstaufen im roemischen Reich. Skill behandelt die Unterscheidung Bewegungs-Rechte (ius migrationis) Eherecht (ius conubii) Handelsrecht (ius commercii) und prozessuale Stellung. Liefert Pruefraster."
+---
+
+# Rom 152 Civis Romanus Vs Latinus Vs Peregrinus
+
+## Aufgabe
+
+Skill fuer die Unterscheidung der drei Hauptbuergerschaften.
+
+## Civis Romanus
+
+- Vollrechte: ius commercii, ius conubii, ius suffragii, ius honorum.
+- Schutz durch roemisches ius civile.
+- Provocatio ad populum (Berufung an die Volksversammlung).
+
+## Latinus
+
+### Latini veteres
+- Buerger der alten latinischen Staedte Italiens.
+- Voll ius commercii und ius conubii (bei Latini prisci nominis).
+- Eingeschraenktes ius suffragii (nur bei Anwesenheit in Rom).
+
+### Latini coloniarii
+- Buerger der lateinischen Kolonien.
+- Eingeschraenktere Rechte.
+
+### Latini Iuniani
+- Durch Lex Iunia (19 v. Chr. oder 17 v. Chr.) geschaffene Kategorie freigelassener Sklaven mit Latiner-Status.
+- Beschraenkte Vermoegensvererbung (bei Tod fiel Vermoegen an den ehemaligen dominus zurueck).
+
+## Peregrinus
+
+- Auslaender (nicht-Buerger).
+- Eigener status nach Heimatrecht.
+- Vor Praetor peregrinus.
+- Eingeschraenktes ius commercii ueber ius gentium.
+- Kein ius conubii.
+
+## Wirtschaftliche Wirkung
+
+- Civis: konnte alle Vertragstypen schliessen.
+- Latinus: meist gleichgestellt im Geschaeftsverkehr.
+- Peregrinus: Recourse auf ius gentium-Vertragstypen (stipulatio, locatio conductio).
+
+## Pruefraster
+
+1. Welcher Buergerstatus?
+2. Welche Rechte?
+3. Welches Verfahren?
+
+## Output
+
+- Quellenmatrix.
+- Synopse.

--- a/roemisches-recht/skills/rom-153-constitutio-antoniniana-212/SKILL.md
+++ b/roemisches-recht/skills/rom-153-constitutio-antoniniana-212/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: rom-153-constitutio-antoniniana-212
+description: "Constitutio Antoniniana 212 n. Chr.: allgemeine Buergerrechtsverleihung durch Caracalla. Skill behandelt die Reichweite die mutmasslichen Motive (Steuern aus vicesima hereditatum) die Beschraenkung auf bestimmte dediticii sowie die rechtshistorische Folge. Liefert Quellenmatrix."
+---
+
+# Rom 153 Constitutio Antoniniana 212 Allgemeine Buergerrechtsverleihung
+
+## Aufgabe
+
+Skill fuer die Constitutio Antoniniana.
+
+## Rechtsquelle
+
+- Papyrus Gissensis 40 (Hauptquelle, mit Lakunen).
+- Cassius Dio, Historia Romana 78.9.
+- D. 1.5.17 (Ulpian).
+
+## Tatbestand
+
+- Caracalla verleiht 212 n. Chr. allen freien Reichsbewohnern (mit Ausnahme der dediticii) das roemische Buergerrecht.
+
+## Reichweite
+
+- Praktisch fast vollstaendig: in der gesamten Mittelmeerwelt einschliesslich der Provinzen.
+- Ausnahme: dediticii Aelianer (juristisch streitige Kategorie).
+
+## Motive
+
+- Steuern: vicesima hereditatum (5 Prozent Erbschaftssteuer) galt nur fuer cives Romani.
+- Erweiterung der Steuerbasis.
+- Ideologisch: einheitliches Reich.
+
+## Rechtshistorische Folge
+
+- Universalisierung des ius civile als Reichsrecht.
+- Verschwinden des praktischen Unterschieds zwischen ius civile und ius gentium.
+- Vorbereitung der spaeteren Reichscodifizierung (Codex Theodosianus, Justinianus).
+
+## Folgen fuer das Privatrecht
+
+- Vereinheitlichung des Privatrechts.
+- Aufhebung der peregrini-Sonderstellung.
+- Lateinische Tochterrechte (frueh entstehend in Provinzen) gewinnen an Einfluss.
+
+## Pruefraster
+
+1. Zeitpunkt vor oder nach 212?
+2. Personenkreis (auch dediticii)?
+3. Wirkung auf konkretes Geschaeft?
+
+## Output
+
+- Quellenmatrix.
+- Memo zur rechtshistorischen Wirkung.

--- a/roemisches-recht/skills/rom-154-ius-conubii-und-ius-commercii/SKILL.md
+++ b/roemisches-recht/skills/rom-154-ius-conubii-und-ius-commercii/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: rom-154-ius-conubii-und-ius-commercii
+description: "Ius conubii und ius commercii: zentrale Privatrechtsrechte des roemischen Buergerrechts. Skill behandelt das Recht zur rechtsgueltigen Ehe (matrimonium) und das Recht zum Abschluss zivilrechtlicher Vertraege das Verhaeltnis zur usucapio und mancipatio. Liefert Quellenmatrix."
+---
+
+# Rom 154 Ius Conubii Und Ius Commercii
+
+## Aufgabe
+
+Skill fuer ius conubii und ius commercii.
+
+## Ius conubii
+
+- Recht zur Eingehung einer rechtsgueltigen Ehe (matrimonium iustum).
+- Voraussetzung: beide Partner haben ius conubii.
+- Folge bei iustum matrimonium: Kinder folgen Vater (status patris); patria potestas; eheliches Gueterrecht.
+
+## Ius commercii
+
+- Recht zum Abschluss aller zivilrechtlichen Vertraege nach ius civile.
+- Mancipatio, in iure cessio, stipulatio, usucapio.
+- Voraussetzung fuer den Zugang zum praetor urbanus.
+
+## Verhaeltnis
+
+- Cives Romani: voll beide Rechte.
+- Latini: i. d. R. beide Rechte (mit Sondervorschriften).
+- Peregrini: kein ius conubii, eingeschraenktes ius commercii ueber ius gentium-Vertragstypen.
+
+## Mischehen
+
+- Civis Romanus + Peregrina (oder umgekehrt): kein matrimonium iustum.
+- Lex Minicia (90 v. Chr.): Kinder folgen dem niedrigeren Status.
+- Folge: keine patria potestas, kein iure civili-Erbe.
+
+## Vergleich zu modernem Recht
+
+- Recht auf Eheschliessung Art. 6 GG.
+- Vertragsfreiheit Art. 2 GG.
+- DSGVO-Pendant findet sich nicht in den status-Begriffen.
+
+## Pruefraster
+
+1. Buergerstatus beider Partner?
+2. Ius conubii vorhanden?
+3. Welche Vertragsform?
+
+## Output
+
+- Quellenmatrix.
+- Synopse.

--- a/roemisches-recht/skills/rom-155-ius-suffragii-und-ius-honorum/SKILL.md
+++ b/roemisches-recht/skills/rom-155-ius-suffragii-und-ius-honorum/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: rom-155-ius-suffragii-und-ius-honorum
+description: "Ius suffragii und ius honorum: politische Buergerrechte im roemischen Recht. Skill behandelt das Stimmrecht in den Volksversammlungen und die Wahlbarkeit zu Aemtern Einschraenkungen fuer Latini und Frauen sowie das Verhaeltnis zum status civitatis. Liefert Quellenmatrix."
+---
+
+# Rom 155 Ius Suffragii Und Ius Honorum
+
+## Aufgabe
+
+Skill fuer politische Buergerrechte im roemischen Recht.
+
+## Ius suffragii
+
+- Stimmrecht in den Volksversammlungen (comitia centuriata, tributa, curiata).
+- Civis Romanus: voll.
+- Cives sine suffragio: keine politische Stimme, aber zivilrechtliche Buergerrechte (z. B. Bewohner einzelner Halb-Buergerschaftsstaedte).
+- Latini: eingeschraenkt, nur bei Anwesenheit in Rom.
+
+## Ius honorum
+
+- Wahlbarkeit zu Aemtern (Quaestur, Aedilitaet, Praetur, Konsulat, Zensur).
+- Voraussetzung: civis sui iuris, vermoegen (census), bestimmtes Alter.
+
+## Einschraenkungen
+
+- Frauen: kein politisches Buergerrecht.
+- Liberti: kein ius honorum (erst Nachkommen freier libertini erhielten Aemtertaehigkeit).
+- Senatorenfamilien: Geburtsrecht zum cursus honorum.
+
+## Vergleich zu modernem Recht
+
+- Aktives und passives Wahlrecht Art. 38 GG.
+- Geschlechtergleichstellung Art. 3 GG.
+
+## Pruefraster
+
+1. Welche politische Stellung?
+2. Welche Wahlbarkeit?
+
+## Output
+
+- Quellenmatrix.
+- Synopse.

--- a/roemisches-recht/skills/rom-156-rechtsfolgen-fuer-peregrini-und-ius-gentium/SKILL.md
+++ b/roemisches-recht/skills/rom-156-rechtsfolgen-fuer-peregrini-und-ius-gentium/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: rom-156-rechtsfolgen-fuer-peregrini-und-ius-gentium
+description: "Rechtsfolgen fuer Peregrini und das ius gentium. Skill behandelt die Stellung der Auslaender vor dem praetor peregrinus die Vertragstypen des ius gentium (stipulatio locatio conductio mutuum) und die Anerkennung von Heimatrecht. Liefert Quellenmatrix."
+---
+
+# Rom 156 Rechtsfolgen Fuer Peregrini Und Ius Gentium
+
+## Aufgabe
+
+Skill fuer Peregrini-Recht.
+
+## Praetor peregrinus
+
+- Eingefuehrt 242 v. Chr.
+- Zustaendigkeit fuer Streitigkeiten zwischen Peregrini und Cives oder zwischen Peregrini untereinander.
+- Edictum peregrinum als eigene Edikts-Sammlung.
+
+## Ius gentium
+
+- "Voelker-Recht" im Sinne des allen Voelkern gemeinsamen Rechts.
+- Vertragstypen: stipulatio, locatio conductio, mutuum, commodatum, depositum, mandatum.
+- Eigentumserwerb durch traditio (statt mancipatio).
+
+## Anerkennung des Heimatrechts
+
+- Praetor peregrinus konnte das Heimatrecht des Peregrinus heranziehen.
+- Aegypten: griechisches Recht der Ptolemaer-Zeit blieb teilweise erhalten.
+- Provinzialrecht und ius gentium ueberlagerten sich.
+
+## Lex Iulia et Plautia
+
+- Stufen weiser Buergerrechtsverleihung nach dem Bundesgenossenkrieg (90/89 v. Chr.).
+
+## Constitutio Antoniniana 212
+
+- Aufhebung der peregrini-Sonderstellung im praktischen Sinn.
+
+## Pruefraster
+
+1. Peregrinus-Status?
+2. Welches Heimatrecht?
+3. Welche Vertragstypen?
+
+## Output
+
+- Quellenmatrix.
+- Synopse.

--- a/roemisches-recht/skills/rom-157-doppelte-buergerschaft-und-municipien/SKILL.md
+++ b/roemisches-recht/skills/rom-157-doppelte-buergerschaft-und-municipien/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: rom-157-doppelte-buergerschaft-und-municipien
+description: "Doppelte Buergerschaft und Municipien. Skill behandelt die roemisch-rechtliche Stellung der municipes als Doppelbuerger (Buerger der Heimatstadt und Roms) das Verhaeltnis zwischen Stadtrecht und Reichsrecht. Liefert Quellenmatrix."
+---
+
+# Rom 157 Doppelte Buergerschaft Und Municipien
+
+## Aufgabe
+
+Skill fuer Doppelbuergerschaft im roemischen Reich.
+
+## Municipes
+
+- Buerger einer municipium (selbstverwaltete Stadt mit roemischem Buergerrecht).
+- Doppelte Buergerschaft: Stadt und Rom.
+- Origo (Geburtsstadt) und domicilium (Wohnsitz) wurden unterschieden.
+
+## Rechtsfolgen
+
+- Munera (Gemeindelasten) der Heimatstadt.
+- Roemisches ius civile in privaten Rechtsstreitigkeiten.
+- Stadtrecht (ius municipale) galt subsidiaer.
+
+## Lex Iulia municipalis (45 v. Chr.)
+
+- Reorganisation der Municipalverwaltung.
+- Einheitliches Verwaltungsschema.
+
+## Edictum perpetuum
+
+- Vereinheitlichung der praetorischen Edikte (zugeschrieben Hadrian 130-138 n. Chr.).
+
+## Vergleich zu modernem Recht
+
+- Doppelte Staatsangehoerigkeit nach § 4 StAG / § 25 StAG.
+
+## Pruefraster
+
+1. Origo und domicilium?
+2. Welche Pflichten?
+3. Welches Stadtrecht?
+
+## Output
+
+- Quellenmatrix.
+- Synopse.

--- a/roemisches-recht/skills/rom-158-cives-sine-suffragio-und-municipia-sine-iure-suffragii/SKILL.md
+++ b/roemisches-recht/skills/rom-158-cives-sine-suffragio-und-municipia-sine-iure-suffragii/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: rom-158-cives-sine-suffragio-und-municipia-sine-iure-suffragii
+description: "Cives sine suffragio und municipia sine iure suffragii: roemische Halbbuerger und ihre Gemeinden. Skill behandelt die historische Konstruktion der Buergerschaft ohne Stimmrecht ihre Rechtsfolgen und die Aufhebung im 1. Jh. v. Chr. Liefert Quellenmatrix."
+---
+
+# Rom 158 Cives Sine Suffragio Und Municipia Sine Iure Suffragii
+
+## Aufgabe
+
+Skill fuer Halbbuergerschaft.
+
+## Cives sine suffragio
+
+- Buerger mit ius commercii und ius conubii, ohne ius suffragii und ohne ius honorum.
+- Erstmals geschaffen 338 v. Chr. fuer Anagnia und andere besiegte Staedte des Latinerkriegs.
+
+## Municipia sine iure suffragii
+
+- Gemeinden mit cives sine suffragio.
+- Reichsrechtlich roemisches Privatrecht.
+- Politisch keine Beteiligung.
+
+## Wechsel zu vollem Buergerrecht
+
+- Lex Iulia 90 v. Chr.: Verleihung des Vollbuergerrechts an Bundesgenossen Italiens.
+- Aufhebung der Halbbuergerschaft im 1. Jh. v. Chr.
+
+## Rechtshistorische Bedeutung
+
+- Erster Schritt zur Reichseinheit.
+- Vorbild fuer die spaetere universelle Buergerschaftsverleihung.
+
+## Pruefraster
+
+1. Welche Gemeinde?
+2. Welcher Buergerstatus?
+3. Welche Aenderungen im Zeitverlauf?
+
+## Output
+
+- Quellenmatrix.
+- Synopse.

--- a/roemisches-recht/skills/rom-159-romanisierung-der-provinzen-und-stadtrecht/SKILL.md
+++ b/roemisches-recht/skills/rom-159-romanisierung-der-provinzen-und-stadtrecht/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: rom-159-romanisierung-der-provinzen-und-stadtrecht
+description: "Romanisierung der Provinzen und Stadtrecht: kommunale Selbstverwaltung im Reich. Skill behandelt die ius latinum-Verleihung an Provinzialstaedte (vor allem in Spanien Britannien Gallien) die Lex Irnitana als Beispiel und die Wirkung auf das ius civile. Liefert Quellenmatrix."
+---
+
+# Rom 159 Romanisierung Der Provinzen Und Stadtrecht
+
+## Aufgabe
+
+Skill fuer die Romanisierung der Provinzen.
+
+## Ius Latinum
+
+- Verleihung des "lateinischen Rechts" an Provinzialstaedte.
+- Status zwischen peregrinus und civis Romanus.
+- Beamte (Duumviri, Aedili, Quaestoren) erwarben durch Amtsausuebung das volle Buergerrecht.
+
+## Lex Irnitana
+
+- Gemeindegesetz der Stadt Irni in der Baetica (Spanien).
+- 91 n. Chr. (Flavische Zeit).
+- Stadtrechtsverfassung mit ueber 90 Kapiteln.
+- Enthaltene Bestimmungen zu Magistratsaemtern, Senat, Gerichtsverfahren, kommunalen Aufgaben.
+
+## Spanien
+
+- Vespasian verlieh 73/74 n. Chr. das ius Latinum allen spanischen Gemeinden (Edictum Vespasiani).
+- Massive Romanisierung.
+
+## Britannien
+
+- Spaetere und unvollstaendigere Romanisierung.
+
+## Gallien
+
+- Frueh teilweise Romanisierung (Gallia Narbonensis).
+
+## Verhaeltnis zum Reichsrecht
+
+- Roemisches Privatrecht in Provinzialstaedten.
+- Stadtrecht (ius municipale) subsidiaer.
+- Praetor und Statthalter (procurator, propraetor) als Gerichtshof.
+
+## Pruefraster
+
+1. Welche Provinz?
+2. Welcher Buergerstatus?
+3. Welche Quellen (Stadtrechte, Inschriften)?
+
+## Output
+
+- Quellenmatrix.
+- Memo zur Romanisierung.


### PR DESCRIPTION
50 neue Skills im `roemisches-recht`-Plugin (von 140 auf 190), in fünf Clustern.

## Cluster 1 — Konkurs und Anfechtung (12)
- `rom-110-vollstreckungsrecht-personal-und-vermoegen` (manus iniectio, nexum, Lex Poetelia Papiria)
- `rom-111-cessio-bonorum-lex-iulia` (D. 42.3, Vorläufer der Restschuldbefreiung)
- `rom-112-missio-in-bona-praetorische-vermoegensergreifung` (D. 42.4-5)
- `rom-113-bonorum-venditio-versteigerung-und-bonorum-emptor` (Gaius III.77 ff., infamia-Folge)
- `rom-114-bonorum-distractio-vermoegenseinzelverkauf`
- **`rom-115-actio-pauliana-glaeubigeranfechtung`** (D. 42.8 — eventus damni / consilium fraudis / scientia des Dritten)
- `rom-116-actio-pauliana-voraussetzungen-und-beweisrecht`
- `rom-117-interdictum-fraudatorium-und-restitutio-in-integrum`
- **`rom-118-paulianische-anfechtung-fortwirkung-anfg-inso`** (Synopse zu §§ 129 ff. InsO und AnfG)
- `rom-119-konkursrechtliche-stellung-des-magister-bonorum`
- `rom-120-konkurs-und-glaeubigerquoten-rangfolge`
- `rom-121-restitutio-in-integrum-ob-aetatem-vermoegensschutz`

## Cluster 2 — Seehandel (12)
- **`rom-122-seehandel-lex-rhodia-de-iactu`** (D. 14.2 — Generalhavarie, Vorbild York-Antwerp Rules)
- **`rom-123-fenus-nauticum-seedarlehen`** (D. 22.2 — Vorläufer Schiffsversicherung mit Risikotragung)
- `rom-124-actio-exercitoria-reederhaftung` (D. 14.1)
- `rom-125-actio-institoria-prokuristenhaftung` (D. 14.3)
- `rom-126-receptum-nautarum-cauponum-stabulariorum` (D. 4.9 — custodia-Haftung der Gastwirte und Reeder)
- `rom-127-magister-navis-und-mehrere-reeder`
- `rom-128-seerouten-ostia-alexandria-und-importzoll`
- `rom-129-getreidehandel-cura-annonae`
- `rom-130-import-aus-orient-aurum-silberbarren` (Muziris-Papyrus, Periplus Maris Erythraei)
- `rom-131-seeunglueck-versicherung-und-risiko`
- `rom-132-actio-tributoria-handelssklave-sondervermoegen` (D. 14.4)
- `rom-133-stellio-und-schmuggel-roemische-zollordnung` (D. 39.4, D. 47.20)

## Cluster 3 — Bürgschaft und Versicherung (8)
- `rom-134-buergschaftstypen-sponsio-fidepromissio-fideiussio` (Gaius III.115-127)
- `rom-135-beneficium-divisionis-und-excussionis` (Justinian Novelle 4)
- `rom-136-intercessio-frauen-senatusconsultum-velleianum` (D. 16.1)
- `rom-137-pignus-conventum-hypotheca-praxisfaelle` (D. 20.1, invecta et illata)
- `rom-138-mandatum-pecuniae-credendae-bankvertrag` (D. 17.1.6.3)
- `rom-139-versicherung-und-risiko-im-roemischen-recht`
- `rom-140-tutela-fiduciaria-und-pflegevormundschaft-vermoegen`
- `rom-141-mandatum-qualificatum-buergschaftsersatz`

## Cluster 4 — Testament und Erbrecht (8)
- `rom-142-testamentum-calatis-comitiis-und-in-procinctu`
- `rom-143-testamentum-per-aes-et-libram-mancipationstestament` (Gaius II.103 ff.)
- `rom-144-testamentum-praetorium-tabulae-septies-signatae`
- `rom-145-querela-inofficiosi-testamenti-pflichtteil` (D. 5.2 — portio legitima 1/4, später Justinian 1/3 bzw. 1/2)
- `rom-146-bonorum-possessio-contra-tabulas` (D. 37.4)
- `rom-147-legitimatio-und-erbfaehigkeit-roemischer-buerger`
- `rom-148-codicilli-und-nachtragliche-erbverfuegungen` (D. 29.7)
- `rom-149-fideicommissa-und-substitutionsformen` (SC Trebellianum 56, SC Pegasianum 75, quarta Falcidia)

## Cluster 5 — Bürgerrecht (10)
- `rom-150-civitas-romana-erwerb-und-verlust`
- `rom-151-status-libertatis-status-civitatis-status-familiae` (Gaius I.9-200)
- `rom-152-civis-romanus-vs-latinus-vs-peregrinus`
- **`rom-153-constitutio-antoniniana-212`** (Caracalla, Pap. Giss. 40, D. 1.5.17 Ulpian)
- `rom-154-ius-conubii-und-ius-commercii`
- `rom-155-ius-suffragii-und-ius-honorum`
- `rom-156-rechtsfolgen-fuer-peregrini-und-ius-gentium`
- `rom-157-doppelte-buergerschaft-und-municipien` (Lex Iulia municipalis 45 v. Chr.)
- `rom-158-cives-sine-suffragio-und-municipia-sine-iure-suffragii`
- `rom-159-romanisierung-der-provinzen-und-stadtrecht` (Lex Irnitana 91 n. Chr., Edictum Vespasiani)

## Methodik

- Quellenanker durchgehend auf Digestenstellen (D. X.Y.Z), Gaius-Institutionen, Codex Theodosianus/Justinianus.
- Vergleichende Synopse zu modernen Pendants: InsO, AnfG, BGB, HGB, VVG, StAG, GG.
- Vorsichtige Datumsangaben mit "vor Zitat verifizieren" wo strittig.

## Validator

`node scripts/validate-plugin-structure.mjs` -> OK. Slug `rom-153-constitutio-antoniniana-212` (vorher länger, gekürzt auf 36 Zeichen).

---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_