### PR TITLE
docs(asset-index): Stand-Marker auf v100.0.0 ziehen

### DIFF
--- a/ASSET_INDEX.md
+++ b/ASSET_INDEX.md
@@ -1,5 +1,5 @@
 # Release-Asset-Index
-**Stand:** v71.2.2 — automatisch aktualisierte Asset-Übersicht
+**Stand:** v100.0.0 — automatisch aktualisierte Asset-Übersicht
 
 ## Sammel-Assets
 | Asset | Verwendung |


### PR DESCRIPTION
Stand-Marker-Drift behoben.

`ASSET_INDEX.md` zeigte noch `v71.2.2` — `SKILLS.md` und `README.md` sind seit der Konsolidierung auf `v100.0.0`.

**Geändert**: 1 Zeile in `ASSET_INDEX.md` (Stand-Marker).

**Nicht geändert**: Section-Header "## Neue Testakten v71" auf Zeile 407 — das ist ein historischer Abschnittstitel ("was war neu in v71"), kein aktueller Stand-Marker.

Validator grün.

---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_