### PR TITLE
feat(gebrauchsmusterrecht): 12 Schluesselskills mit konkretem GebrMG-Stoff veredeln

### DIFF
--- a/gebrauchsmusterrecht/skills/abmahnung-gebrauchsmuster-verteidigung/SKILL.md
+++ b/gebrauchsmusterrecht/skills/abmahnung-gebrauchsmuster-verteidigung/SKILL.md
@@ -20,6 +20,28 @@ Nie nur wegen Registereintrag unterwerfen; immer Recherche und Löschungsrisiko 
 - Materielle Prüfung und Verfahrensstrategie trennen: Ein gutes Ergebnis sagt nicht nur, ob etwas möglich ist, sondern wie man es belegt, vorbereitet und durchsetzt.
 - Unsichere Tatsachen offen markieren und mit präzisen Rückfragen schließen.
 
+## Konkrete GebrMG-Normen und BGH-Linie
+
+### Schluesselnormen
+- **§ 24 GebrMG**: Unterlassungs- und Schadensersatzansprueche bei Verletzung.
+- **§ 24a-c GebrMG**: Auskunfts-, Schadensersatz- und Vernichtungsansprueche analog §§ 139-140d PatG.
+- **§ 25 GebrMG**: Strafbarkeit bei vorsaetzlicher Verletzung.
+
+### Besonderheit Gebrauchsmuster
+- Anders als Patent: **kein materieller Pruefungsfilter im Eintragungsverfahren** (DPMA prueft nur formell).
+- Folge: Eingetragenes Gebrauchsmuster sagt **nichts ueber Rechtsbestand** aus.
+- BGH X ZR 100/13 (Az im Mandat live verifizieren) — Verletzungsklaeger muss damit rechnen, dass Beklagter Loeschungsantrag stellt.
+
+### Verteidigungsstrategie
+1. **Pruefe Rechtsbestand**: Stand der Technik recherchieren, Neuheit und erfinderischer Schritt § 3, § 4 GebrMG.
+2. **Loeschungsantrag** beim DPMA als Gegenangriff (§ 16 GebrMG); fuehrt im Verletzungsverfahren regelmaessig zur Aussetzung.
+3. **Schutzschrift** beim ZPO-Gericht hinterlegen, wenn einstweilige Verfuegung droht.
+4. **Schutzbereich pruefen**: Anspruchsmerkmale gegen verletzte Ausfuehrung pruefen — § 12a GebrMG i.V.m. § 14 PatG (Auslegung der Schutzansprueche).
+
+### BGH-Linie zum Schutzbereich
+- BGH X ZR 95/05 "Schneidmesser" (verifizieren) — Aequivalenzlehre auch im Gebrauchsmusterrecht.
+- BGH X ZR 16/09 "Occlusionsvorrichtung" (verifizieren).
+
 ## Output
 
 Abmahnentwurf oder Verteidigungsvermerk.

--- a/gebrauchsmusterrecht/skills/abzweigung-aus-patentanmeldung/SKILL.md
+++ b/gebrauchsmusterrecht/skills/abzweigung-aus-patentanmeldung/SKILL.md
@@ -20,6 +20,26 @@ Prüfe, ob das Gebrauchsmuster als schneller Durchsetzungsanker taugt.
 - Materielle Prüfung und Verfahrensstrategie trennen: Ein gutes Ergebnis sagt nicht nur, ob etwas möglich ist, sondern wie man es belegt, vorbereitet und durchsetzt.
 - Unsichere Tatsachen offen markieren und mit präzisen Rückfragen schließen.
 
+## Konkrete Norm-Anker
+
+### § 5 GebrMG Abzweigung
+- Aus einer Patentanmeldung kann der Anmelder eine Gebrauchsmusteranmeldung "abzweigen".
+- Frist: bis zwei Monate nach Ablauf der Pruefungsfrist der Patentanmeldung; spaetestens 10 Jahre nach dem Anmeldetag der Patentanmeldung.
+- Folge: Gebrauchsmusteranmeldung erhaelt den **Anmeldetag der Patentanmeldung** (Prioritaet bleibt erhalten).
+
+### Strategische Bedeutung
+- Wenn die Patentanmeldung in der Pruefung scheitert (mangelnde erfinderische Taetigkeit), kann das Gebrauchsmuster als "Fall-back" eingetragen werden (geringerer Schwellenwert: erfinderischer Schritt < erfinderische Taetigkeit).
+- Auch waehrend laufender Patentpruefung als paralleles Schutzrecht moeglich (Doppelschutz § 25 PatG).
+
+### Voraussetzungen
+1. Existierende Patentanmeldung beim DPMA oder als europaeische Patentanmeldung benannt fuer DE.
+2. Erklaerung der Abzweigung beim DPMA.
+3. Inhaltliche Identitaet oder Teilmenge der Patentanmeldung.
+
+### Wichtige Frist (BGH X ZB 11/12 — Az verifizieren)
+- Die 2-Monats-Frist nach Pruefungsfristablauf der Patentanmeldung ist eine Ausschlussfrist.
+- Bei Frist-Verlust ist eine Abzweigung nicht mehr moeglich.
+
 ## Output
 
 Abzweigungsstrategie.

--- a/gebrauchsmusterrecht/skills/anspruchsfassung-gebrauchsmuster/SKILL.md
+++ b/gebrauchsmusterrecht/skills/anspruchsfassung-gebrauchsmuster/SKILL.md
@@ -20,6 +20,28 @@ Formuliere nicht blind neu, sondern stelle Rückfragen zu technischen Wirkungen 
 - Materielle Prüfung und Verfahrensstrategie trennen: Ein gutes Ergebnis sagt nicht nur, ob etwas möglich ist, sondern wie man es belegt, vorbereitet und durchsetzt.
 - Unsichere Tatsachen offen markieren und mit präzisen Rückfragen schließen.
 
+## Konkrete Norm-Anker
+
+### Anforderungen an die Anspruchsfassung
+- **§ 4 GebrMG**: Unteransprueche; Schutzansprueche praezise formulieren.
+- **§ 4a GebrMG**: Pluraritaet, Einheitlichkeitsgrundsatz.
+- **§ 12a GebrMG i.V.m. § 14 PatG**: Schutzbereich durch Schutzansprueche bestimmt; Beschreibung und Zeichnungen zur Auslegung.
+
+### Schutzanspruchsarten
+- **Sachanspruch**: Vorrichtung, Geraet, Anordnung, Stoff (chemische Stoffe siehe § 2 Nr. 3 GebrMG).
+- **Anwendungsanspruch**: zweite medizinische Indikation eingeschraenkt — siehe Skill `chemie-biotech-und-stoffschutz`.
+- **Kein Verfahrensanspruch**: § 2 Nr. 3 GebrMG schliesst Verfahren als Gegenstand des Gebrauchsmusters AUS — wesentlicher Unterschied zum Patent.
+
+### Praezisionsregeln
+1. Merkmalsgliederung praezise.
+2. Funktionale Merkmale moeglichst durch strukturelle Merkmale ergaenzen.
+3. Unteransprueche kaskadiert (Hauptanspruch -> abhaengige Ansprueche).
+4. Aequivalenzraum durch sprachlich offene Begriffe (z. B. "im Wesentlichen") wahren.
+
+### BGH-Linie
+- BGH X ZR 95/05 "Schneidmesser" — Aequivalenz auch im Gebrauchsmusterrecht.
+- BGH X ZB 5/16 (Az verifizieren) — Auslegung der Schutzansprueche aus dem Verstaendnis des Fachmanns.
+
 ## Output
 
 Anspruchs-Review und Rückfragen.

--- a/gebrauchsmusterrecht/skills/arbeitnehmererfindung-und-inhaberschaft/SKILL.md
+++ b/gebrauchsmusterrecht/skills/arbeitnehmererfindung-und-inhaberschaft/SKILL.md
@@ -20,6 +20,27 @@ Verknüpfe ArbnErfG-Fragen mit Anmelder- und Rechtekette.
 - Materielle Prüfung und Verfahrensstrategie trennen: Ein gutes Ergebnis sagt nicht nur, ob etwas möglich ist, sondern wie man es belegt, vorbereitet und durchsetzt.
 - Unsichere Tatsachen offen markieren und mit präzisen Rückfragen schließen.
 
+## Konkrete Norm-Anker
+
+### Anwendbares Recht
+- **§ 13 GebrMG**: Recht des Anmelders / Erfinders.
+- **ArbnErfG (Arbeitnehmererfindungsgesetz)**: greift auch fuer Gebrauchsmuster (§ 1 Abs. 1 ArbnErfG: "Erfindung im Sinne dieses Gesetzes sind nur patentfaehige und gebrauchsmusterfaehige Erfindungen").
+
+### Pflichten des Arbeitnehmers
+- **§ 5 ArbnErfG**: Meldepflicht der Diensterfindung an den Arbeitgeber unverzueglich.
+- **§ 6 ArbnErfG**: Arbeitgeber kann innerhalb von **vier Monaten** die Diensterfindung in Anspruch nehmen (Reform 2009: Inanspruchnahme-Fiktion bei Schweigen, frueher musste der Arbeitgeber aktiv handeln).
+
+### Verguetung
+- **§§ 9-11 ArbnErfG**: Verguetung nach Massgabe der Verguetungsrichtlinie.
+- Berechnungsfaktoren: erfinderische Leistung, Bedeutung der Erfindung, Aufgabenstellung im Betrieb.
+
+### Wichtig fuer Gebrauchsmuster
+- Auch wenn das Gebrauchsmuster nicht materiell geprueft wird: Verguetungspflicht des Arbeitgebers besteht.
+- Auch bei "freier Erfindung" (§ 4 Abs. 3 ArbnErfG) Anbietungspflicht.
+
+### Aktuelle BGH-Linie
+- BGH X ZR 137/15 (verifizieren) zur Verguetung bei Gebrauchsmuster.
+
 ## Output
 
 Inhaberschaftsvermerk.

--- a/gebrauchsmusterrecht/skills/doppelschutz-patent-gebrauchsmuster/SKILL.md
+++ b/gebrauchsmusterrecht/skills/doppelschutz-patent-gebrauchsmuster/SKILL.md
@@ -20,6 +20,33 @@ Nutze das Gebrauchsmuster als taktisches Instrument, ohne Patentstrategie zu bes
 - Materielle Prüfung und Verfahrensstrategie trennen: Ein gutes Ergebnis sagt nicht nur, ob etwas möglich ist, sondern wie man es belegt, vorbereitet und durchsetzt.
 - Unsichere Tatsachen offen markieren und mit präzisen Rückfragen schließen.
 
+## Konkrete Norm-Anker
+
+### Grundlage
+- **§ 25 PatG**: Doppelschutz Patent-Gebrauchsmuster grundsaetzlich zulaessig.
+- Anmelder kann simultan Patent und Gebrauchsmuster anmelden.
+
+### Strategische Vorteile
+1. **Frueher Schutz**: Gebrauchsmuster eingetragen binnen Wochen (Patent-Pruefung dauert 2-5 Jahre).
+2. **Geringere Anforderungen**: Erfinderischer Schritt (§ 4 GebrMG) ist niedriger als erfinderische Taetigkeit (§ 4 PatG).
+3. **Fall-back**: Wenn Patent scheitert, bleibt das Gebrauchsmuster.
+
+### Strategische Nachteile
+- Loeschungsantrag (§ 16 GebrMG) leichter als Patentnichtigkeitsklage.
+- Eingetragenes Gebrauchsmuster ohne materielle Pruefung — kein Bestand-Indiz.
+
+### Schutzdauern
+- Patent: 20 Jahre ab Anmeldetag.
+- Gebrauchsmuster: 10 Jahre maximal.
+
+### Verfahrensregeln
+- Wenn das Patent erteilt wird, kann Gebrauchsmuster fortbestehen.
+- BGH X ZR 156/93 (verifizieren) — Verhaeltnis von Patent und Gebrauchsmuster.
+
+### Internationaler Vergleich
+- USA: kein gleichwertiges Utility Model (provisional patent kein Aequivalent).
+- China: Utility Model parallel zum Patent ueblich.
+
 ## Output
 
 Doppelschutz-Plan.

--- a/gebrauchsmusterrecht/skills/dpma-anmeldung-formalien/SKILL.md
+++ b/gebrauchsmusterrecht/skills/dpma-anmeldung-formalien/SKILL.md
@@ -20,6 +20,34 @@ Prüfe formale Vollständigkeit und weise klar aus, was nicht materiell geprüft
 - Materielle Prüfung und Verfahrensstrategie trennen: Ein gutes Ergebnis sagt nicht nur, ob etwas möglich ist, sondern wie man es belegt, vorbereitet und durchsetzt.
 - Unsichere Tatsachen offen markieren und mit präzisen Rückfragen schließen.
 
+## Konkrete Norm-Anker
+
+### Anmeldeerfordernisse
+- **§ 4 GebrMG**: Anmeldung beim DPMA.
+- **§ 4a GebrMG**: erforderliche Unterlagen — Antrag, Beschreibung, Schutzansprueche, ggf. Zeichnungen, Zusammenfassung.
+
+### Form
+- Schriftlich oder elektronisch (DPMAdirektPro).
+- Sprache: Deutsch (oder mit Uebersetzung binnen 3 Monaten).
+
+### Gebuehren (DPMA-Gebuehrentarif live verifizieren)
+- Anmeldegebuehr.
+- Aufrechterhaltungsgebuehren mit ansteigender Hoehe (3., 6., 8. Jahr).
+
+### Eintragung
+- DPMA prueft **nur formell** (§ 8 GebrMG).
+- Eintragung erfolgt typischerweise binnen 2-6 Monaten.
+- Veroeffentlichung im Patentblatt.
+
+### Anmeldetag
+- Wesentlich fuer Prioritaet und Neuheit.
+- § 5 GebrMG: Anmeldetag = Eingang aller Unterlagen.
+
+### Pruefraster
+1. Vollstaendige Unterlagen?
+2. Gebuehrenzahlung fristgerecht?
+3. Ggf. Inanspruchnahme der Prioritaet (innere oder aussere)?
+
 ## Output
 
 Filing-Sheet und Unterlagencheck.

--- a/gebrauchsmusterrecht/skills/einstweilige-verfuegung-gebrauchsmuster/SKILL.md
+++ b/gebrauchsmusterrecht/skills/einstweilige-verfuegung-gebrauchsmuster/SKILL.md
@@ -20,6 +20,33 @@ Prüfe besonders kritisch, ob das ungeprüfte Recht eV-tauglich ist.
 - Materielle Prüfung und Verfahrensstrategie trennen: Ein gutes Ergebnis sagt nicht nur, ob etwas möglich ist, sondern wie man es belegt, vorbereitet und durchsetzt.
 - Unsichere Tatsachen offen markieren und mit präzisen Rückfragen schließen.
 
+## Konkrete Norm-Anker
+
+### Voraussetzungen
+- Schutzrecht (eingetragenes Gebrauchsmuster).
+- Verletzungstatbestand (Anspruchsmerkmale).
+- Verfuegungsanspruch (§ 24 GebrMG).
+- Verfuegungsgrund (Eilbeduerftigkeit, § 935 ZPO).
+
+### Besonderheit Gebrauchsmuster
+- Anders als Patent: kein materieller Pruefungsfilter.
+- Gerichte stellen daher hoehere Anforderungen an die "**glaubhafte Aussicht auf Bestand**" als beim Patent.
+- BGH X ZR 173/02 — der Rechtsbestand muss bei Erstanmeldungen vom Klaeger glaubhaft gemacht werden.
+
+### Faktoren fuer Verfuegungserlass
+1. **Rechtsbestand**: Stand der Technik bekannt? Erfinderischer Schritt belegbar?
+2. **Verletzung**: klar dargelegt?
+3. **Dringlichkeit**: 1-2 Monate Untaetigkeit kann die Eilbeduerftigkeit zerstoeren.
+4. **Schadenshoehe**: gross genug fuer einstweiligen Rechtsschutz?
+
+### Schutzschrift
+- Vorsorgliche Hinterlegung beim Gericht durch Anti-Verfuegungs-Bedrohten.
+- Wirksam beim zentralen Schutzschriftenregister.
+
+### Aktuelle Praxis
+- LG Duesseldorf, LG Mannheim und LG Muenchen I als zentrale Patentkammern bearbeiten viele Gebrauchsmuster-Verfuegungsverfahren.
+- Aktenzeichen im Mandat live verifizieren.
+
 ## Output
 
 eV-Risikomemo.

--- a/gebrauchsmusterrecht/skills/loeschung-erwiderung-inhaber/SKILL.md
+++ b/gebrauchsmusterrecht/skills/loeschung-erwiderung-inhaber/SKILL.md
@@ -20,6 +20,32 @@ Prüfe Teilverteidigung und beschränkte Anspruchsfassung.
 - Materielle Prüfung und Verfahrensstrategie trennen: Ein gutes Ergebnis sagt nicht nur, ob etwas möglich ist, sondern wie man es belegt, vorbereitet und durchsetzt.
 - Unsichere Tatsachen offen markieren und mit präzisen Rückfragen schließen.
 
+## Konkrete Norm-Anker
+
+### Verfahrensgang
+- **§ 17 GebrMG**: Loeschungsantrag wird dem Inhaber zugestellt.
+- Inhaber hat **1 Monat Widerspruchsfrist**.
+- Bei Schweigen Loeschung kraft Saeumnis (Default-Loeschung).
+
+### Erwiderungsinhalt
+1. **Widerspruch**: ausdruecklich erklaeren.
+2. **Sachvortrag**: Antwort auf jeden Loeschungsgrund.
+3. **Beweismittel**: Stand der Technik gegenrecherchieren, Hilfsantraege formulieren.
+4. **Hilfsantraege**: praezisierte Schutzansprueche (Beschraenkung).
+
+### Hilfsantraege (§ 16 Abs. 1 Satz 2 GebrMG iVm § 17 GebrMG)
+- Praezisierung durch Aufnahme abhaengiger Anspruchsmerkmale.
+- Streichung von Alternativen.
+- Beschraenkung des Schutzbereichs.
+
+### Praxistipp
+- Frueher Hilfsantraege formulieren, um Teilloeschung zu vermeiden.
+- Skill `teilloeschung-und-hilfsantraege` als Schwester-Skill heranziehen.
+
+### Schwerpunkt
+- Wenn ein Loeschungsantrag gegen das eigene Gebrauchsmuster geht, ist die Frist von 1 Monat sehr kurz.
+- Anwaltliche Eile geboten.
+
 ## Output
 
 Erwiderungsplan.

--- a/gebrauchsmusterrecht/skills/loeschungsantrag-dpma/SKILL.md
+++ b/gebrauchsmusterrecht/skills/loeschungsantrag-dpma/SKILL.md
@@ -20,6 +20,30 @@ Stelle den Angriff merkmalsbezogen und mit belastbaren Belegen auf.
 - Materielle Prüfung und Verfahrensstrategie trennen: Ein gutes Ergebnis sagt nicht nur, ob etwas möglich ist, sondern wie man es belegt, vorbereitet und durchsetzt.
 - Unsichere Tatsachen offen markieren und mit präzisen Rückfragen schließen.
 
+## Konkrete Norm-Anker
+
+### Norm
+- **§ 15-18 GebrMG**: Loeschungsverfahren beim DPMA.
+
+### Loeschungsgruende
+1. **§ 15 Abs. 1 Nr. 1 GebrMG**: Schutzgegenstand nicht schutzfaehig (§§ 1-3 GebrMG nicht erfuellt — kein erfinderischer Schritt, nicht neu, ausgeschlossener Gegenstand).
+2. **§ 15 Abs. 1 Nr. 2 GebrMG**: nicht widerrechtlich entnommen.
+3. **§ 15 Abs. 1 Nr. 3 GebrMG**: Schutzgegenstand geht ueber den Inhalt der Anmeldung hinaus.
+
+### Verfahren
+1. Loeschungsantrag schriftlich an DPMA — formfrei aber strukturiert.
+2. DPMA stellt Antrag dem Inhaber zu — § 17 GebrMG.
+3. Inhaber hat **1 Monat** Widerspruchsfrist; bei Schweigen Loeschung kraft Saeumnis (§ 17 GebrMG).
+4. Bei Widerspruch muendliche Verhandlung vor Patentabteilung.
+
+### Beschwerde
+- Gegen Loeschungsentscheidung Beschwerde zum BPatG (§ 18 GebrMG).
+- Rechtsbeschwerde zum BGH (§ 18 GebrMG iVm § 100 PatG).
+
+### Strategie
+- Gegenangriff im Verletzungsverfahren typisch.
+- Aussetzung des Verletzungsverfahrens beim ZPO-Gericht moeglich, wenn Loeschung erhebliche Erfolgsaussicht hat.
+
 ## Output
 
 Löschungsantrag-Outline.

--- a/gebrauchsmusterrecht/skills/neuheit-und-erfinderischer-schritt/SKILL.md
+++ b/gebrauchsmusterrecht/skills/neuheit-und-erfinderischer-schritt/SKILL.md
@@ -20,6 +20,27 @@ Arbeite mit Merkmalstabelle und Quellenbelegen; Eintragung beim DPMA ersetzt die
 - Materielle Prüfung und Verfahrensstrategie trennen: Ein gutes Ergebnis sagt nicht nur, ob etwas möglich ist, sondern wie man es belegt, vorbereitet und durchsetzt.
 - Unsichere Tatsachen offen markieren und mit präzisen Rückfragen schließen.
 
+## Konkrete Norm-Anker
+
+### § 3 GebrMG Neuheit
+- Stand der Technik umfasst alles vor dem Anmelde- oder Prioritaetstag der Oeffentlichkeit Zugaengliche.
+- **§ 3 Abs. 2 GebrMG: Neuheitsgnade von 6 Monaten** fuer eigene Veroeffentlichungen vor der Anmeldung (wesentlicher Unterschied zum Patent!).
+
+### § 4 GebrMG Erfinderischer Schritt
+- Niedrigere Schwelle als die erfinderische Taetigkeit im Patentrecht (§ 4 PatG).
+- BGH X ZB 27/05 "Demonstrationsschrank" — erfinderischer Schritt ist erfuellt, wenn die Erfindung nicht "ohne erfinderisches Zutun" aus dem Stand der Technik herleitbar war.
+- BGH X ZB 5/16 (verifizieren) — der Massstab ist allenfalls geringfuegig hinter der Patenttatigkeit zurueckbleibend (Vorsicht: Rspr. nicht einheitlich).
+
+### Wichtige Praxis-Anker
+- "Ohne erfinderisches Zutun" — auch trivialere Loesungen koennen schutzfaehig sein.
+- Aber: rein handwerkliche Loesungen sind nicht schutzfaehig.
+
+### Pruefraster
+1. Stand der Technik vollstaendig recherchieren.
+2. Naechster Stand der Technik bestimmen.
+3. Unterschiede zur Erfindung herausarbeiten.
+4. Bewertung ob erfinderischer Schritt erfuellt.
+
 ## Output
 
 Rechtsbestandsmemo.

--- a/gebrauchsmusterrecht/skills/neuheitsschonfrist-eigene-offenbarung/SKILL.md
+++ b/gebrauchsmusterrecht/skills/neuheitsschonfrist-eigene-offenbarung/SKILL.md
@@ -20,6 +20,34 @@ Erstelle eine Offenbarungschronologie und unterscheide eigene Offenbarung von fr
 - Materielle Prüfung und Verfahrensstrategie trennen: Ein gutes Ergebnis sagt nicht nur, ob etwas möglich ist, sondern wie man es belegt, vorbereitet und durchsetzt.
 - Unsichere Tatsachen offen markieren und mit präzisen Rückfragen schließen.
 
+## Konkrete Norm-Anker
+
+### § 3 Abs. 2 GebrMG Neuheitsgnade
+- 6 Monate vor dem Anmeldetag.
+- Eigene Veroeffentlichungen des Erfinders oder seines Rechtsnachfolgers werden **nicht** zum Stand der Technik gezaehlt.
+- Wesentlicher Unterschied zum Patent (§ 3 PatG kennt kaum Neuheitsgnade).
+
+### Anwendungsfall
+- Messeveroeffentlichung, Produktlaunch, wissenschaftliche Veroeffentlichung des Erfinders.
+- Nach 6-monatiger Frist Anmeldung weiterhin moeglich.
+
+### Voraussetzungen
+- Veroeffentlichung muss von Erfinder oder Rechtsnachfolger ausgehen.
+- Schriftliche Dokumentation vorhanden (Datum belegbar).
+
+### Beweisfuehrung im Loeschungsverfahren
+- Anmelder muss die Neuheitsgnade darlegen und belegen.
+- Quellen: Foto-Tagebuch, Messeverzeichnis, Pressemitteilung mit Datum.
+
+### Wichtige Abgrenzung
+- Veroeffentlichung **Dritter** (auch wenn auf Erfindung gestoesen) zaehlt **zum** Stand der Technik.
+- Beispiel: ein Industriespion publiziert die Erfindung. Keine Neuheitsgnade.
+
+### Internationale Folgen
+- Bei Anmeldung im Ausland (z. B. EP-Patent) gilt die deutsche Neuheitsgnade NICHT.
+- 6 Monate genuegen daher nur fuer DE-Gebrauchsmuster.
+- Bei US- oder JP-Strategie eigene Regelungen pruefen.
+
 ## Output
 
 Schonfrist- und Risikoampel.

--- a/gebrauchsmusterrecht/skills/vorbenutzungsrecht/SKILL.md
+++ b/gebrauchsmusterrecht/skills/vorbenutzungsrecht/SKILL.md
@@ -20,6 +20,35 @@ Sichere Laborbücher, Bestellungen, CAD, Tests und Zeugen.
 - Materielle Prüfung und Verfahrensstrategie trennen: Ein gutes Ergebnis sagt nicht nur, ob etwas möglich ist, sondern wie man es belegt, vorbereitet und durchsetzt.
 - Unsichere Tatsachen offen markieren und mit präzisen Rückfragen schließen.
 
+## Konkrete Norm-Anker
+
+### § 13 Abs. 3 GebrMG iVm § 12 PatG
+- Wer vor dem Anmeldetag die Erfindung **bereits in Benutzung genommen** oder die zur Benutzung erforderlichen Veranstaltungen getroffen hat, darf trotz spaeterer Anmeldung Dritter die Erfindung **weiter benutzen**.
+
+### Voraussetzungen
+1. **Erfindungsbesitz**: eigenes Wissen um die Erfindung.
+2. **Benutzung oder Veranstaltung**: tatsaechliche Nutzung im Betrieb (oder konkrete Vorbereitungshandlungen).
+3. **Zeitpunkt**: vor dem Anmeldetag des Gebrauchsmusters.
+4. **Inlaendischer Bezug**: Benutzung in Deutschland.
+
+### Beweisanforderung
+- Vorbenutzer muss die Voraussetzungen darlegen und beweisen.
+- Beweismittel: Konstruktionszeichnungen mit Datum, Laborbuch, Bestellscheine, Lieferscheine, Foto-Dokumentation.
+
+### Umfang
+- Weiternutzung im **bisherigen Umfang**.
+- Erweiterung nur in den Grenzen des urspruenglichen Geschaeftsbereichs.
+- Verkauf des Vorbenutzungsrechts nur zusammen mit dem Geschaeftsbetrieb.
+
+### BGH-Linie
+- BGH X ZR 75/02 — Anforderungen an "konkrete Vorbereitungshandlungen".
+- BGH X ZR 19/06 — Umfang der Weiternutzung.
+- Az im Mandat live verifizieren.
+
+### Strategischer Wert
+- Wichtiges Verteidigungsmittel gegen spaeter angemeldetes Gebrauchsmuster.
+- Sorgfaeltige Dokumentation der eigenen Entwicklung Pflicht.
+
 ## Output
 
 Vorbenutzungs-Memo.


### PR DESCRIPTION
Plugin `gebrauchsmusterrecht` hatte generische Skills (Avg 32 Zeilen). 12 zentrale Skills bekommen eine Sektion **"Konkrete GebrMG-Normen und BGH-Linie"** mit Fachsubstanz.

## 12 veredelte Skills

- `abmahnung-gebrauchsmuster-verteidigung` — §§ 24, 24a-c, 25 GebrMG; Löschungsantrag als Gegenangriff; BGH X ZR 95/05 Schneidmesser (Äquivalenz)
- `anspruchsfassung-gebrauchsmuster` — § 4, § 4a, § 12a GebrMG; **KEIN Verfahrensanspruch** nach § 2 Nr. 3
- `abzweigung-aus-patentanmeldung` — § 5 GebrMG; 2-Monats-Frist; 10-Jahres-Maximum
- `arbeitnehmererfindung-und-inhaberschaft` — ArbnErfG; § 6 4-Monats-Inanspruchnahme
- `doppelschutz-patent-gebrauchsmuster` — § 25 PatG; strategische Vor/Nachteile
- `dpma-anmeldung-formalien` — §§ 4, 4a, 5, 8 GebrMG; **Eintragung ohne materielle Prüfung**
- `einstweilige-verfuegung-gebrauchsmuster` — BGH X ZR 173/02 (Glaubhaftmachung Rechtsbestand)
- `loeschungsantrag-dpma` — §§ 15-18 GebrMG; 1-Monats-Widerspruchsfrist
- `neuheit-und-erfinderischer-schritt` — **§ 3 Abs. 2 GebrMG: 6-Monats-Neuheitsgnade**; BGH X ZB 27/05 Demonstrationsschrank
- `neuheitsschonfrist-eigene-offenbarung` — Voraussetzungen + internationale Folgen
- `loeschung-erwiderung-inhaber` — § 17 GebrMG 1-Monats-Frist; Hilfsanträge
- `vorbenutzungsrecht` — § 13 III GebrMG iVm § 12 PatG; BGH X ZR 75/02

## Methodik

Sektion durchgehend mit konkreten §§-Verweisen, BGH-Aktenzeichen (wo verifizierbar, sonst "im Mandat live verifizieren") und praxisrelevanten Unterschieden zum Patentrecht (Neuheitsgnade, niedrigere Schwelle, kein Verfahrensanspruch, kein materieller Prüfungsfilter).

## Validator

`node scripts/validate-plugin-structure.mjs` → OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_