### PR TITLE
feat(bau-architektenrecht): 40 Skills Bautraegervertrag-Pruefung MaBV Notar Vormerkung WEG Maengelhaftung Insolvenz (Plugin 54 -> 94)

### DIFF
--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-abnahme-formgerecht-640-bgb/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-abnahme-formgerecht-640-bgb/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: bautraeger-abnahme-formgerecht-640-bgb
+description: "Bautraeger-Abnahme formgerecht nach § 640 BGB. Skill klaert das Abnahmeverfahren die Voraussetzungen Vorbehalte (Maengelliste) und die Folgen der wirksamen Abnahme (Beginn Maengelhaftungsverjaehrung Umkehr Beweislast). Liefert Pruefraster."
+---
+
+# Bautraeger Abnahme Formgerecht 640 Bgb
+
+## Norm
+
+§ 640 BGB Abnahme — Erklaerung des Erwerbers, dass die Leistung vertragsgemaess erbracht ist.
+
+## Voraussetzungen
+
+- Leistung im Wesentlichen fertig.
+- Erwerber wird zur Abnahme aufgefordert.
+- Abnahmetermin vereinbart.
+
+## Vorbehalte
+
+- Maengelliste mit konkreten Punkten.
+- Schriftlicher Vorbehalt.
+
+## Folge Abnahme
+
+- Beginn der Verjaehrungsfrist § 634a BGB (5 Jahre fuer Bauwerk).
+- Umkehr der Beweislast: Erwerber muss spaetere Maengel beweisen.
+- Verguetungspflicht wird faellig.
+- Gefahrtragung geht auf Erwerber ueber.
+
+## Foerderung Bautraeger zur Abnahme
+
+- Bautraeger draengt oft auf Abnahme, um Verguetung zu erhalten und Maengelhaftungsfrist zu starten.
+- Erwerber sollte nicht abnehmen, wenn wesentliche Maengel bestehen.
+
+## Pruefraster
+
+1. Abnahme erforderlich?
+2. Leistung wesentlich fertig?
+3. Maengelliste vorbereitet?
+4. Abnahme oder Verweigerung?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-abnahmefiktion-clause-unwirksam/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-abnahmefiktion-clause-unwirksam/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: bautraeger-abnahmefiktion-clause-unwirksam
+description: "Bautraeger-Abnahmefiktion-Klausel und Unwirksamkeit. Skill behandelt die haeufige Bautraeger-Klausel zur fiktiven Abnahme bei Einzug oder nach Frist die BGH-Linie zu deren Unwirksamkeit und die Konsequenzen. Liefert Pruefraster."
+---
+
+# Bautraeger Abnahmefiktion Clause Unwirksam
+
+## Typische Klausel
+
+"Erfolgt die Abnahme nicht binnen 14 Tagen nach Bezugsfertigkeit, gilt die Leistung als abgenommen."
+
+oder
+
+"Mit Einzug in die Wohnung gilt die Abnahme als erklaert."
+
+## BGH-Linie
+
+- BGH staendige Rspr.: solche Klauseln sind in der Regel unwirksam, weil sie den Erwerber ohne ausreichende Belehrung in eine Abnahme drangen.
+- BGH VII ZR 137/16 (Az im Mandat verifizieren).
+
+## Voraussetzungen einer wirksamen Fiktionsklausel
+
+- Konkrete Frist (mind. 30 Tage).
+- Hinweis auf Konsequenzen.
+- Vor Bezug nicht.
+
+## Folge Unwirksamkeit
+
+- Keine Abnahme erfolgt.
+- Verjaehrungsfrist startet nicht.
+- Verguetung nicht faellig.
+
+## Pruefraster
+
+1. Welche Abnahmefiktionsklausel?
+2. BGH-Standard erfuellt?
+3. Bei Unwirksamkeit: Bautraeger muss um foermliche Abnahme bitten.

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-anlagen-zur-baubeschreibung/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-anlagen-zur-baubeschreibung/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: bautraeger-anlagen-zur-baubeschreibung
+description: "Anlagen zur Baubeschreibung beim Bautraegervertrag. Skill listet typische Anlagen Plaene Grundriss Schnitt Ansicht Wohnflaechenberechnung Energieausweis Teilungserklaerung. Folgen fehlender oder veralteter Anlagen."
+---
+
+# Bautraeger Anlagen Zur Baubeschreibung
+
+## Typische Anlagen
+
+### Plaene
+- Grundriss mit Massen.
+- Schnitte.
+- Ansichten Aussen.
+- Lageplan.
+
+### Wohnflaechenberechnung
+- Nach Wohnflaechenverordnung (WoFlV).
+- Hauptnutzflaeche und Nebennutzflaeche getrennt.
+
+### Energieausweis
+- Bedarfs- oder Verbrauchsausweis nach GEG.
+- Energieklasse.
+
+### Teilungserklaerung
+- Bei Wohnungseigentum.
+- Aufteilungsplan und Abgeschlossenheitsbescheinigung.
+
+### Baubeschreibung
+- Detaillierte Beschreibung als Anlage.
+
+### Sonderwunschliste
+- Optional, mit Preisangabe.
+
+## Probleme
+
+### Anlage fehlt
+- Vertrag ist unklar.
+- Erwerber kann nicht pruefen, was er kauft.
+
+### Anlage veraltet
+- Aktualisierungsklausel pruefen.
+
+### Anlage nicht zur Beurkundung mit ausgehaendigt
+- Notarverletzung.
+
+## Pruefraster
+
+1. Alle Anlagen vorhanden?
+2. Aktuelle Fassung?
+3. Bei Beurkundung uebergeben?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-aufflassungsvormerkung-883-bgb/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-aufflassungsvormerkung-883-bgb/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: bautraeger-aufflassungsvormerkung-883-bgb
+description: "Aufflassungsvormerkung § 883 BGB beim Bautraegervertrag. Skill klaert die zentrale Schutzfunktion der Vormerkung Rang Eintragung Voraussetzungen und Konsequenzen fuer den Erwerber bei Bautraegerinsolvenz. Liefert Pruefraster."
+---
+
+# Bautraeger Aufflassungsvormerkung 883 Bgb
+
+## Norm
+
+§ 883 BGB Vormerkung — Sicherungsinstrument fuer einen schuldrechtlichen Anspruch auf Eigentumsuebertragung.
+
+## Funktion beim Bautraegervertrag
+
+- Erwerber hat Anspruch auf Eigentumsuebertragung (Auflassung) — aber Eigentum geht erst nach Fertigstellung und vollstaendiger Zahlung ueber.
+- Vormerkung sichert die Rangstellung.
+- Schutz vor Verfuegungen des Bautraegers an Dritte.
+
+## Eintragung im Grundbuch
+
+- Antrag durch Notar.
+- Vor Bezahlung der ersten Rate eingetragen (im sicheren Modell).
+- Rang vor allen weiteren Belastungen.
+
+## Konsequenz bei Bautraegerinsolvenz
+
+- Vormerkungserwerber hat insolvenzfesten Anspruch.
+- Insolvenzverwalter muss Eigentum nach Vollzahlung uebertragen.
+- Bei nur teilweiser Zahlung: kompliziert — Skill `bautraeger-rueckabwicklung-bei-insolvenz`.
+
+## Pruefraster
+
+1. Vormerkung im Grundbuch eingetragen?
+2. Eintragungsdatum vor Zahlung?
+3. Rang gesichert?
+4. Belastungsfreiheit dazu?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-belehrungspflicht-17-beurkg/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-belehrungspflicht-17-beurkg/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: bautraeger-belehrungspflicht-17-beurkg
+description: "Notar-Belehrungspflicht nach § 17 BeurkG beim Bautraegervertrag. Skill klaert den Umfang die Pflicht zur Erlaeuterung der wirtschaftlichen Bedeutung und die Vorlauffrist von zwei Wochen nach § 17 Abs. 2a BeurkG fuer Verbraucher. Folgen bei Verstoss."
+---
+
+# Bautraeger Belehrungspflicht 17 Beurkg
+
+## Norm
+
+§ 17 BeurkG (Beurkundungsgesetz): Notar muss die rechtliche Tragweite des Geschaefts erlaeutern und sich vergewissern, dass die Beteiligten die rechtliche Tragweite erfassen.
+
+## § 17 Abs. 2a BeurkG — Verbraucher
+
+- Bei Vertraegen mit Verbraucher als Erwerber.
+- Vertragsentwurf muss dem Verbraucher in der Regel **zwei Wochen** vor Beurkundung zur Verfuegung stehen.
+- Ausnahmen: nur, wenn Verbraucher ausdruecklich zustimmt oder dringender Anlass.
+
+## Belehrungsinhalte beim Bautraegervertrag
+
+- Wirtschaftliche Bedeutung der Vorausleistung.
+- MaBV-Schutz und seine Grenzen.
+- Auflassungsvormerkung.
+- Verjaehrung Maengelhaftung.
+- Steuerliche Konsequenzen (Grunderwerbsteuer Spekulationsfrist).
+
+## Folge bei Verstoss
+
+- Notarielle Amtspflichtverletzung.
+- Schadensersatzhaftung nach § 19 BNotO.
+- Vertrag ist trotzdem wirksam — Schaden ist sekundaer.
+
+## Pruefraster
+
+1. Wann hat Erwerber den Entwurf erhalten?
+2. Wurden alle wesentlichen Punkte belehrt?
+3. Bei Versaeumnis: Schadensersatzanspruch?
+
+## BGH-Linie
+
+- BGH zur Belehrungspflicht — staendige Rspr.
+- BGH zu Vertraegen, in denen die 2-Wochen-Frist nicht eingehalten wurde.
+- Konkrete Az im Mandat live verifizieren.

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-bonitaetspruefung-warnsignale/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-bonitaetspruefung-warnsignale/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: bautraeger-bonitaetspruefung-warnsignale
+description: "Bautraeger-Bonitaetspruefung Warnsignale. Skill listet typische Warnsignale Mangelbild im Bau Verzoegerungen Personalfluktuation und gibt strategische Empfehlungen ob mit Vertrag fortzufahren. Liefert Risiko-Cockpit."
+---
+
+# Bautraeger Bonitaetspruefung Warnsignale
+
+## Warnsignale waehrend Bau
+
+### Verzoegerungen
+- Bau-Stand nicht plangerecht.
+- Wenig Aktivitaet auf der Baustelle.
+
+### Mangelbild
+- Falscher Materialeinsatz.
+- Verminderte Ausstattung gegenueber Baubeschreibung.
+
+### Personalfluktuation
+- Wechselnde Subunternehmer.
+- Bautraeger-Mitarbeiter verlassen das Unternehmen.
+
+### Kommunikationsschwankungen
+- Erwerber bekommen verspaetet Antworten.
+
+### Drittforderungen
+- Subunternehmer klagen Bautraeger.
+
+## Strategische Optionen
+
+1. Ratenzahlungen aussetzen (auf MaBV-Grundlage).
+2. Anwalt einschalten.
+3. Andere Erwerber kontaktieren.
+
+## Pruefraster
+
+1. Welche Warnsignale?
+2. Risiko-Hoehe?
+3. Aufruf zur Sicherung?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-eigenkapital-ueberpruefung-vor-vertrag/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-eigenkapital-ueberpruefung-vor-vertrag/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: bautraeger-eigenkapital-ueberpruefung-vor-vertrag
+description: "Bautraeger-Eigenkapital-Ueberpruefung vor Vertragsabschluss. Skill klaert was Erwerber selbst pruefen koennen Handelsregister Bonitaetsauskuenfte Referenzen aktuelle Schlagzeilen sowie Warnsignale. Liefert Pruefliste."
+---
+
+# Bautraeger Eigenkapital Ueberpruefung Vor Vertrag
+
+## Was pruefen
+
+### Handelsregisterauszug
+- Aktualitaet der Eintragung.
+- Stammkapital (mindestens?).
+- Geschaeftsfuehrer und sein Hintergrund.
+
+### Bonitaetsauskunft
+- Creditreform oder Schufa-Auskunft fuer den Bautraeger.
+
+### Vorhaben des Bautraegers
+- Anzahl laufender Bauvorhaben.
+- Referenzobjekte besichtigen.
+
+### Aktuelle Schlagzeilen
+- Insolvenzeroeffnungen?
+- Streit mit anderen Erwerbern?
+
+## Warnsignale
+
+- Unklare Rechtsform.
+- Junge GmbH ohne Kapital.
+- Geschaeftsfuehrer-Wechsel kurz vor Vertragsabschluss.
+- Foren mit Klagen.
+
+## Pruefraster
+
+1. Handelsregisterstand?
+2. Bonitaetsauskunft eingeholt?
+3. Referenzobjekte besichtigt?
+4. Internet-Recherche?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-elektronische-notarverkuendung-2023/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-elektronische-notarverkuendung-2023/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: bautraeger-elektronische-notarverkuendung-2023
+description: "Elektronische notarielle Verkuendung beim Bautraegervertrag. Skill klaert die Reform 2022/2023 zum elektronischen Notariat die Online-Beurkundung und ihre Anwendbarkeit auf Bautraegervertraege. Stand und Grenzen. Liefert Pruefraster."
+---
+
+# Bautraeger Elektronische Notarverkuendung 2023
+
+## Reform
+
+- BeurkG Reform 2022 / 2023 — elektronische Beurkundung in bestimmten Faellen.
+- Erstmals Online-Beurkundung moeglich (zunaechst beschraenkt auf bestimmte Sachverhalte).
+
+## Anwendbar auf Bautraegervertraege?
+
+- Im Stand 2024/2025: GmbH-Gruendung online moeglich; Grundstuecksgeschaefte typischerweise weiterhin in Praesenz erforderlich.
+- Aktuellen Stand des elektronischen Notariats vor Anwendung verifizieren — Reformlage in Bewegung.
+
+## Vorteile fuer Erwerber
+
+- Erleichterung der Beurkundung bei langen Anreisen.
+- Aufzeichnung der Beurkundung im Notarregister.
+
+## Nachteile
+
+- Manche Belehrungen verlieren an Gewicht ohne persoenlichen Kontakt.
+- Identifikation kann erschwert sein.
+
+## Pruefraster
+
+1. Persoenliche oder elektronische Beurkundung?
+2. Welche Notarvorschriften?
+3. Welche Sicherheit?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-fertigstellungsfrist-und-verzug/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-fertigstellungsfrist-und-verzug/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: bautraeger-fertigstellungsfrist-und-verzug
+description: "Bautraeger Fertigstellungsfrist und Verzug. Skill klaert die Vereinbarung der Bauzeit Verzugsfolgen Vertragsstrafe und das Verhaeltnis zur MaBV. BGH-Linie zu zu weiten Verzugsfristen. Liefert Pruefraster."
+---
+
+# Bautraeger Fertigstellungsfrist Und Verzug
+
+## Fertigstellungsfrist
+
+- Soll konkret datiert sein (z. B. "spaetestens 30.06.2027").
+- Vermeide Klauseln mit "voraussichtlich" oder "unter Vorbehalt der Wetterverhaeltnisse" allein.
+
+## Verzugsfolgen
+
+- § 280 Abs. 2 BGB iVm § 286 BGB: bei Verzug Schadensersatzanspruch.
+- Mahnung erforderlich, soweit nicht kalendermaessig bestimmt.
+
+## Vertragsstrafe
+
+- Pauschal je Tag Verzug ueblich (z. B. 0.05 Prozent des Vertragspreises).
+- Hoechstgrenze: 5 Prozent des Vertragspreises (BGH-Linie).
+
+## BGH zu weiten Verzugsfristen
+
+- BGH I ZR XX/XX Az verifizieren: Verzugsfristen ueber 6 Monate haeufig unangemessen.
+- Erwerber kann nach angemessener Frist zuruecktreten.
+
+## Pruefraster
+
+1. Fertigstellungsfrist konkret?
+2. Vertragsstrafe vereinbart?
+3. Hoehe der Vertragsstrafe angemessen?
+4. Bei Verzug: Mahnungs- und Klagestrategie?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-finanzierungsgrundschuld-belastungsfolge/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-finanzierungsgrundschuld-belastungsfolge/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: bautraeger-finanzierungsgrundschuld-belastungsfolge
+description: "Bautraeger-Finanzierungsgrundschuld und Belastungsfolge. Skill klaert wie die Bautraegerfinanzierung mit der Erwerberzahlung verzahnt ist und welche Rolle die Globalgrundschuld spielt. Liefert Pruefraster."
+---
+
+# Bautraeger Finanzierungsgrundschuld Belastungsfolge
+
+## Globalgrundschuld
+
+- Bautraeger schliesst Kredit mit Bank ab.
+- Bank erhaelt Globalgrundschuld auf das gesamte Grundstueck.
+
+## Pfandentnahmen (Pfandfreigaben)
+
+- Mit jedem Erwerber-Ratenzahlung gibt der Bautraeger einen Teil seiner Schuld bei der Bank an die Bank ab.
+- Bank gibt schrittweise Pfandfreigaben fuer einzelne Wohnungen.
+
+## Pflicht der Bank
+
+- Bank muss bei Vorliegen der Voraussetzungen die Pfandfreigabe erklaeren.
+- Bei Streit: BGB-Vertrag zwischen Bank und Bautraeger relevant; Erwerber hat oft Drittwirkung.
+
+## Pruefraster
+
+1. Bestehende Globalgrundschuld?
+2. Pfandfreigabevereinbarung mit Bank?
+3. Pfandentnahmen bei Ratenzahlungen?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-gemeinschaftliche-maengelverfolgung-weg/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-gemeinschaftliche-maengelverfolgung-weg/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: bautraeger-gemeinschaftliche-maengelverfolgung-weg
+description: "Gemeinschaftliche Maengelverfolgung in der WEG. Skill klaert wie die Wohnungseigentuemergemeinschaft Maengel am Gemeinschaftseigentum verfolgt und welche Kompetenzen einzelnen Eigentuemern bleiben. Reform 2020. Liefert Pruefraster."
+---
+
+# Bautraeger Gemeinschaftliche Maengelverfolgung Weg
+
+## Norm
+
+§§ 9a, 18 WEG (Reform 2020): Maengelansprueche am Gemeinschaftseigentum werden durch die WEG verfolgt.
+
+## WEG-Reform 2020
+
+- Vor 2020: einzelner Eigentuemer konnte Maengel am Gemeinschaftseigentum geltend machen.
+- Seit 2020: nur noch die WEG (vertreten durch den Verwalter).
+- Beschluss der Eigentuemerversammlung ueber Geltendmachung erforderlich.
+
+## Sondereigentum
+
+- Maengelansprueche am Sondereigentum bleiben beim einzelnen Eigentuemer.
+- Maengel an Wohnungs-Innenwaenden, Bodenbelag, Sanitaer.
+
+## Streitfaelle
+
+- Manche Maengel sind sowohl Sonder- als auch Gemeinschaftseigentum betroffen (z. B. Lecken in der Wand).
+- Sorgfaeltige Abgrenzung.
+
+## Pruefraster
+
+1. Mangel am Sondereigentum oder Gemeinschaftseigentum?
+2. Bei Gemeinschaftseigentum: WEG-Beschluss eingeholt?
+3. Verwalter aktiv?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-grundbuchaufflassung-925-bgb/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-grundbuchaufflassung-925-bgb/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: bautraeger-grundbuchaufflassung-925-bgb
+description: "Aufflassung nach § 925 BGB beim Bautraegervertrag. Skill klaert die Form der Aufflassung den Zeitpunkt der Eigentumsuebertragung und das Verhaeltnis zur Vormerkung. Notarielle Beurkundung. Liefert Pruefraster."
+---
+
+# Bautraeger Grundbuchaufflassung 925 Bgb
+
+## Norm
+
+§ 925 BGB Aufflassung — formgerechte Einigung ueber die Eigentumsuebertragung des Grundstuecks.
+
+## Form
+
+- Notarielle Beurkundung erforderlich.
+- Beide Parteien zugleich anwesend (oder durch Vollmacht vertreten).
+
+## Zeitpunkt
+
+- Aufflassung typischerweise bei Vertragsschluss erklaert, aber Wirksamkeit aufgeschoben auf Bedingung vollstaendige Zahlung.
+- Eigentumseintragung im Grundbuch erfolgt nach Zahlung und Fertigstellung.
+
+## Bedingung
+
+- "Bedingungslose Aufflassung" gibt es nicht — die Bedingung ist die Zahlung.
+
+## Verhaeltnis zur Vormerkung
+
+- Vormerkung sichert den Anspruch auf Aufflassung.
+- Aufflassung mit Eintragung ist der eigentliche Eigentumserwerb.
+
+## Pruefraster
+
+1. Aufflassung notariell erklaert?
+2. Bedingungsklausel?
+3. Eintragung erfolgt?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-grundbuchgebuehren-rangwahrung/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-grundbuchgebuehren-rangwahrung/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: bautraeger-grundbuchgebuehren-rangwahrung
+description: "Grundbuchgebuehren und Rangwahrung beim Bautraegervertrag. Skill listet die typischen Gebuehren der Notar Grundbuchamt und Bank sowie die Aufteilung zwischen Bautraeger und Erwerber. Liefert Pruefraster."
+---
+
+# Bautraeger Grundbuchgebuehren Rangwahrung
+
+## Gebuehren
+
+### Notarkosten
+- Beurkundung Bautraegervertrag.
+- Vollzugsmassnahmen Auflassung Vormerkung.
+- Hoehe: nach GNotKG, Verhaeltnis zum Vertragswert (typisch 1.5 % der Vertragssumme insgesamt).
+
+### Grundbuchgebuehren
+- Eintragung Vormerkung.
+- Eintragung Auflassung.
+- Hoehe: nach GNotKG.
+
+### Grunderwerbsteuer
+- Je nach Bundesland 3.5 - 6.5 Prozent.
+- Berechnungsgrundlage: Kaufpreis Wohnung anteilig (auch Stellplatz).
+
+### Versicherungs- und Bankkosten
+- Ggf. Pfandfreigabegebuehren.
+
+## Aufteilung
+
+- Standardklausel: Erwerber traegt Notar Grundbuch Grunderwerbsteuer.
+- Bautraeger traegt eigene Loeschungs- und Verwaltungskosten.
+
+## Pruefraster
+
+1. Gebuehrenaufstellung im Vertrag?
+2. Aufteilung klar?
+3. Realistische Kalkulation?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-haftungsausschluss-307-bgb/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-haftungsausschluss-307-bgb/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: bautraeger-haftungsausschluss-307-bgb
+description: "Bautraeger-Haftungsausschluss und § 307 BGB. Skill klaert welche Haftungsklauseln im Bautraegervertrag wirksam und welche unwirksam sind insbesondere Maengelausschluss Haftungsbegrenzung Kardinalpflichten-Verletzung. Liefert Pruefraster."
+---
+
+# Bautraeger Haftungsausschluss 307 Bgb
+
+## Norm
+
+§ 307 BGB Inhaltskontrolle.
+
+## Unwirksame Klauseln
+
+### Pauschaler Haftungsausschluss
+- "Wir haften nicht fuer Maengel, soweit sie nicht erkennbar waren."
+- Unwirksam — Maengelhaftung darf nicht ueber § 634 BGB hinausgehend ausgeschlossen werden.
+
+### Maengelpauschalierung
+- "Bei Maengeln ist statt Beseitigung nur eine Pauschale zu zahlen."
+- Unwirksam.
+
+### Verkuerzung der Verjaehrung
+- "Maengelansprueche verjaehren in 2 Jahren."
+- Unwirksam — § 634a BGB beim Bauwerk 5 Jahre zwingend.
+
+### Ausschluss fuer einfache Fahrlaessigkeit
+- "Wir haften nur fuer Vorsatz und grobe Fahrlaessigkeit."
+- Unwirksam bei Verletzung Leben Koerper Gesundheit (§ 309 Nr. 7a BGB).
+- Bei sonstigen Schaeden: unwirksam, wenn Kardinalpflicht beruehrt.
+
+## Wirksame Klauseln
+
+### Haftungsbegrenzung auf Versicherungsdeckung
+- "Wir haften nur in Hoehe der Versicherungsdeckung." — meist unwirksam.
+
+### Begrenzung auf vertragstypische vorhersehbare Schaeden
+- Wirksam bei einfacher Fahrlaessigkeit.
+
+## Pruefraster
+
+1. Welche Klausel?
+2. § 307 / § 309 / § 634a BGB Verstoss?
+3. Kardinalpflicht beruehrt?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-insolvenz-konsequenzen-erwerber/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-insolvenz-konsequenzen-erwerber/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: bautraeger-insolvenz-konsequenzen-erwerber
+description: "Bautraeger-Insolvenz Konsequenzen fuer den Erwerber. Skill klaert die Risikobetrachtung Vormerkungsschutz nicht-fertiggestellte Wohnung Buergschaftsabruf MaBV-Vermoegenstrennung Forderungsanmeldung. Liefert Pruefraster."
+---
+
+# Bautraeger Insolvenz Konsequenzen Erwerber
+
+## Risiko-Konstellationen
+
+### Wohnung fertiggestellt aber noch nicht uebertragen
+- Erwerber hat Vormerkung im Grundbuch.
+- Insolvenzverwalter muss Eigentum gegen Restzahlung uebertragen.
+- Erwerber relativ gut geschuetzt.
+
+### Wohnung im Bau
+- MaBV-Buergschaft greift, wenn vorhanden.
+- Andernfalls: Erwerber wird Insolvenzglaeubiger fuer bisher gezahlte Raten.
+- Bisher vorhandenes Bauwerk wird ggf. von einem anderen Bautraeger fertiggestellt.
+
+### Wohnung noch nicht begonnen
+- Bei MaBV-Buergschaft: Buergschaft abrufen.
+- Andernfalls: Insolvenzglaeubiger.
+
+## Handlungsoptionen
+
+1. Vormerkung im Grundbuch pruefen (Rang!).
+2. Buergschaft auf Bestand und Bonitaet pruefen.
+3. Forderungsanmeldung im Insolvenzverfahren binnen Frist.
+4. Klage gegen Insolvenzverwalter auf Vollzug.
+
+## Pruefraster
+
+1. Bau-Stand?
+2. Vormerkung gesichert?
+3. Buergschaft vorhanden?
+4. Forderungsanmeldung erfolgt?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-leistungsbeschreibung-baubeschreibung/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-leistungsbeschreibung-baubeschreibung/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: bautraeger-leistungsbeschreibung-baubeschreibung
+description: "Leistungsbeschreibung und Baubeschreibung beim Bautraegervertrag. Skill klaert was zwingend in der Baubeschreibung stehen muss (Standards Ausstattung Materialien) Inhaltsfeinheit und Folgen mangelhafter Baubeschreibung. § 650l BGB Verbraucherbauvertrag. Liefert Pruefraster."
+---
+
+# Bautraeger Leistungsbeschreibung Baubeschreibung
+
+## § 650l BGB Verbraucherbauvertrag
+
+Seit 01.01.2018: Bautraegervertraege mit Verbrauchern sind Verbraucherbauvertraege im Sinne §§ 650i-650n BGB.
+
+## Inhalt Baubeschreibung
+
+§ 650j BGB: Bautraeger muss vor Vertragsschluss eine detaillierte Baubeschreibung uebergeben.
+
+### Erforderliche Inhalte
+- Art und Ausfuehrung der Leistungen (Innenausbau Bodenbelaege Sanitaer).
+- Konkrete Materialangaben (z. B. Daemmung WLG 035).
+- DIN- und EN-Standards.
+- Energetische Standards (z. B. KfW 40).
+- Heizungsart und Energietraeger.
+- Anlagen Aufzug Tiefgarage.
+
+### Verbindlichkeit
+- Baubeschreibung wird Vertragsbestandteil.
+- Abweichungen bedeuten Maengel.
+
+## Mangelhafte Baubeschreibung
+
+- Wenn unvollstaendig: Erwerber kann Ergaenzung verlangen.
+- Wenn nicht ausgehaendigt: Vertrag ist anfechtbar.
+- § 650l BGB: jederzeitige Aufzeichnung der vereinbarten Leistungen.
+
+## Pruefraster
+
+1. Baubeschreibung vorliegend?
+2. Materialien konkret bezeichnet?
+3. Standards genannt?
+4. Anlagen aufgelistet?
+5. Verbindlichkeit erklaert?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-mabv-buchfuehrungspflicht-10/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-mabv-buchfuehrungspflicht-10/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: bautraeger-mabv-buchfuehrungspflicht-10
+description: "MaBV § 10 Buchfuehrungspflicht. Skill klaert die Aufzeichnungspflichten des Bautraegers ueber alle Vorgaenge im Bauvorhaben Trennung der Konten Bilanz und Pruefberichte. Folgen bei Versaeumnis. Liefert Pruefraster."
+---
+
+# Bautraeger Mabv Buchfuehrungspflicht 10
+
+## Norm
+
+§ 10 MaBV: Bautraeger muss separate Aufzeichnungen ueber jedes Bauvorhaben fuehren. Aufzeichnungen aufzubewahren mindestens 5 Jahre.
+
+## Pflichten
+
+- Eingaenge und Ausgaben dokumentieren.
+- Bauverlauf dokumentieren.
+- Periodischer Pruefbericht (jaehrlich).
+
+## Folge bei Versaeumnis
+
+- Ordnungswidrigkeit (Bussgeld bis zu 5000 Euro).
+- Gewerberechtliche Konsequenzen.
+
+## Praxis Erwerber
+
+- Erwerber hat Anspruch auf Auskunft ueber den Stand des Bauvorhabens.
+- Bei Verweigerung: Klagewege.
+
+## Pruefraster
+
+1. Hat der Bautraeger ordentliche Buchfuehrung?
+2. Hat der Erwerber Einsicht erhalten?
+3. Versaeumnisse dokumentieren.

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-mabv-erweiterte-sicherheit-7/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-mabv-erweiterte-sicherheit-7/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: bautraeger-mabv-erweiterte-sicherheit-7
+description: "MaBV § 7 erweiterte Sicherheitsleistung — Alternative zum Ratenmodell. Skill klaert die Voraussetzungen Praxisfragen und das Risiko-Profil aus Erwerberperspektive. Liefert Pruefraster."
+---
+
+# Bautraeger Mabv Erweiterte Sicherheit 7
+
+## Vergleich zu § 3-Modell
+
+- § 3-Modell: Raten nach Baufortschritt (mit Schutz durch Baufortschritts-Pruefung).
+- § 7-Modell: volle Vorauszahlung gegen Sicherheit.
+
+## Bewertung aus Erwerberperspektive
+
+### § 7-Modell Vorteile
+- Klar definierte Sicherheit.
+- Bautraeger hat Liquiditaet — Bau laeuft fluessig.
+
+### § 7-Modell Risiken
+- Im Insolvenzfall: Erwerber abhaengig von Bonitaet des Buergen.
+- Bei schwacher Buergschaft: Erwerber haftet im Schlepptau.
+
+### § 3-Modell Vorteile
+- Erwerber zahlt nur fuer Geleistetes.
+- Bei Insolvenz: bisher gezahlte Raten sind ggf. werthaltig in Vermoegensauskehr.
+
+### § 3-Modell Risiken
+- Komplexer.
+- Streit ueber Baufortschritts-Stand.
+
+## Aktuelle Bonitaetspruefung
+
+- Vor Annahme der Buergschaft Erwerber bonitaetspruefung des Bautraegers UND der Bank.
+- Frueh: Bautraegerinsolvenz Pleiten typisch zwischen Baubeginn und Bezugsfertigkeit.
+
+## Pruefraster
+
+1. Welches Modell?
+2. Bonitaet aller Parteien?
+3. Erwerber-Risiko-Profil?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-mabv-gewerberechtliche-folgen/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-mabv-gewerberechtliche-folgen/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: bautraeger-mabv-gewerberechtliche-folgen
+description: "MaBV-Verstoss gewerberechtliche Folgen. Skill behandelt die gewerberechtlichen Sanktionen bei Verstoessen Bussgeld Erlaubnisentzug und das Verhaeltnis zum zivilrechtlichen Schutz. Liefert Pruefraster."
+---
+
+# Bautraeger Mabv Gewerberechtliche Folgen
+
+## Gewerberechtliche Sanktionen
+
+- Bussgeld nach § 18 MaBV bis 5000 Euro.
+- Bei wiederholten Verstoessen Erlaubnisentzug nach § 34c Abs. 4 GewO.
+- Anzeige durch geschaedigte Erwerber an Gewerbeaufsicht moeglich.
+
+## Zivilrechtlich
+
+- MaBV-Verstoss ist Schutzgesetz im Sinne § 823 Abs. 2 BGB. Schadensersatzanspruch des Erwerbers.
+- Vertragsklauseln, die der MaBV widersprechen, sind unwirksam.
+
+## Praxis
+
+- Erwerber kann bei Verstoss:
+  - Ratenzahlung verweigern.
+  - Vertragsanpassung verlangen.
+  - Schadensersatz fordern.
+  - Anzeige bei Gewerbeaufsicht erstatten.
+
+## Pruefraster
+
+1. Welcher MaBV-Verstoss?
+2. Zivilrechtliche Konsequenzen?
+3. Gewerberechtliche Anzeige sinnvoll?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-mabv-grundlagen-1-2/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-mabv-grundlagen-1-2/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: bautraeger-mabv-grundlagen-1-2
+description: "Makler- und Bautraegerverordnung (MaBV) Grundlagen. Skill behandelt das Anwendungsfeld der MaBV §§ 1 2 die definition Bautraeger und das Verhaeltnis zur Gewerbeordnung § 34c GewO. Liefert Pruefraster fuer Erwerber."
+---
+
+# Bautraeger Mabv Grundlagen 1 2
+
+## Anwendungsbereich
+
+§ 1 MaBV: Die MaBV gilt fuer Gewerbetreibende mit Erlaubnis nach § 34c Abs. 1 GewO — Bautraeger sind erfasst nach § 34c Abs. 1 Satz 1 Nr. 4 GewO (Bauvorhaben als Bautraeger oder Baubetreuer).
+
+## Bautraegerdefinition
+
+Bautraeger ist, wer wirtschaftlich auf eigene Rechnung Bauvorhaben fuer fremde Rechnung durchfuehrt. Typisch: Erwerb des Grundstuecks im eigenen Namen, Bau, Verkauf von Wohnungs- oder Teileigentum an Endkunden.
+
+## Verhaeltnis Bautraeger vs. Generaluebernehmer
+
+- Bautraeger: verkauft an Erwerber, der danach Eigentuemer wird.
+- Generaluebernehmer: fuehrt Bauvorhaben fuer fremden Auftraggeber durch, der bereits Eigentuemer ist.
+- Wichtig: nur fuer Bautraeger gilt § 3 MaBV — der zentrale Erwerberschutz.
+
+## Pruefraster fuer Erwerber
+
+1. Ist der Vertragspartner ein Bautraeger im Sinne § 34c GewO?
+2. Hat er eine gueltige Erlaubnis?
+3. Bewerbung als "Bautraeger" oder Tarnung als "Baubetreuung" / "GU"?
+4. Welche Schutzvorschriften greifen?
+
+## Aktuelle BGH-Linie
+
+- BGH-Linie staendige Rspr.: Verstoss gegen MaBV macht Klausel oder Zahlungsverlangen unwirksam — Erwerber kann zurueck.
+- BGH-Az im Mandat live verifizieren.

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-mabv-ratenplan-3-mabv/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-mabv-ratenplan-3-mabv/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: bautraeger-mabv-ratenplan-3-mabv
+description: "MaBV § 3 Ratenplan — 7 Raten nach Baufortschritt. Skill listet die einzelnen Raten in Prozent abhaengig vom Baufortschritt erkennt unzulaessige Vorausleistungen und gibt Tipps zur Pruefung. Liefert exakten Pruefraster."
+---
+
+# Bautraeger Mabv Ratenplan 3 Mabv
+
+## Norm
+
+§ 3 Abs. 2 MaBV: Maximal 7 Teilzahlungen nach Baufortschritt. Genauer Ratenkatalog vor Anwendung live verifizieren (juristische Stoffsammlung); typischerweise sieht der Katalog folgende Stufen vor:
+
+- 30 % nach Beginn der Erdarbeiten.
+- 28 % nach Rohbaufertigstellung einschliesslich Zimmererarbeiten.
+- 5,6 % nach Herstellung der Dachflaechen und Dachrinnen.
+- 2,1 % nach Rohinstallation Heizung.
+- 2,1 % nach Rohinstallation Sanitaer.
+- 2,1 % nach Rohinstallation Elektro.
+- 7 % nach Fenstereinbau, Verglasung.
+- 4,2 % nach Innenputz.
+- 2,1 % nach Estricharbeiten.
+- 2,8 % nach Fliesenarbeiten im Sanitaer.
+- 8,4 % nach bezugsfertiger Herstellung und Zug-um-Zug-Uebergabe.
+- 2,1 % nach Fassade.
+- 3,5 % nach vollstaendiger Fertigstellung.
+
+Summen koennen je nach Fassung der MaBV abweichen — Vor Mandatsmaessigen Beratung im aktuellen Gesetzestext im Detail pruefen.
+
+## Verbot Vorausleistung
+
+- Bautraeger darf nur Zahlungen nach Erreichen der jeweiligen Stufe verlangen.
+- Vorausleistung ohne Sicherung ist nichtig.
+
+## BGH-Linie
+
+- BGH staendige Rspr.: zu hohe Raten oder vorgezogene Zahlung machen Klausel unwirksam.
+- Erwerber kann zurueckhalten / zurueckfordern.
+
+## Pruefraster
+
+1. Welcher Stand?
+2. Welche Rate verlangt?
+3. Stand belegbar (Architektenbestaetigung, Photo)?
+4. Hoehe rechtmaessig?
+
+## Werkzeug Photo-Tagebuch
+
+- Erwerber empfohlen: bei jedem Bauabschnitt eigene Fotos mit Datum und GPS.
+- Wichtig fuer Beweisfuehrung.

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-mabv-sicherheit-2-buergschaft/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-mabv-sicherheit-2-buergschaft/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: bautraeger-mabv-sicherheit-2-buergschaft
+description: "MaBV § 2: Sicherheit fuer Vorausleistungen durch Buergschaft. Skill klaert die alternative Sicherheitsleistung statt Ratenzahlung nach Baufortschritt die Anforderungen an die Buergschaft (selbstschuldnerisch unbedingt unbefristet) und die Folgen ungueltiger Sicherheiten. Liefert Pruefraster."
+---
+
+# Bautraeger Mabv Sicherheit 2 Buergschaft
+
+## Norm
+
+§ 2 MaBV (in Verbindung mit § 7 MaBV): Bautraeger kann statt Zahlung nach Baufortschritt (§ 3 MaBV) eine **Sicherheit** in Hoehe der gesamten Vertragssumme stellen. Erwerber zahlt dann gegen die Sicherheit.
+
+## Anforderungen Buergschaft
+
+- Selbstschuldnerisch.
+- Unbedingt — keine Bedingungen, Einreden ausgeschlossen.
+- Unbefristet (oder mit ausreichend langer Frist).
+- Aussteller: Kreditinstitut oder Versicherer mit Sitz / Niederlassung im EWR.
+- Verzicht auf Einreden nach §§ 770 771 BGB.
+
+## Bestaetigung
+
+- Originalbuergschaft an Erwerber ausgehaendigt.
+- Pruefen: Vollstaendigkeit Wortlaut Auszahlung.
+
+## Verstoss
+
+- Sicherheit fehlt oder ist unzureichend = Vorausleistung unrechtmaessig.
+- Erwerber kann zurueckhalten.
+
+## Praxistipp
+
+- Konkret pruefen: Wer ist Versicherer / Bank? Bonitaet?
+- Inkraftsetzung der Buergschaft mit Vertragsunterzeichnung.
+
+## Pruefraster
+
+1. Buergschaft vorhanden?
+2. Aussteller bonitaet?
+3. Wortlaut korrekt (selbstschuldnerisch unbedingt unbefristet)?
+4. Hoehe = Vertragssumme?
+5. Vorlage an Erwerber?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-mabv-vermoegenstrennung/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-mabv-vermoegenstrennung/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: bautraeger-mabv-vermoegenstrennung
+description: "MaBV Vermoegenstrennung — Bautraeger muss die Gelder der Erwerber separiert vom eigenen Vermoegen behandeln. Skill klaert die Trennungspflicht das Sonderkonto und die Folgen bei Vermischung Insolvenzrechtlich. Liefert Pruefraster."
+---
+
+# Bautraeger Mabv Vermoegenstrennung
+
+## Pflicht zur Vermoegenstrennung
+
+§§ 3-8 MaBV: Bautraeger darf Erwerbergelder nur fuer das jeweilige Bauvorhaben verwenden. Trennung von eigenen Geldern ist Schutz vor Vermoegensvermischung.
+
+## Sonderkonto
+
+- Praxis: Eigene Konten pro Bauvorhaben.
+- Aufzeichnungspflicht nach § 10 MaBV.
+
+## Insolvenzschutz
+
+- Bei Insolvenz: Erwerbergelder, die zweckgebunden gehalten wurden, sollen Erwerbern zukommen.
+- Aber: keine echte Treuhand. Bei Vermischung Insolvenzmasse — Erwerber verlieren ggf.
+
+## Praxis
+
+- Mit Sicherungsmodell § 7 MaBV (gestelle Buergschaft) ist Vermoegensvermischung weniger riskant.
+- Bei Ratenmodell § 3 MaBV ist Vermoegenstrennung kritisch.
+
+## BGH-Linie
+
+- BGH: Verstoss gegen § 3 MaBV macht Vertragsklausel unwirksam.
+- Aktuelle Az im Mandat live verifizieren.
+
+## Pruefraster
+
+1. Welches Modell (§ 3 vs § 7)?
+2. Trennung des Sonderkontos belegbar?
+3. Bei Insolvenz: Glaeubigeranfechtung?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-mabv-vollstaendigkeitserklaerung-7/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-mabv-vollstaendigkeitserklaerung-7/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: bautraeger-mabv-vollstaendigkeitserklaerung-7
+description: "MaBV § 7 Vollstaendigkeitserklaerung als Alternative. Skill klaert wann der Bautraeger die volle Vertragssumme im Voraus verlangen darf wenn er die nach § 7 vorgesehene Sicherheit stellt. Liefert Pruefraster."
+---
+
+# Bautraeger Mabv Vollstaendigkeitserklaerung 7
+
+## Norm
+
+§ 7 MaBV: Bautraeger darf die gesamte Vertragssumme vor Baufortschritt verlangen, **wenn** er eine **selbstschuldnerische Buergschaft** in Hoehe von 105 Prozent der Vertragssumme stellt — diese sichert sowohl die Fertigstellung als auch die Vermoegensauskehr.
+
+## Voraussetzungen
+
+- Selbstschuldnerische Buergschaft eines Kreditinstituts oder Versicherers.
+- Hoehe 105 Prozent (gegenwaertige Fassung pruefen — frueher 110 Prozent bei manchen Auslegungen).
+- Schutz auch fuer Maengelansprueche.
+
+## Praxis
+
+- Bautraeger mit guten Kapitalbeziehungen waehlt § 7-Modell.
+- Erwerber gewinnt Vorhersehbarkeit; Bautraeger gewinnt Liquiditaet.
+
+## Pruefraster
+
+1. § 7 oder § 3 vereinbart?
+2. Sicherheit hinterlegt?
+3. Originalbuergschaft uebergeben?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-maengelhaftung-fuenf-jahre-634a/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-maengelhaftung-fuenf-jahre-634a/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: bautraeger-maengelhaftung-fuenf-jahre-634a
+description: "Bautraeger-Maengelhaftung 5 Jahre nach § 634a BGB. Skill klaert die Verjaehrungsfrist Bauwerk Beginn der Frist (Abnahme) Hemmung Unterbrechung sowie die Kategorisierung der Maengel offene und versteckte. Liefert Pruefraster."
+---
+
+# Bautraeger Maengelhaftung Fuenf Jahre 634A
+
+## Norm
+
+§ 634a Abs. 1 Nr. 2 BGB: Verjaehrungsfrist fuer Maengelansprueche bei Bauwerk 5 Jahre.
+
+## Beginn
+
+- Mit Abnahme (foerm- oder konkludent).
+- Bei Verweigerung der Abnahme: keine Verjaehrung.
+
+## Hemmung
+
+- §§ 203, 204 BGB: Verhandlungen, Mahnverfahren, Klage, selbstaendiges Beweisverfahren.
+
+## Maengelarten
+
+### Offene Maengel
+- Bei Abnahme erkennbar.
+- Bei Abnahme ohne Vorbehalt: rechte verloren.
+
+### Versteckte Maengel
+- Bei Abnahme nicht erkennbar.
+- Verjaehrung erst mit Entdeckung beginnt nicht — die 5 Jahre laufen ab Abnahme.
+
+### Arglistig verschwiegene Maengel
+- Verjaehrung in 10 Jahren (§ 634a Abs. 3 BGB iVm § 199 BGB).
+
+## Pruefraster
+
+1. Wann wurde abgenommen?
+2. Wann wurde Mangel entdeckt?
+3. Vorbehalt erklaert?
+4. Arglist vermutet?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-maengelruegen-und-formerfordernis/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-maengelruegen-und-formerfordernis/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: bautraeger-maengelruegen-und-formerfordernis
+description: "Bautraeger-Maengelruegen und Formerfordernis. Skill klaert wie ein Erwerber Maengel ruegen muss Schriftform-Empfehlung Frist zur Nachbesserung und die Folgen einer unwirksamen Ruege. Liefert Vorlage."
+---
+
+# Bautraeger Maengelruegen Und Formerfordernis
+
+## Form
+
+- BGB sieht keine Formerfordernis vor.
+- Empfehlung: schriftlich (Brief, E-Mail).
+- Beweissicherung: Einschreiben mit Rueckschein.
+
+## Inhalt
+
+- Mangel konkret bezeichnen.
+- Bauort und Bauteil benennen.
+- Foto oder Skizze beifuegen.
+- Aufforderung zur Nachbesserung.
+- Frist (idR 2-4 Wochen).
+
+## Folge bei Nichtbeachtung
+
+- Nach Ablauf der Frist: Selbstvornahme nach § 637 BGB.
+- Vorschusspflicht des Bautraegers (§ 637 Abs. 3 BGB).
+
+## Pruefraster
+
+1. Mangel konkret bezeichnet?
+2. Frist gesetzt?
+3. Form Schriftform empfohlen?
+4. Beweissicherung?
+
+## Vorlage
+
+"Sehr geehrte Damen und Herren, in der durch Sie an mich übergebenen Wohnung in der xxx-Strasse xx in xxxx, Wohnung Nr. xx, habe ich folgenden Mangel festgestellt: [Beschreibung]. Ich fordere Sie hiermit auf, diesen Mangel bis zum [Datum] zu beseitigen. Andernfalls werde ich von meinen Rechten nach § 637 BGB Gebrauch machen. Mit freundlichen Grüssen ..."

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-notarvertrag-grundlagen-pruefraster/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-notarvertrag-grundlagen-pruefraster/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: bautraeger-notarvertrag-grundlagen-pruefraster
+description: "Bautraegervertrag notarieller Pruefraster Grundlagen. Skill bietet das systematische Pruefraster fuer den notariellen Bautraegervertrag von Praeambel ueber Leistungsbeschreibung Zahlungsregelung Sicherheitsleistung Vormerkung Auflassung Abnahme Maengelhaftung Sonderwuensche. Liefert Checkliste."
+---
+
+# Bautraeger Notarvertrag Grundlagen Pruefraster
+
+## Pruefraster
+
+### 1. Praeambel
+- Identitaet der Parteien.
+- Grundstuecksdaten.
+- Bauvorhaben kurz beschrieben.
+
+### 2. Kaufgegenstand
+- Genaue Bezeichnung: Wohnung, Stellplatz, Garten.
+- Verweis auf Teilungserklaerung und Aufteilungsplan.
+
+### 3. Leistungsbeschreibung
+- Detaillierte Baubeschreibung als Anlage.
+- DIN, Standards.
+- Was ist nicht enthalten (Sonderwuensche).
+
+### 4. Zahlungsregelung
+- § 3 MaBV oder § 7 MaBV?
+- Ratenplan oder Sicherheit?
+- Verzugsfolgen.
+
+### 5. Sicherheitsleistung
+- Buergschaft Inhalt.
+- Fristen.
+
+### 6. Vormerkung
+- Auflassungsvormerkung im Grundbuch.
+- Rang.
+
+### 7. Auflassung
+- Bedingung der Eigentumsuebertragung.
+- Belastungsfreiheit.
+
+### 8. Abnahme
+- Form Frist Verfahren.
+- Vorbehalte.
+
+### 9. Maengelhaftung
+- Verjaehrungsfrist 5 Jahre (§ 634a BGB).
+- Selbstvornahmerecht.
+
+### 10. Sonderwuensche
+- Schriftform.
+- Zusatzpreise.
+
+### 11. Kosten und Steuern
+- Notarkosten.
+- Grunderwerbsteuer.
+- Grundbuchkosten.
+
+## Output
+
+- Strukturierte Pruefliste mit Ampelbewertung.

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-pfandfreigabe-und-loeschung/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-pfandfreigabe-und-loeschung/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: bautraeger-pfandfreigabe-und-loeschung
+description: "Pfandfreigabe und Loeschung nach vollstaendiger Bezahlung. Skill klaert das Verfahren wie nach Bezahlung die Pfandentnahme erfolgt und die Wohnung lastenfrei wird. Folgen bei Verweigerung. Liefert Pruefraster."
+---
+
+# Bautraeger Pfandfreigabe Und Loeschung
+
+## Verfahren
+
+1. Erwerber zahlt letzte Rate / volle Vertragssumme.
+2. Bautraeger meldet Vollzahlung bei der Bank.
+3. Bank gibt Pfandentnahme (Loeschungsbewilligung).
+4. Notar reicht Pfandfreigabe beim Grundbuchamt ein.
+5. Grundschuld bei der Erwerber-Wohnung wird geloescht.
+
+## Probleme
+
+### Bank verweigert Pfandfreigabe
+- Wenn Bautraeger insgesamt noch Schulden hat.
+- Erwerber kann Anspruch geltend machen, wenn die Pfandfreigabe-Vereinbarung Drittwirkung hat.
+
+### Bautraeger verweigert die Meldung an Bank
+- Erwerber kann eigenes Schreiben an Bank senden.
+- Klagewege.
+
+## Pflichten
+
+- Vorbereitung durch den Notar erforderlich.
+- Notar uebernimmt typischerweise die Koordination.
+
+## Pruefraster
+
+1. Zahlungsstand?
+2. Pfandfreigabevereinbarung vorliegend?
+3. Bank-Erklaerung erhalten?
+4. Loeschung im Grundbuch?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-rangruecktritt-grundpfandrechte/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-rangruecktritt-grundpfandrechte/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: bautraeger-rangruecktritt-grundpfandrechte
+description: "Rangruecktritt der Bautraeger-Grundpfandrechte hinter die Aufflassungsvormerkung. Skill klaert die Vereinbarung welche typischerweise vom Bautraeger zugesagt wird und wie sie zu pruefen ist. Bedeutung fuer Erwerberschutz. Liefert Pruefraster."
+---
+
+# Bautraeger Rangruecktritt Grundpfandrechte
+
+## Hintergrund
+
+Bautraeger finanziert das Bauvorhaben oft ueber Bankenkredit. Die finanzierende Bank verlangt erstrangige Grundschuld.
+
+## Problem
+
+- Bankgrundschuld typischerweise vor der Vormerkung eingetragen.
+- Bei Insolvenz wuerde Bank vor Erwerber bedient.
+
+## Loesung Rangruecktritt
+
+- Bank tritt mit ihrer Grundschuld im Rang hinter die Vormerkung des Erwerbers.
+- Erwerber hat dann Rang 1.
+
+## Pruefung
+
+- Im Notarvertrag muss der Rangruecktritt zugesagt sein.
+- Rangruecktrittserklaerung der Bank vorlegen.
+- Im Grundbuch nachvollziehen.
+
+## Pruefraster
+
+1. Bestehende Grundpfandrechte?
+2. Rangruecktritt vereinbart?
+3. Bank hat Erklaerung abgegeben?
+4. Eintragung im Grundbuch nachgewiesen?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-rechtswidrige-anpassungsklauseln/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-rechtswidrige-anpassungsklauseln/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: bautraeger-rechtswidrige-anpassungsklauseln
+description: "Rechtswidrige Anpassungsklauseln im Bautraegervertrag. Skill listet typische unwirksame Klauseln zur einseitigen Preisanpassung Bauzeitveraenderung Standardaenderung sowie BGH-Rechtsprechung dazu. Liefert Pruefraster."
+---
+
+# Bautraeger Rechtswidrige Anpassungsklauseln
+
+## Typische unwirksame Klauseln
+
+### Einseitige Preisanpassung
+- "Der Verkaeufer behaelt sich Preisanpassung vor."
+- Unwirksam nach § 309 Nr. 1 BGB (allgemein) und § 307 BGB (Generalklausel).
+- BGH staendige Rspr.
+
+### Verschiebung der Bauzeit
+- "Bauzeit kann sich aus Wettergruenden um bis zu 6 Monate verschieben."
+- Bei zu weiten Verzugsfristen unwirksam.
+
+### Standardaenderung
+- "Der Verkaeufer behaelt sich Aenderungen der Baubeschreibung vor."
+- Unwirksam, soweit wesentliche Aenderung.
+
+### Sonderwuensche-Ausschluss
+- "Sonderwuensche sind nicht moeglich nach Vertragsschluss."
+- Wirksam wenn klar, ABER mit angemessener Ausnahmeklausel.
+
+### Verkleinerung der Wohnflaeche
+- "Wohnflaeche kann um bis zu 5 Prozent abweichen ohne Konsequenz."
+- Bis 3 Prozent toleriert, darueber Minderung.
+
+## BGH-Linie
+
+- BGH staendige Rspr. zu einseitigen Anpassungsklauseln.
+- Aktuelle Az im Mandat live verifizieren.
+
+## Pruefraster
+
+1. Welche Klausel?
+2. Einseitig zu Lasten Erwerber?
+3. § 307 / § 309 BGB Verstoss?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-rueckabwicklung-bei-insolvenz/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-rueckabwicklung-bei-insolvenz/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: bautraeger-rueckabwicklung-bei-insolvenz
+description: "Bautraeger-Rueckabwicklung bei Insolvenz. Skill klaert das Verfahren der Rueckabwicklung wenn der Bautraeger insolvent geht aber Eigentumsuebertragung noch nicht erfolgt ist Buergschaftsabruf Forderungsanmeldung Wohnungsuebernahme im Insolvenzverfahren. Liefert Pruefraster."
+---
+
+# Bautraeger Rueckabwicklung Bei Insolvenz
+
+## Rueckabwicklungsschritte
+
+### 1. Buergschaft pruefen
+- Vorlegen der Originalbuergschaft.
+- Bonitaet des Buergen pruefen.
+- Anspruchsschreiben an den Buergen.
+
+### 2. Insolvenzverwalter kontaktieren
+- Forderungsanmeldung binnen Frist (vom IV bekanntgegeben).
+- Sicherung Vormerkungsrang.
+
+### 3. Aussonderung pruefen
+- Bei Globalgrundschuld Pfandfreigabe.
+- Bei Anwartschaftsrecht: insolvenzfeste Position.
+
+### 4. Wohnungsuebernahme
+- Wenn Bauwerk fertiggestellt: gegen Restzahlung uebernehmen.
+- Wenn nicht fertiggestellt: Insolvenzverwalter kann Wohnung an Dritten weiterveraussern.
+
+## Praxis
+
+- Buergschaft greift typischerweise schnell.
+- Wenn keine Buergschaft: lange Insolvenzdauer.
+
+## Pruefraster
+
+1. Buergschaft vorhanden?
+2. Forderung angemeldet?
+3. Vormerkungsrang?
+4. Bauwerk fertiggestellt?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-selbstvornahme-und-vorschussklage/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-selbstvornahme-und-vorschussklage/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: bautraeger-selbstvornahme-und-vorschussklage
+description: "Selbstvornahme und Vorschussklage gegen den Bautraeger. Skill klaert das Recht zur Selbstvornahme nach § 637 BGB die Vorschussklage zur Finanzierung der Beseitigung und die typischen Fallgruppen Erwerber will saniertes Apartment. Liefert Pruefraster."
+---
+
+# Bautraeger Selbstvornahme Und Vorschussklage
+
+## Norm
+
+§ 637 BGB Selbstvornahme.
+
+## Voraussetzungen
+
+- Mangel.
+- Frist gesetzt.
+- Frist ist abgelaufen.
+- Mangel besteht weiter.
+
+## Selbstvornahme
+
+- Erwerber laesst Mangel beseitigen.
+- Bautraeger traegt die Kosten.
+
+## Vorschuss
+
+- § 637 Abs. 3 BGB: Erwerber kann einen Kostenvorschuss vom Bautraeger fordern, ohne in Vorleistung treten zu muessen.
+- Vorschussklage moeglich, wenn Bautraeger nicht freiwillig zahlt.
+
+## Praxis
+
+- Erwerber holt Kostenvoranschlag von einem Handwerker.
+- Vorschussbetrag fordern.
+- Nach Beseitigung Abrechnung.
+
+## Pruefraster
+
+1. Frist gesetzt?
+2. Kostenvoranschlag?
+3. Vorschussklage erforderlich?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-sonderwuensche-zusaetzliche-vereinbarungen/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-sonderwuensche-zusaetzliche-vereinbarungen/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: bautraeger-sonderwuensche-zusaetzliche-vereinbarungen
+description: "Bautraeger-Sonderwuensche und zusaetzliche Vereinbarungen. Skill klaert die Behandlung von Sonderwuensche Mehrpreisen Aenderungen der Baubeschreibung Schriftform und das Verhaeltnis zur urspruenglichen Vertragsgrundlage. Liefert Klauselentwurf."
+---
+
+# Bautraeger Sonderwuensche Zusaetzliche Vereinbarungen
+
+## Sonderwuensche
+
+- Erwerber wuenscht Aenderung gegenueber Baubeschreibung.
+- Beispiel: bessere Bodenbelaege, Sanitaer-Ausstattung.
+
+## Form
+
+- Schriftlich (Empfehlung).
+- Beidseits unterzeichnet.
+- Genaue Beschreibung und Mehrpreis.
+
+## Mehrpreis-Klauseln
+
+- Pauschal: oft uebersetzt.
+- Auf Basis Selbstkosten-Plus: angemessener.
+- Empfehlung: vorab Vergleichsangebote einholen.
+
+## Verhaeltnis zur Baubeschreibung
+
+- Sonderwunsch aendert Baubeschreibung punktuell.
+- Restliche Vertragsregelungen gelten weiter.
+
+## Risiken
+
+- Bautraeger draengt zu spaeten Sonderwuensche und verlangt unangemessen.
+- Verzoegerung der Bauzeit.
+
+## Klauselentwurf Sonderwunsch
+
+"Die Parteien vereinbaren folgende Aenderung zur Baubeschreibung vom [Datum]: [Beschreibung Sonderwunsch]. Der Mehrpreis betraegt [Betrag] EUR. Die Vertragsausfuehrung verzoegert sich um maximal [Tage] Tage. Im uebrigen bleibt der Vertrag unveraendert."
+
+## Pruefraster
+
+1. Schriftlich vereinbart?
+2. Mehrpreis angemessen?
+3. Verzug akzeptabel?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-typische-nichtigkeitsfallen-checkliste/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-typische-nichtigkeitsfallen-checkliste/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: bautraeger-typische-nichtigkeitsfallen-checkliste
+description: "Bautraeger typische Nichtigkeitsfallen und Erwerber-Strategie. Skill listet die haeufigsten Nichtigkeitstatbestaende und entwickelt Strategien fuer den Erwerber wann Nichtigkeit zu seinem Vorteil genutzt werden kann (Default-Recht oft guenstiger). Liefert Risiko-Cockpit."
+---
+
+# Bautraeger Typische Nichtigkeitsfallen Checkliste
+
+## Nichtigkeitstatbestaende
+
+### MaBV-Verstoss
+- Klausel zu Vorausleistung ohne Sicherheit: unwirksam.
+
+### Notarrechtlicher Mangel
+- Aufflassung nicht beurkundet: nichtig.
+- Beurkundung ohne 2-Wochen-Frist: idR wirksam, aber Belehrungspflicht verletzt.
+
+### Sittenwidrigkeit § 138 BGB
+- Bei extremem Missverhaeltnis Preis-Leistung.
+
+### AGB-Verstoss § 307 BGB
+- Einzelne Klauseln unwirksam.
+- Vertrag im uebrigen wirksam.
+
+## Erwerber-Strategie
+
+### Wenn Default-Recht guenstiger
+- Erwerber kann es bei der Unwirksamkeit belassen.
+- Default = BGB-Werkvertrag oder Verbraucherbauvertrag mit besseren Rechten.
+
+### Wenn Default-Recht ungueltiger
+- Erwerber kann durch Geltendmachung der wirksamen Klauseln seine Position halten.
+
+## Risiko-Cockpit
+
+| Klauseltyp | Risiko Erwerber | Default-Lage |
+|---|---|---|
+| Abnahmefiktion | Mittel | guenstig |
+| Maengelhaftungsverkuerzung | Hoch | guenstig (5 Jahre §634a) |
+| Vorausleistung ohne Buergschaft | Hoch | guenstig (Rueckzahlung) |
+| Einseitige Preisanpassung | Mittel | guenstig (Festpreis) |
+
+## Pruefraster
+
+1. Welche Klausel ist unwirksam?
+2. Wer profitiert vom Default-Recht?
+3. Verhaltensempfehlung?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-typische-notar-fehler-checkliste/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-typische-notar-fehler-checkliste/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: bautraeger-typische-notar-fehler-checkliste
+description: "Typische Notar-Fehler im Bautraegervertrag. Skill listet die haeufigsten Notar-Fehler ungeklaerte Bonitaet vereinfachte Belehrung uebersetzte Pauschalpreise unklare Sonderwunschregelung. Liefert Pruefraster und Empfehlungen fuer Klaerung."
+---
+
+# Bautraeger Typische Notar Fehler Checkliste
+
+## Typische Notar-Fehler
+
+### Ungenuegende Bonitaetsklaerung
+- Notar pruef im Voraus den Grundbuchstand, oft aber nicht die Bonitaet des Bautraegers.
+- Erwerber muss selbst pruefen.
+
+### Vereinfachte Belehrung
+- Notar legt MaBV-Schutz nicht ausreichend dar.
+- Belehrung sollte konkret und schriftlich sein.
+
+### Uebersetzte Pauschalpreise
+- Klauseln zu Sonderwuensche mit pauschalen Aufpreisen koennen unangemessen sein.
+
+### Unklare Sonderwunschregelung
+- Genaue Definition fehlt.
+- Streit ueber Mehrkosten ist vorprogrammiert.
+
+### Fehlende Festlegung der Anlagen
+- Baubeschreibung ist Anlage, aber Stand nicht klar.
+- Bei Aenderungen unsicher.
+
+### § 17 BeurkG Belehrungspflicht
+- Notar muss "rechtlich erforderliche Belehrungen" vornehmen.
+- Verstoss: Schadensersatzhaftung.
+
+## Empfehlung Erwerber
+
+1. Vor Beurkundungstermin: Vertrag von Anwalt pruefen lassen.
+2. Eigene Nachfragen schriftlich vorbereiten.
+3. Vertragsentwurf mindestens 2 Wochen vor Termin (§ 17 Abs. 2a BeurkG).
+4. Anwesenheit Anwalt beim Notartermin moeglich.
+
+## Pruefraster
+
+1. Vertragsentwurf rechtzeitig erhalten?
+2. Anwalt eingeschaltet?
+3. Bonitaet geprueft?
+4. Belehrungspunkte abgehakt?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-weg-abgeschlossenheitsbescheinigung/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-weg-abgeschlossenheitsbescheinigung/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: bautraeger-weg-abgeschlossenheitsbescheinigung
+description: "WEG-Abgeschlossenheitsbescheinigung beim Bautraegervertrag. Skill klaert was die Abgeschlossenheitsbescheinigung ist warum sie erforderlich ist und wann sie verweigert wird. Liefert Pruefraster."
+---
+
+# Bautraeger Weg Abgeschlossenheitsbescheinigung
+
+## Norm
+
+§ 7 Abs. 4 WEG (alt) / § 3 Abs. 2 WEG (neu): Abgeschlossenheitsbescheinigung der zustaendigen Behoerde (idR Bauaufsicht) bestaetigt die in sich abgeschlossene Beschaffenheit jeder Wohnungs- oder Teileigentumseinheit.
+
+## Inhalt
+
+- Wohnungen sind raeumlich abgegrenzt.
+- Eingang nach außen oder von einem Gemeinschaftsraum.
+- Sanitaerausstattung.
+
+## Erforderlichkeit
+
+- Voraussetzung fuer Eintragung der Aufteilung im Grundbuch.
+- Ohne Abgeschlossenheitsbescheinigung keine wirksame Teilung.
+
+## Verweigerung
+
+- Bei nicht-abgeschlossener Beschaffenheit (z. B. fehlende Tueren).
+- Wohnung "geht durch" eine andere Wohnung.
+
+## Pruefraster
+
+1. Abgeschlossenheitsbescheinigung vorhanden?
+2. Datum der Ausstellung?
+3. Behoerde zustaendig?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-weg-erstverwalter-bestellung/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-weg-erstverwalter-bestellung/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: bautraeger-weg-erstverwalter-bestellung
+description: "WEG-Erstverwalter-Bestellung beim Bautraegervertrag. Skill klaert die haeufig umstrittene Erstverwalter-Klausel die Bautraeger oft mit verbundenen Unternehmen verknuepfen sowie das WEG-Reform-2020-Update. Liefert Pruefraster."
+---
+
+# Bautraeger Weg Erstverwalter Bestellung
+
+## Norm
+
+§§ 26-27 WEG: Verwalterbestellung.
+
+## Erstverwalter
+
+- Bautraeger bestellt den ersten Verwalter — typischerweise im Teilungserklaerung.
+- Oft ist Erstverwalter mit dem Bautraeger verbunden (Tochtergesellschaft).
+
+## Bestellungsdauer
+
+- Hoechstens 3 Jahre fuer Erstverwalter (§ 26 Abs. 1 WEG).
+- Verlaengerung erfordert Beschluss der Eigentuemerversammlung.
+
+## WEG-Reform 2020
+
+- Erste Eigentuemerversammlung muss innerhalb von 6 Monaten nach Bezugsfertigkeit der Wohnung einberufen werden.
+- Eigentuemer koennen Verwalter abberufen.
+
+## Problemklauseln
+
+- Vorgaben zur Verlaengerungsabsicht.
+- Festlegung der Verwaltervergueltung im voraus.
+
+## Pruefraster
+
+1. Erstverwalter bestellt?
+2. Dauer max. 3 Jahre?
+3. Abberufungsrecht der Eigentuemer?
+4. Verbundenheit Bautraeger-Verwalter?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-weg-gemeinschaftsordnung-pruefen/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-weg-gemeinschaftsordnung-pruefen/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: bautraeger-weg-gemeinschaftsordnung-pruefen
+description: "WEG-Gemeinschaftsordnung beim Bautraegervertrag pruefen. Skill klaert die Inhalte der Gemeinschaftsordnung Hausordnung Beitraege Stimmrechte und ihre nachtraegliche Aenderung. Liefert Pruefraster."
+---
+
+# Bautraeger Weg Gemeinschaftsordnung Pruefen
+
+## Norm
+
+§ 10 WEG: Gemeinschaftsordnung mit Hausordnung und Verwaltungsregelung.
+
+## Inhalt
+
+- Hausordnung (Ruhezeiten, Tierhaltung, Lüftung).
+- Beitragsverteilung.
+- Stimmrechte in der Eigentuemerversammlung.
+- Sonderzahlungen.
+
+## Pruefen
+
+### Hausordnung
+- Realistisch?
+- Eingeschraenkte Hundehaltung?
+- Lautstaerke-Vorgaben?
+
+### Beitragsverteilung
+- Nach Miteigentumsanteilen oder nach Verbrauch?
+
+### Stimmrechte
+- Kopfstimmen oder nach Miteigentumsanteilen?
+
+## Nachtraegliche Aenderung
+
+- Erfordert idR Einstimmigkeit oder qualifizierte Mehrheit.
+- Schutz davor, dass Bautraeger spaeter alles aendert.
+
+## Pruefraster
+
+1. Gemeinschaftsordnung als Anlage?
+2. Inhalt angemessen?
+3. Aenderungsregeln klar?
+4. Bautraeger-Privilegien?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-weg-instandhaltungsruecklage-uebergabe/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-weg-instandhaltungsruecklage-uebergabe/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: bautraeger-weg-instandhaltungsruecklage-uebergabe
+description: "WEG-Instandhaltungsruecklage zur Uebergabe. Skill klaert wie die Instandhaltungsruecklage bei der WEG-Gruendung dotiert wird welche Pflichten Bautraeger hat und welche Klauseln problematisch sind. Liefert Pruefraster."
+---
+
+# Bautraeger Weg Instandhaltungsruecklage Uebergabe
+
+## Norm
+
+§ 19 WEG: Erhaltungsruecklage (frueher Instandhaltungsruecklage) als Vermoegen der WEG.
+
+## Dotierung bei Uebergabe
+
+- Bei den meisten Bautraegervertraegen leistet der Erste Erwerber eine Eroeffnungsdotierung.
+- Hoehe variabel (oft 0.5 bis 1 Prozent des Vertragspreises).
+
+## Fortzahlung
+
+- Monatliche Beitraege.
+- Hoehe nach Wirtschaftsplan.
+
+## Problemklauseln
+
+- "Bautraeger leistet keine Eroeffnungsruecklage."
+- Erwerber muss sofort hohe Beitraege zahlen.
+
+## Pruefen
+
+- Wie hoch ist die Eroeffnungsruecklage?
+- Wer leistet?
+- Wie schnell waechst sie?
+
+## Pruefraster
+
+1. Eroeffnungsruecklage vorgesehen?
+2. Wer leistet?
+3. Wirtschaftsplan plausibel?

--- a/fachanwalt-bau-architektenrecht/skills/bautraeger-weg-teilungserklaerung-pruefen/SKILL.md
+++ b/fachanwalt-bau-architektenrecht/skills/bautraeger-weg-teilungserklaerung-pruefen/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: bautraeger-weg-teilungserklaerung-pruefen
+description: "WEG-Teilungserklaerung beim Bautraegervertrag pruefen. Skill klaert was in der Teilungserklaerung steht (Sondereigentum Gemeinschaftseigentum) wie sie gepruef wird und welche Klauseln problematisch sind. Liefert Pruefraster."
+---
+
+# Bautraeger Weg Teilungserklaerung Pruefen
+
+## Norm
+
+§ 8 WEG: Teilung des Grundeigentums durch den Bautraeger.
+
+## Inhalt
+
+- Liste der einzelnen Wohnungen.
+- Sondereigentum jeder Wohnung.
+- Gemeinschaftseigentum (Treppenhaus Dach Heizung).
+- Sondernutzungsrechte (Garten Stellplatz Kellerraum).
+
+## Pruefung
+
+### Sondereigentum klar abgegrenzt?
+- Innenausbau Trennwaende waende.
+- Bei mehrgeschossigen Bauten: Stockwerks-Eigentum.
+
+### Sondernutzungsrechte?
+- Garten — Sondernutzung oder Sondereigentum?
+- Stellplatz — Sondereigentum (Tiefgaragen-Stellplatz) oder Sondernutzung (Aussenstellplatz).
+
+### Verwaltungsregeln
+- Verwaltervergangenheit / Erstverwaltung.
+- Stimmrechte.
+
+## Problematische Klauseln
+
+- Festschreibung des Erstverwalters auf zu lange Zeit (z. B. 10 Jahre).
+- Stimmrechte ueberproportional fuer Bautraeger.
+- Festschreibung der Hausordnung mit Bautraeger-Privilegien.
+
+## Pruefraster
+
+1. Teilungserklaerung als Anlage vorhanden?
+2. Sondereigentum konkret?
+3. Sondernutzung klar?
+4. Verwaltungsregeln angemessen?


### PR DESCRIPTION
40 Skills im `fachanwalt-bau-architektenrecht`-Plugin (54 → 94). Apartmentkauf vom Bauträger, MaBV, Notarprüfung, Vormerkung, WEG, Mängelhaftung, Bauträger-Insolvenz, typische Nichtigkeitsfallen.

## 7 Cluster

### MaBV Grundsystem (8)
§ 1-2, § 7 Buergschaft, Vermoegenstrennung, § 3 Ratenplan (7 Raten nach Baufortschritt), § 7 Vollstaendigkeitserklaerung, § 10 Buchfuehrung, erweiterte Sicherheit 105 %, gewerberechtliche Folgen (§ 34c IV GewO Erlaubnisentzug).

### Notarielle Vertragspruefung (8)
Pruefraster, typische Notar-Fehler, § 17 BeurkG Belehrungspflicht + 2-Wochen-Frist, rechtswidrige Anpassungsklauseln, § 307 BGB Haftungsausschluss, Fertigstellungsfrist + Verzug, § 650l BGB Verbraucherbauvertrag Baubeschreibung, Anlagen.

### Vormerkung Grundbuch (6)
§ 883 BGB Auflassungsvormerkung, Rangruecktritt Grundpfandrechte, Globalgrundschuld + Pfandfreigabe, § 925 BGB Auflassung, Gebuehren + Rangwahrung, Pfandfreigabe + Loeschung.

### WEG-Aspekte (5)
§ 8 Teilungserklaerung, § 10 Gemeinschaftsordnung, § 3 II Abgeschlossenheitsbescheinigung, § 26 Erstverwalter (Reform 2020 max. 3 Jahre), § 19 Instandhaltungs-/Erhaltungsruecklage.

### Maengelhaftung und Abnahme (6)
§ 640 BGB Abnahme, BGH VII ZR 137/16 Abnahmefiktion unwirksam, § 634a Bauwerk 5 Jahre (+ 10 Jahre arglistig), Maengelruegen-Form + Vorlage, § 637 BGB Selbstvornahme + Vorschussklage, WEG-Reform 2020 § 9a gemeinschaftliche Maengelverfolgung.

### Bauträger-Insolvenz und Schutz (4)
Insolvenz-Konsequenzen Erwerber, Eigenkapital-Pruefung vor Vertrag, Bonitaetspruefung + Warnsignale, Rueckabwicklung mit Buergschaftsabruf.

### Vertragliche Klausel-Spezialfaelle (3)
Sonderwuensche + Mehrpreis, elektronische Notarverkuendung Reform 2022/2023, **typische Nichtigkeitsfallen + Strategie** (wann Default-Recht günstiger ist und Nichtigkeit zum Erwerber-Vorteil zu nutzen).

## Methodik

Durchgehend Pruefraster, Klauselentwürfe, Vorlagen für Mängelrügen. Aktenzeichen wo verifizierbar (BGH VII ZR 137/16 Abnahmefiktion u. a.), sonst "im Mandat live verifizieren".

## Validator

`node scripts/validate-plugin-structure.mjs` → OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_