### PR TITLE
fix(rom): § 599 BGB ist Verleiher-Privileg, nicht Entleiher-Limitierung (Codex P2)

### DIFF
--- a/roemisches-recht/skills/rom-024-leihe-commodatum/SKILL.md
+++ b/roemisches-recht/skills/rom-024-leihe-commodatum/SKILL.md
@@ -67,7 +67,7 @@ Nur frei prüfbare Quellen oder Nutzerquellen zitieren. Rechtsprechung nur mit G
 ### Subsumtionsbeispiel: Geliehenes Pferd geht im Feldzug verloren
 Sachverhalt: A leiht B ein Pferd; B wird auf einem Feldzug ueberfallen; Pferd entlaeuft.
 - **Roemisch**: Custodia-Haftung; Diebstahl ist nicht casus maior; B haftet. Ausnahme: Feindangriff = vis maior (D. 13.6.18).
-- **BGB**: § 599 BGB Leihe; Entleiher haftet nur fuer Vorsatz und grobe Fahrlaessigkeit; bei einfacher Fahrlaessigkeit keine Haftung.
+- **BGB**: § 598 BGB Leihvertrag; **Entleiher haftet voll fuer jede Fahrlaessigkeit** nach allgemeinen Regeln (§§ 280, 276 BGB) — insbesondere muss er die Sache pflegen und zurueckgeben (§ 604 BGB). Bei Diebstahl durch einfache Fahrlaessigkeit (z. B. unverschlossen abgestellt) haftet B regelmaessig auf Schadensersatz. NICHT zu verwechseln mit § 599 BGB: dieser begrenzt die Haftung des **Verleihers** auf Vorsatz und grobe Fahrlaessigkeit (weil unentgeltlich gibt) — Entleiher bleibt der vollen Sorgfaltspflicht unterworfen.
 
 ### Pflichten des Entleihers
 - Pflegliche Behandlung.

--- a/roemisches-recht/skills/rom-038-culpa-dolus-custodia/SKILL.md
+++ b/roemisches-recht/skills/rom-038-culpa-dolus-custodia/SKILL.md
@@ -80,5 +80,5 @@ Sachverhalt: A schickt Lebensmittel-Lieferung; B als Spediteur verliert sie durc
 ### Subsumtionsbeispiel: Pferd gestohlen waehrend Krieg
 Sachverhalt: B leiht Pferd; auf der Reise wird er von Feinden ueberfallen; Pferd genommen.
 - **Roemisch**: commodatum; vis maior (feindlicher Angriff); B nicht haftbar (D. 13.6.18).
-- **BGB**: § 599 BGB Leihe; B haftet nur fuer Vorsatz und grobe Fahrlaessigkeit.
+- **BGB**: § 598 BGB Leihvertrag; § 604 BGB Rueckgabepflicht; § 280 BGB iVm § 276 BGB Verschuldenshaftung. **Entleiher haftet fuer jede Fahrlaessigkeit** — bei einfacher Fahrlaessigkeit Wertersatz, bei vis maior (Feindangriff) entfaellt das Verschulden. Hinweis: § 599 BGB privilegiert den **Verleiher** (unentgeltliches Geschaeft) auf Vorsatz und grobe Fahrlaessigkeit; der Entleiher bleibt voll sorgfaltspflichtig.
 


### PR DESCRIPTION
Codex P2-Finding (PR #219 Nachreview): § 599 BGB ist eine **Privilegierung des Verleihers** (unentgeltliches Geschäft), nicht des Entleihers.

## Sachfehler

In `rom-024-leihe-commodatum` und `rom-038-culpa-dolus-custodia` hatte ich den BGB-Vergleich falsch:
> "BGB: § 599 BGB Leihe; Entleiher haftet nur fuer Vorsatz und grobe Fahrlaessigkeit"

**Richtig**: § 599 BGB begrenzt nur die **Verleiher**-Haftung. Der **Entleiher** haftet nach allgemeinen Regeln (§§ 280, 276 BGB) für **jede Fahrlässigkeit**; er hat Sorgfalts- und Rückgabepflicht aus § 598 BGB / § 604 BGB.

## Fix in 2 Skills

- **rom-024-leihe-commodatum** (Pferd-im-Feldzug-Beispiel): Entleiher haftet voll für jede Fahrlässigkeit; Hinweis auf richtige Norm-Verteilung Entleiher/Verleiher.
- **rom-038-culpa-dolus-custodia** (Pferd gestohlen während Krieg): Entleiher haftet für jede Fahrlässigkeit; vis maior (Feindangriff) entlastet vom Verschulden.

## Validator

`node scripts/validate-plugin-structure.mjs` → OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_