### PR TITLE
Anwalts-Dashboard-Konvention + PDF-Tweak: Einstieg-Skills mit verifizierten Slugs

### DIFF
--- a/fachanwalt-arbeitsrecht/skills/einstieg-routing/SKILL.md
+++ b/fachanwalt-arbeitsrecht/skills/einstieg-routing/SKILL.md
@@ -1,42 +1,55 @@
 ---
 name: einstieg-routing
-description: "Einstieg, Triage und Routing für Fachanwalt Arbeitsrecht: ordnet Rolle (Arbeitnehmer, Arbeitgeber, Betriebsrat), markiert Frist (§ 4 KSchG 3 Wochen Kündigungsschutzklage), wählt Norm (BGB §§ 611a ff., 623, KSchG §§ 1/4/7, AGG) und Zuständigkeit (Arbeitsgericht (1. Instanz)), leitet zum passenden..."
+description: "Anwalts-Dashboard Fachanwalt Arbeitsrecht: Sofort-Triage als Tabelle (Rolle, Verfahrensstand, Eilfrist, Hauptanspruch, Zuständigkeit), Risiko-Ampel, Anschluss-Skill-Router mit echten Slugs, Norm-Radar; maximal eine Rückfrage. Der Anwalt bleibt im Driver Seat."
 ---
 
-# Einstieg und Routing
+# Anwalts-Dashboard Fachanwalt Arbeitsrecht
 
-## Einsatzlage
+> Kündigung, Aufhebungsvertrag, Befristung, Betriebsrat, Betriebsübergang — sieben Eilfristen, ein Klagestrang.
+>
+> Sie sehen unten die Sofort-Triage. Keine Rückfragen, bis die Tabelle steht. Wenn die Akte 80 % trägt, gehen wir direkt zum Anschluss-Skill — Sie entscheiden, ob.
 
-Dieser Einstieg routet **Fachanwalt Arbeitsrecht** vom ersten Sachverhalt zu Rollen, Fristen, zuständiger Stelle, passendem Spezialpfad und nächstem Arbeitsprodukt.
+## Sofort-Triage
 
-## Fachlandkarte dieses Plugins
+| Punkt | Schnellprüfung | Standardquelle / Hilfsweg |
+| --- | --- | --- |
+| Rolle | Wen vertrete ich? (Mandant · Gegenseite · Mehrere) | Mandantenmail, Vertretungsbestellung |
+| Verfahrensstand | Vorprozessual · außergerichtlich · Klage · Rechtsmittel · Vollstreckung | Vorhandene Schriftsätze, Eingangsstempel |
+| Eilfrist | **§ 4 KSchG: 3 Wochen** ab Zugang Kündigung. Daneben § 626 II BGB (außerordentlich, 2 Wochen ab Kenntnis), § 15 IV AGG (2 Monate Geltendmachung), § 17 KSchG (Massenentlassungsanzeige), § 9 MuSchG, § 613a VI BGB (1 Monat Widerspruch). | Frist aus Zugangs-/Kenntnisdatum berechnen |
+| Hauptanspruch | Kündigungsschutz §§ 1, 4, 7 KSchG · Lohn §§ 611a, 614, 615 BGB (Annahmeverzug) · Schadensersatz §§ 280 I, 823 BGB · AGG-Entschädigung §§ 7, 15 AGG · Betriebsübergang § 613a BGB. | Sachverhaltsabgleich mit Tatbestandsmerkmalen |
+| Zuständigkeit | Arbeitsgericht am Arbeitsort (§ 48 ArbGG, § 17 ZPO). Streitwert KSchG-Klage: 1/4 Bruttojahresgehalt (§ 42 II GKG). | Gesetz, Vertrag, Gerichtsstandsklausel |
 
-- `abmahnung-loeschung-personalakte-bag-2-azr-782-11` — Abmahnung Loeschung Personalakte BAG 2 AZR 782 11
-- `aktenzeichen-fehlerkatalog` — Aktenzeichen Fehlerkatalog
-- `ar-aufhebungsvertrag-praxis` — AR Aufhebungsvertrag Konkurrenzklausel
-- `ar-betriebsuebergang-spezial` — AR Betriebsuebergang Spezial Einfuehrung
-- `einstieg-schnelltriage-fallrouting` — AR Kuendigungspruefung Fazugang Arbeitgeber
-- `vergleich-arbeitsgericht-abrechnung` — Arbeitsgericht Abrechnung
-- `aufhebungsvertrag-faires-verhandeln-bag-6-azr-333-21` — Aufhebungsvertrag Faires Verhandeln BAG 6 AZR 333 21
-- `bag-mindesturlaub-kein-verzicht` — BAG
-- `befristung-compliance-dokumentation-und-akte` — Befristung FAO Unwirksam Fristennotiz
-- `befristung-tzbfg` — Befristung Tzbfg BEM Verfahren Fazugang
-- `beteiligung-betriebsrat-102-betrvg` — Beteiligung Betriebsrat Erstgespraech
-- `betriebsrat-zahlen-schwellen-und-berechnung` — Betriebsrat BETRVG Datum
-- `betriebsratswahl-anfechtung-leiharbeit-bag-7-abr-4-21` — Betriebsratswahl Anfechtung Leiharbeit BAG 7 ABR 4 21
-- `anschluss-routing` — Anschluss Routing
-- `dokumente-intake` — Dokumente Intake
+## Risiko-Ampel
 
-## Arbeitsweg
+- **Frist:** 🔴 Kündigung mit laufender 3-Wochen-Frist: heute Klageschrift. 🟠 Aufhebungsvertrag mit Widerrufsoption: 14 Tage prüfen. 🟢 Lohnklage ohne Verfallsklausel.
+- **Beweislage:** 🟠 Zugang der Kündigung trägt der Arbeitgeber (§ 130 BGB); Zustellungsnachweis sichern. 🔴 Bei mündlicher Kündigung: Zeugen organisieren.
+- **Wirtschaftlich:** 🔴 Lohnverlust > 3 Monate + Verlust SV-Pflicht: Eilantrag Weiterbeschäftigung (§ 102 V BetrVG) prüfen. 🟠 Abfindung ≈ 0,5 Monatsgehälter pro BJ als Verhandlungsstart.
 
-- Rolle und Ziel klären: Welche Partei vertritt der Mandant, welcher Ergebnistyp wird gebraucht (Schriftsatz, Bescheidprüfung, Vertragsentwurf, Stellungnahme), welches Verfahren oder Dokument liegt vor?
-- Eilfristen isolieren: die im Fachgebiet einschlägigen Verfahrens- und materiellen Fristen pflichtmäßig vorab markieren und nicht aus Modellwissen finalisieren.
-- Fachpfad wählen: zentrale Anker im Fachanwalt Arbeitsrecht sind AGG, BetrVG, EntgTranspG, KSchG, TzBfG. Anhand des Sachverhalts in einen Sach-Cluster routen und den passenden Spezial-Skill aus der Fachlandkarte oben benennen.
-- Zuständige Stelle bestimmen: Mandant, Gegner, zuständiges Gericht oder Behörde, etwaige Sachverständige oder beauftragte Stellen.
-- Nur die Rückfragen stellen, die die nächste Weiche tatsächlich ändern.
+## Anschluss-Skills (Router)
 
-## Qualitätsanker
+| Wenn der Fall trägt … | dann Skill | Erwartung |
+| --- | --- | --- |
+| **Kündigung erhalten — Schutzklage prüfen** | `ar-kuendigungspruefung-workflow` | Klageschrift mit Anträgen, Streitwertangabe, Antrag auf vorläufige Weiterbeschäftigung |
+| Aufhebungsvertrag angeboten | `ar-aufhebungsvertrag-praxis` | Risikomatrix, Abfindungs-Range, Sperrzeit § 159 SGB III |
+| Befristung soll geprüft werden | `befristung-tzbfg` | Sachgrund- vs. sachgrundlose Befristung, Anschlussverbot § 14 II 2 TzBfG |
+| Betriebsrats-Beteiligung streitig | `beteiligung-betriebsrat-102-betrvg` | Anhörungsfehler, Heilung, Folge der Unwirksamkeit |
+| Betriebsübergang im Raum | `ar-betriebsuebergang-spezial` | Widerspruchsfrist § 613a VI BGB (1 Monat), Informationsanspruch |
 
-- Normen und Rechtsprechung nach `references/quellenhygiene.md` und `references/zitierweise.md` behandeln.
-- Wenn eine Spezialfrage sichtbar wird, den passenden Skill nennen und kurz erklären, warum genau dieser Arbeitsgang passt.
-- Bei Zeitdruck zuerst Frist, Zuständigkeit, Form und Beweislast sichern.
+## Norm-Radar (live verifizieren)
+
+- **§ 4 KSchG** — 3-Wochen-Frist Kündigungsschutzklage
+- **§ 626 BGB** — außerordentliche Kündigung, 2-Wochen-Frist Abs. 2
+- **§ 1 KSchG** — Sozialwidrigkeit; KSchG-Anwendung ab 10 AN (Kleinbetrieb)
+- **§§ 611a, 615 BGB** — Arbeitsvertrag, Annahmeverzug
+- **§ 613a BGB** — Betriebsübergang; Widerspruchsrecht Abs. 6
+- **§ 102 BetrVG** — Anhörung Betriebsrat; Folge der Unwirksamkeit
+
+## Genau eine Rückfrage (nur wenn nötig)
+
+> Liegt eine **Kündigung mit Zugangsdatum** vor — oder ist der Triggerpunkt ein anderer (Befristung, Lohn, Aufhebungsvertrag, AGG)?
+
+Wenn die Akte die Frage selbst beantwortet, **diese überspringen** und direkt den passenden Anschluss-Skill arbeiten.
+
+## Hinweis
+
+Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte. Quellenhygiene nach `references/quellenhygiene.md`, Zitierform nach `references/zitierweise.md`. Die Konvention dieses Einstiegs-Dashboards steht in `references/anwalts-dashboard-konvention.md`.

--- a/fachanwalt-erbrecht/skills/einstieg-routing/SKILL.md
+++ b/fachanwalt-erbrecht/skills/einstieg-routing/SKILL.md
@@ -1,42 +1,55 @@
 ---
 name: einstieg-routing
-description: "Einstieg, Triage und Routing für Fachanwalt Erbrecht: ordnet Rolle (Erblasser (Beratung), Erben, Vermächtnisnehmer), markiert Frist (Ausschlagung 6 Wochen § 1944 BGB), wählt Norm (BGB §§ 1922 ff., ErbStG, FamFG §§ 342 ff.) und Zuständigkeit (Nachlassgericht (AG)), leitet zum passenden Spezial-Skill."
+description: "Anwalts-Dashboard Fachanwalt Erbrecht: Sofort-Triage als Tabelle (Rolle, Verfahrensstand, Eilfrist, Hauptanspruch, Zuständigkeit), Risiko-Ampel, Anschluss-Skill-Router mit echten Slugs, Norm-Radar; maximal eine Rückfrage. Der Anwalt bleibt im Driver Seat."
 ---
 
-# Einstieg und Routing
+# Anwalts-Dashboard Fachanwalt Erbrecht
 
-## Einsatzlage
+> Erbfall, Pflichtteil, Erbschein, Erbengemeinschaft, Testament — Ausschlagungsfrist tickt ab Kenntnis. Wer beerbt wen, wann?
+>
+> Sie sehen unten die Sofort-Triage. Keine Rückfragen, bis die Tabelle steht. Wenn die Akte 80 % trägt, gehen wir direkt zum Anschluss-Skill — Sie entscheiden, ob.
 
-Dieser Einstieg routet **Fachanwalt Erbrecht** vom ersten Sachverhalt zu Rollen, Fristen, zuständiger Stelle, passendem Spezialpfad und nächstem Arbeitsprodukt.
+## Sofort-Triage
 
-## Fachlandkarte dieses Plugins
+| Punkt | Schnellprüfung | Standardquelle / Hilfsweg |
+| --- | --- | --- |
+| Rolle | Wen vertrete ich? (Mandant · Gegenseite · Mehrere) | Mandantenmail, Vertretungsbestellung |
+| Verfahrensstand | Vorprozessual · außergerichtlich · Klage · Rechtsmittel · Vollstreckung | Vorhandene Schriftsätze, Eingangsstempel |
+| Eilfrist | **§ 1944 BGB: 6 Wochen** Ausschlagung ab Kenntnis von Anfall und Berufungsgrund (6 Monate bei Auslandsbezug). § 1954 BGB: Anfechtung der Annahme/Ausschlagung 6 Wochen. § 2306 BGB: Ausschlagungsrecht bei Beschwerung 6 Wochen. § 2082 BGB: Anfechtung Testament 1 Jahr ab Kenntnis. § 2332 BGB: Pflichtteils-Verjährung 3 Jahre. | Frist aus Zugangs-/Kenntnisdatum berechnen |
+| Hauptanspruch | Erbe §§ 1922, 1942 BGB · Pflichtteil §§ 2303 ff. BGB · Pflichtteilsergänzung §§ 2325 ff. BGB · Auskunft § 2314 BGB · Auseinandersetzung §§ 2042 ff. BGB · Erbschein §§ 2353 ff. BGB · Vermächtnis §§ 2147 ff. BGB. | Sachverhaltsabgleich mit Tatbestandsmerkmalen |
+| Zuständigkeit | Nachlassgericht am letzten gewöhnlichen Aufenthalt (§ 343 FamFG). Streitige Erbsachen: LG/AG nach Streitwert (§ 27 ZPO). | Gesetz, Vertrag, Gerichtsstandsklausel |
 
-- `berater-mehrparteien-konflikt-und-interessen` — Berater Interessen Beweislast Darlegungslast
-- `workflow-mandantenkommunikation` — BGB
-- `digitaler-nachlass-facebook-bgh-iii-zr-183-17` — Digitaler Nachlass Facebook BGH III ZR 183 17
-- `ehegattentestament-bindungswirkung` — Ehegattentestament Bindungswirkung
-- `erb-einfuehrung-erbfolge-system` — ERB Einfuehrung Erbfolge Erstgespraech
-- `erb-nachlassinventar-erstellung` — ERB Nachlassinventar Pflichtteilsanspruch
-- `erbengemeinschaft-blockade-auseinandersetzung` — Erbengemeinschaft Blockade Erstgespraech
-- `internationaler-erbfall-eu-erbvo` — Erbfall EU Mandat Triage Pflichtteil Auskunft
-- `erbfall-intake-und-nachlassordnung` — Erbfall Intake Erbrecht Erbschein
-- `pflichtteilsergaenzung-2325` — Erbrecht Pflichtteilsergaenzung Schenkung
-- `erbschein-antrag` — Erbschein Antrag Orientierung
-- `erbschein-einziehung-paragraf-2361-bgb-olg-muenchen-31-wx-275-19` — Erbschein Einziehung Paragraf 2361 BGB OLG Muenchen 31 WX 275 19
-- `erbverzicht-pflichtteilsverzicht` — Erbverzicht Pflichtteilsverzicht
-- `anschluss-routing` — Anschluss Routing
-- `dokumente-intake` — Dokumente Intake
+## Risiko-Ampel
 
-## Arbeitsweg
+- **Frist:** 🔴 Ausschlagungsfrist 6 Wochen läuft ab Kenntnis; Akten dokumentieren. 🟠 Pflichtteilsergänzung (10-Jahresfrist § 2325 III BGB) und Pflichtteils-Verjährung (3 Jahre) gegen Schenkungen verfolgen.
+- **Beweislage:** 🟠 Pflichtteils-Auskunft § 2314 BGB lückenhaft → notarielles Verzeichnis erzwingen. 🔴 Testament: Testierfähigkeit Beweis (medizinische Akten, Zeugen, ggf. Sachverständige).
+- **Wirtschaftlich:** 🔴 Nachlassinsolvenz droht → § 1980 BGB Antrag (binnen 3 Monaten), Erbenhaftungsbeschränkung. 🟠 Hoher Nachlasswert: Pflichtteilsanspruch parallel zu Auseinandersetzung.
 
-- Rolle und Ziel klären: Welche Partei vertritt der Mandant, welcher Ergebnistyp wird gebraucht (Schriftsatz, Bescheidprüfung, Vertragsentwurf, Stellungnahme), welches Verfahren oder Dokument liegt vor?
-- Eilfristen isolieren: die im Fachgebiet einschlägigen Verfahrens- und materiellen Fristen pflichtmäßig vorab markieren und nicht aus Modellwissen finalisieren.
-- Fachpfad wählen: zentrale Anker im Fachanwalt Erbrecht sind BGB, §§ 1922 ff. Anhand des Sachverhalts in einen Sach-Cluster routen und den passenden Spezial-Skill aus der Fachlandkarte oben benennen.
-- Zuständige Stelle bestimmen: Mandant, Gegner, zuständiges Gericht oder Behörde, etwaige Sachverständige oder beauftragte Stellen.
-- Nur die Rückfragen stellen, die die nächste Weiche tatsächlich ändern.
+## Anschluss-Skills (Router)
 
-## Qualitätsanker
+| Wenn der Fall trägt … | dann Skill | Erwartung |
+| --- | --- | --- |
+| **Pflichtteil berechnen / geltend machen** | `pflichtteil-berechnen` | Pflichtteilsquote, Wertermittlung, Auskunftsverfahren § 2314 BGB |
+| Ausschlagung der Erbschaft | `erbschaftsausschlagung` | 6-Wochen-Frist § 1944 BGB, notarielle/gerichtliche Erklärung |
+| Testament auslegen | `testament-auslegung-und-andeutung` | Andeutungstheorie, Auslegungsregeln, ergänzende Auslegung |
+| Erbschein beantragen | `erbschein-antrag` | Antrag, Glaubhaftmachung, eidesstattliche Versicherung |
+| Erbengemeinschaft blockiert | `erbengemeinschaft-blockade-auseinandersetzung` | Teilungsklage, Vermittlungsverfahren §§ 363 ff. FamFG |
 
-- Normen und Rechtsprechung nach `references/quellenhygiene.md` und `references/zitierweise.md` behandeln.
-- Wenn eine Spezialfrage sichtbar wird, den passenden Skill nennen und kurz erklären, warum genau dieser Arbeitsgang passt.
-- Bei Zeitdruck zuerst Frist, Zuständigkeit, Form und Beweislast sichern.
+## Norm-Radar (live verifizieren)
+
+- **§ 1944 BGB** — Ausschlagungsfrist 6 Wochen
+- **§ 2303 BGB** — Pflichtteilsanspruch
+- **§ 2314 BGB** — Auskunftsanspruch des Pflichtteilsberechtigten
+- **§ 2325 BGB** — Pflichtteilsergänzung; 10-Jahres-Abschmelzung
+- **§ 2353 BGB** — Erbschein
+- **§ 1980 BGB** — Antrag Nachlassinsolvenz
+
+## Genau eine Rückfrage (nur wenn nötig)
+
+> Vertreten Sie **Erbe(n), Pflichtteilsberechtigte oder Vermächtnisnehmer** — und steht eine **Frist** (Ausschlagung, Anfechtung) oder eine **Verteilungsfrage** im Vordergrund?
+
+Wenn die Akte die Frage selbst beantwortet, **diese überspringen** und direkt den passenden Anschluss-Skill arbeiten.
+
+## Hinweis
+
+Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte. Quellenhygiene nach `references/quellenhygiene.md`, Zitierform nach `references/zitierweise.md`. Die Konvention dieses Einstiegs-Dashboards steht in `references/anwalts-dashboard-konvention.md`.

--- a/fachanwalt-familienrecht/skills/einstieg-routing/SKILL.md
+++ b/fachanwalt-familienrecht/skills/einstieg-routing/SKILL.md
@@ -1,42 +1,55 @@
 ---
 name: einstieg-routing
-description: "Einstieg, Triage und Routing für Fachanwalt Familienrecht: ordnet Rolle (Ehegatten, Kinder, Jugendamt), markiert Frist (Trennungsjahr § 1565 BGB), wählt Norm (BGB §§ 1297 ff., FamFG, VersAusglG) und Zuständigkeit (Familiengericht (AG)), leitet zum passenden Spezial-Skill."
+description: "Anwalts-Dashboard Fachanwalt Familienrecht: Sofort-Triage als Tabelle (Rolle, Verfahrensstand, Eilfrist, Hauptanspruch, Zuständigkeit), Risiko-Ampel, Anschluss-Skill-Router mit echten Slugs, Norm-Radar; maximal eine Rückfrage. Der Anwalt bleibt im Driver Seat."
 ---
 
-# Einstieg und Routing
+# Anwalts-Dashboard Fachanwalt Familienrecht
 
-## Einsatzlage
+> Trennung, Unterhalt, Versorgungsausgleich, Sorge- und Umgangsrecht — meist Verbundverfahren, meist im Hintergrund das Kindeswohl.
+>
+> Sie sehen unten die Sofort-Triage. Keine Rückfragen, bis die Tabelle steht. Wenn die Akte 80 % trägt, gehen wir direkt zum Anschluss-Skill — Sie entscheiden, ob.
 
-Dieser Einstieg routet **Fachanwalt Familienrecht** vom ersten Sachverhalt zu Rollen, Fristen, zuständiger Stelle, passendem Spezialpfad und nächstem Arbeitsprodukt.
+## Sofort-Triage
 
-## Fachlandkarte dieses Plugins
+| Punkt | Schnellprüfung | Standardquelle / Hilfsweg |
+| --- | --- | --- |
+| Rolle | Wen vertrete ich? (Mandant · Gegenseite · Mehrere) | Mandantenmail, Vertretungsbestellung |
+| Verfahrensstand | Vorprozessual · außergerichtlich · Klage · Rechtsmittel · Vollstreckung | Vorhandene Schriftsätze, Eingangsstempel |
+| Eilfrist | Keine 3-Wochen-Frist wie im ArbR, aber: § 1565 II BGB (Härtefall-Scheidung vor Trennungsjahr), §§ 1666, 1666a BGB i. V. m. § 49 FamFG (Kindeswohlgefährdung — sofort), § 36 GewSchG (Gewaltschutz — sofortige Wirksamkeit). | Frist aus Zugangs-/Kenntnisdatum berechnen |
+| Hauptanspruch | Scheidung §§ 1564 ff. BGB · Trennungsunterhalt § 1361 BGB · Nachehelicher Unterhalt §§ 1569 ff. BGB · Kindesunterhalt §§ 1601 ff. BGB · Zugewinn §§ 1372 ff. BGB · Versorgungsausgleich §§ 1, 9 VersAusglG · Sorge §§ 1671, 1684 BGB · Umgang § 1684 BGB. | Sachverhaltsabgleich mit Tatbestandsmerkmalen |
+| Zuständigkeit | Familiengericht (Abt. AG) am Aufenthalt des Kindes oder gemeinsamen Wohnsitzes (§§ 122, 152, 232 FamFG). Anwaltszwang in Ehesachen (§ 114 FamFG). | Gesetz, Vertrag, Gerichtsstandsklausel |
 
-- `anpassung-wegen-unterhalt-33-ff-versausglg` — Anpassung Wegen Anwartschaft Dynamisch
-- `anrechte-dokumentenintake` — Anrechte Dokumentenintake
-- `beamtenrechtliche-kuerzung-und-rueckausnahme` — Beamtenrechtliche Kuerzung Beamtenversorgung
-- `ehegattenrecht-internationales-art-13-egbgb` — Ehegattenrecht Internationales ART 13 Egbgb
-- `ehevertrag-sittenwidrigkeit-bgh-xii-zr-129-04` — Ehevertrag Sittenwidrigkeit BGH XII ZR 129 04
-- `erstgespraech-mandatsannahme` — Erstgespraech Mandatsannahme EU
-- `workflow-fristen-und-risikoampel` — FA Familienrecht Fristen Risiko Mandant
-- `kindeswohlgefaehrdung-eilantrag` — Fachanwalt Familienrecht
-- `famfg-quellenkarte` — Famfg Quellenkarte
-- `familiengericht-verhandlung-vergleich-und-eskalation` — Familiengericht Familienrecht
-- `famr-mandantenaufnahme-spezial` — Famr Mandantenaufnahme Regenbogenfamilien
-- `allgemein-familienrecht-normenradar` — Famr Trennungsfolgen
-- `geringfuegigkeit-18-versausglg` — Geringfuegigkeit Versausglg Gesetzliche
-- `dokumente-intake` — Dokumente Intake
-- `output-waehlen` — Output Waehlen
+## Risiko-Ampel
 
-## Arbeitsweg
+- **Frist:** 🔴 Kindeswohlgefährdung: sofort Eilantrag (§ 49 FamFG). 🔴 Häusliche Gewalt: Schutzanordnung § 1 GewSchG. 🟠 Trennungsjahr: Datum dokumentieren (Beweis!).
+- **Beweislage:** 🟠 Trennungszeitpunkt — Indizien (Kontotrennung, Schlafzimmer, schriftliche Erklärung). 🔴 Sorgekonflikt: Beweismittel sorgsam (kein Aufschaukeln, Verfahrensbeistand respektieren).
+- **Wirtschaftlich:** 🟠 Hohes Vermögen: Zugewinn parallel zur Scheidung (Verbund). 🔴 Drohende Verschiebung von Vermögen: § 1379 BGB Auskunft + § 1390 BGB Anfechtung.
 
-- Rolle und Ziel klären: Welche Partei vertritt der Mandant, welcher Ergebnistyp wird gebraucht (Schriftsatz, Bescheidprüfung, Vertragsentwurf, Stellungnahme), welches Verfahren oder Dokument liegt vor?
-- Eilfristen isolieren: die im Fachgebiet einschlägigen Verfahrens- und materiellen Fristen pflichtmäßig vorab markieren und nicht aus Modellwissen finalisieren.
-- Fachpfad wählen: zentrale Anker im Fachanwalt Familienrecht sind FamFG. Anhand des Sachverhalts in einen Sach-Cluster routen und den passenden Spezial-Skill aus der Fachlandkarte oben benennen.
-- Zuständige Stelle bestimmen: Mandant, Gegner, zuständiges Gericht oder Behörde, etwaige Sachverständige oder beauftragte Stellen.
-- Nur die Rückfragen stellen, die die nächste Weiche tatsächlich ändern.
+## Anschluss-Skills (Router)
 
-## Qualitätsanker
+| Wenn der Fall trägt … | dann Skill | Erwartung |
+| --- | --- | --- |
+| **Trennung — Trennungsjahr / Folgen** | `famr-trennungsjahr-praxis` | Trennungszeitpunkt dokumentieren, Trennungsunterhalt vorbereiten |
+| Kindesunterhalt zu prüfen | `kindesunterhalt-mindestsatz-paragraf-1612a-bgb` | Mindestunterhalt, Düsseldorfer Tabelle, Mangelfall-Berechnung |
+| Versorgungsausgleich offen | `famr-versorgungsausgleich-spezial` | Auskunftsverfahren VAB-Fragebogen, Halbteilung, Ausschluss |
+| Gewaltschutz / Umgang in Konflikt | `gewaltschutz-und-umgang-schnittstelle` | GewSchG-Anordnung, Schnittstelle Umgang § 1684 BGB |
+| Kindeswohlgefährdung — Eilantrag | `famr-kindeswohlgefaehrdung-eilantrag-spezial` | Eilantrag § 1666 BGB, Verfahrensbeistand, Jugendamt |
 
-- Normen und Rechtsprechung nach `references/quellenhygiene.md` und `references/zitierweise.md` behandeln.
-- Wenn eine Spezialfrage sichtbar wird, den passenden Skill nennen und kurz erklären, warum genau dieser Arbeitsgang passt.
-- Bei Zeitdruck zuerst Frist, Zuständigkeit, Form und Beweislast sichern.
+## Norm-Radar (live verifizieren)
+
+- **§ 1565 BGB** — Scheidungsvoraussetzung, Trennungsjahr
+- **§ 1361 BGB** — Trennungsunterhalt
+- **§ 1612a BGB** — Mindestkindesunterhalt
+- **§ 1666 BGB** — Maßnahmen bei Kindeswohlgefährdung
+- **§ 1684 BGB** — Umgangsrecht / Umgangspflicht
+- **§ 1 VersAusglG** — Halbteilungsgrundsatz
+
+## Genau eine Rückfrage (nur wenn nötig)
+
+> Geht es vorrangig um **Trennungs-/Scheidungsfolgen (Unterhalt, Zugewinn, VA)** oder um eine **akute Kindes- bzw. Gewaltschutz-Sache** (dann sofortiger Eilantrag)?
+
+Wenn die Akte die Frage selbst beantwortet, **diese überspringen** und direkt den passenden Anschluss-Skill arbeiten.
+
+## Hinweis
+
+Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte. Quellenhygiene nach `references/quellenhygiene.md`, Zitierform nach `references/zitierweise.md`. Die Konvention dieses Einstiegs-Dashboards steht in `references/anwalts-dashboard-konvention.md`.

--- a/fachanwalt-handels-gesellschaftsrecht/skills/einstieg-routing/SKILL.md
+++ b/fachanwalt-handels-gesellschaftsrecht/skills/einstieg-routing/SKILL.md
@@ -1,42 +1,55 @@
 ---
 name: einstieg-routing
-description: "Einstieg, Triage und Routing für Fachanwalt Handels- und Gesellschaftsrecht: ordnet Rolle (Gesellschafter/Aktionäre, Vorstand/Geschäftsführung, Aufsichtsrat), markiert Frist (§ 246 AktG Anfechtung 1 Monat), wählt Norm (HGB, GmbHG, AktG, BGB §§ 705 ff., UmwG) und Zuständigkeit (Handelsregister), l..."
+description: "Anwalts-Dashboard Fachanwalt Handels- und Gesellschaftsrecht: Sofort-Triage als Tabelle (Rolle, Verfahrensstand, Eilfrist, Hauptanspruch, Zuständigkeit), Risiko-Ampel, Anschluss-Skill-Router mit echten Slugs, Norm-Radar; maximal eine Rückfrage. Der Anwalt bleibt im Driver Seat."
 ---
 
-# Einstieg und Routing
+# Anwalts-Dashboard Fachanwalt Handels- und Gesellschaftsrecht
 
-## Einsatzlage
+> Gesellschafterstreit, Geschäftsführerhaftung, Anfechtungsklage, M&A, Handelsvertreterausgleich — Beteiligungsverhältnisse und Beschlüsse zuerst klären.
+>
+> Sie sehen unten die Sofort-Triage. Keine Rückfragen, bis die Tabelle steht. Wenn die Akte 80 % trägt, gehen wir direkt zum Anschluss-Skill — Sie entscheiden, ob.
 
-Dieser Einstieg routet **Fachanwalt Handels Gesellschaftsrecht** vom ersten Sachverhalt zu Rollen, Fristen, zuständiger Stelle, passendem Spezialpfad und nächstem Arbeitsprodukt.
+## Sofort-Triage
 
-## Fachlandkarte dieses Plugins
+| Punkt | Schnellprüfung | Standardquelle / Hilfsweg |
+| --- | --- | --- |
+| Rolle | Wen vertrete ich? (Mandant · Gegenseite · Mehrere) | Mandantenmail, Vertretungsbestellung |
+| Verfahrensstand | Vorprozessual · außergerichtlich · Klage · Rechtsmittel · Vollstreckung | Vorhandene Schriftsätze, Eingangsstempel |
+| Eilfrist | **§ 246 AktG: 1 Monat** Anfechtungsklage Hauptversammlungsbeschluss. § 256 AktG (Nichtigkeitsklage). GmbH-Beschlüsse: analog 1 Monat (h. M., kein gesetzlicher Frist, vertragliche Regelungen prüfen). § 89b HGB: Ausgleichsanspruch Handelsvertreter 1 Jahr nach Ende. § 161 II AktG: Erklärung Corporate Governance jährlich. | Frist aus Zugangs-/Kenntnisdatum berechnen |
+| Hauptanspruch | Anfechtung Beschluss § 243 AktG · Nichtigkeit § 241 AktG · GF-Haftung §§ 43 GmbHG, 93 AktG · Treuepflicht (st. Rspr.) · Wettbewerbsverbot § 88 AktG · Auskunft § 51a GmbHG · Handelsvertreterausgleich § 89b HGB · Einsicht Kommanditist § 166 HGB. | Sachverhaltsabgleich mit Tatbestandsmerkmalen |
+| Zuständigkeit | LG Kammer für Handelssachen (§§ 95, 96 GVG) — auf Antrag (§ 98 GVG). Schiedsklauseln verbreitet → vorab Schiedsvereinbarung prüfen (§ 1029 ZPO). | Gesetz, Vertrag, Gerichtsstandsklausel |
 
-- `ag-vorstandsvertrag-vorbereiten` — AG Vorstandsvertrag HGR
-- `aktionaersklage-anfechtung-paragraf-243-aktg` — Aktionaersklage Anfechtung Paragraf 243 AKTG
-- `anfechtungsklage-bgb-gesellschaft-bgh-ii-zr-66-20` — Anfechtungsklage BGB Gesellschaft BGH II ZR 66 20
-- `einstieg-schnelltriage-fallrouting` — FA Handels Gesellschaft Start Chronologie Fristen
-- `erstpruefung-und-mandatsziel` — Fachanwalt FAO Gesellschafterstreit
-- `geschaeftsfuehrerhaftung-zahlen-schwellen-und-berechnung` — Geschaeftsfuehrerhaftung Holding
-- `gesellschafterstreit` — Gesellschaftsrecht Gesellschafterstreit Eilrechtsschutz
-- `gesellschaftervertrag-abschlussprodukt-und-uebergabe` — Gesellschaftsrecht Gesellschaftervertrag Klauseln
-- `gmbh-beirat-vetorechte-und-organnaehe` — Gmbh Beirat Vergleichsverhandlung Strategie
-- `gmbh-gf-haftung-paragraf-43-gmbhg` — Gmbh GF Haftung Paragraf 43 GMBHG
-- `gmbhg-schriftsatz-brief-und-memo-bausteine` — GMBHG Handels Handelsvertreterausgleich
-- `workflow-mandantenkommunikation` — Handels Gesellschaftsrecht Mandantenkommunikation Redteam
-- `hgb-einsichtsrecht-kommanditist-paragraf-166-hgb-bgh-ii-zr-31-21` — HGB Einsichtsrecht Kommanditist Paragraf 166 HGB BGH II ZR 31 21
-- `anschluss-routing` — Anschluss Routing
-- `dokumente-intake` — Dokumente Intake
+## Risiko-Ampel
 
-## Arbeitsweg
+- **Frist:** 🔴 Anfechtungsklage Hauptversammlungsbeschluss § 246 AktG (1 Monat ab Beschlussfassung). 🟠 Ausgleichsanspruch HV § 89b III HGB Geltendmachung 1 Jahr nach Vertragsbeendigung.
+- **Beweislage:** 🟠 Beschlussfassung: Protokoll, Versammlungsleitung, Beschlussverfahren. 🔴 GF-Haftung: Geschäftsvorfall, Vorteilsabsicht, Kausalität — Buchhaltung sichern.
+- **Wirtschaftlich:** 🔴 Insolvenzantragspflicht § 15a InsO (3 Wochen ab Eintritt Zahlungsunfähigkeit) — parallel zur Geschäftsführerhaftung mitdenken. 🟠 M&A: Due-Diligence-Findings als Verhandlungsmasse.
 
-- Rolle und Ziel klären: Welche Partei vertritt der Mandant, welcher Ergebnistyp wird gebraucht (Schriftsatz, Bescheidprüfung, Vertragsentwurf, Stellungnahme), welches Verfahren oder Dokument liegt vor?
-- Eilfristen isolieren: die im Fachgebiet einschlägigen Verfahrens- und materiellen Fristen pflichtmäßig vorab markieren und nicht aus Modellwissen finalisieren.
-- Fachpfad wählen: zentrale Anker im Fachanwalt Handels Gesellschaftsrecht sind AktG, GmbHG, HGB, MoPeG, PartGG, UmwG, § 14i, § 89b HGB. Anhand des Sachverhalts in einen Sach-Cluster routen und den passenden Spezial-Skill aus der Fachlandkarte oben benennen.
-- Zuständige Stelle bestimmen: Mandant, Gegner, zuständiges Gericht oder Behörde, etwaige Sachverständige oder beauftragte Stellen.
-- Nur die Rückfragen stellen, die die nächste Weiche tatsächlich ändern.
+## Anschluss-Skills (Router)
 
-## Qualitätsanker
+| Wenn der Fall trägt … | dann Skill | Erwartung |
+| --- | --- | --- |
+| **Geschäftsführerhaftung im Raum** | `gmbh-gf-haftung-paragraf-43-gmbhg` | Pflichtverstoß, Schaden, Verschulden, Entlastung § 46 Nr. 5 GmbHG |
+| Hauptversammlungsbeschluss anfechten | `aktionaersklage-anfechtung-paragraf-243-aktg` | 1-Monatsfrist § 246 AktG, Anfechtungsbefugnis |
+| Gesellschafterstreit GmbH | `gesellschafterstreit` | Ausschluss, Einziehung, Treuepflichtklage |
+| Handelsvertreterausgleich § 89b HGB | `handelsvertreterausgleich` | Voraussetzungen, Berechnung, Geltendmachungs-Frist |
+| M&A Due-Diligence Befunde | `ma-due-diligence-findings` | Risikoclustering, SPA-Anpassungen, Earn-out-/MAC-Klauseln |
 
-- Normen und Rechtsprechung nach `references/quellenhygiene.md` und `references/zitierweise.md` behandeln.
-- Wenn eine Spezialfrage sichtbar wird, den passenden Skill nennen und kurz erklären, warum genau dieser Arbeitsgang passt.
-- Bei Zeitdruck zuerst Frist, Zuständigkeit, Form und Beweislast sichern.
+## Norm-Radar (live verifizieren)
+
+- **§ 243 AktG** — Anfechtbarkeit Hauptversammlungsbeschluss
+- **§ 246 AktG** — 1-Monatsfrist Anfechtungsklage
+- **§ 43 GmbHG** — Geschäftsführerhaftung
+- **§ 51a GmbHG** — Auskunftsrecht des GmbH-Gesellschafters
+- **§ 89b HGB** — Handelsvertreterausgleich
+- **§ 15a InsO** — Insolvenzantragspflicht
+
+## Genau eine Rückfrage (nur wenn nötig)
+
+> Steht ein **Beschluss zur Anfechtung** im Raum, **Haftung eines Organs** oder ein **Vertragsstreit** (Handelsvertreter, M&A) im Vordergrund?
+
+Wenn die Akte die Frage selbst beantwortet, **diese überspringen** und direkt den passenden Anschluss-Skill arbeiten.
+
+## Hinweis
+
+Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte. Quellenhygiene nach `references/quellenhygiene.md`, Zitierform nach `references/zitierweise.md`. Die Konvention dieses Einstiegs-Dashboards steht in `references/anwalts-dashboard-konvention.md`.

--- a/fachanwalt-insolvenz-sanierungsrecht/skills/einstieg-routing/SKILL.md
+++ b/fachanwalt-insolvenz-sanierungsrecht/skills/einstieg-routing/SKILL.md
@@ -1,42 +1,55 @@
 ---
 name: einstieg-routing
-description: "Einstieg, Triage und Routing für Fachanwalt Insolvenz- und Sanierungsrecht: ordnet Rolle (Schuldnerunternehmen, Geschäftsführung (Haftung!), Insolvenzverwalter), markiert Frist (§ 15a InsO 3 Wochen Antragspflicht), wählt Norm (InsO, StaRUG, InsVV) und Zuständigkeit (Insolvenzgericht (AG)), leitet..."
+description: "Anwalts-Dashboard Fachanwalt Insolvenz- und Sanierungsrecht: Sofort-Triage als Tabelle (Rolle, Verfahrensstand, Eilfrist, Hauptanspruch, Zuständigkeit), Risiko-Ampel, Anschluss-Skill-Router mit echten Slugs, Norm-Radar; maximal eine Rückfrage. Der Anwalt bleibt im Driver Seat."
 ---
 
-# Einstieg und Routing
+# Anwalts-Dashboard Fachanwalt Insolvenz- und Sanierungsrecht
 
-## Einsatzlage
+> Antragspflicht, Eigenverwaltung, Anfechtung, Restrukturierung — die 3-Wochen-Frist § 15a InsO ist der Taktgeber.
+>
+> Sie sehen unten die Sofort-Triage. Keine Rückfragen, bis die Tabelle steht. Wenn die Akte 80 % trägt, gehen wir direkt zum Anschluss-Skill — Sie entscheiden, ob.
 
-Dieser Einstieg routet **Fachanwalt Insolvenz Sanierungsrecht** vom ersten Sachverhalt zu Rollen, Fristen, zuständiger Stelle, passendem Spezialpfad und nächstem Arbeitsprodukt.
+## Sofort-Triage
 
-## Fachlandkarte dieses Plugins
+| Punkt | Schnellprüfung | Standardquelle / Hilfsweg |
+| --- | --- | --- |
+| Rolle | Wen vertrete ich? (Mandant · Gegenseite · Mehrere) | Mandantenmail, Vertretungsbestellung |
+| Verfahrensstand | Vorprozessual · außergerichtlich · Klage · Rechtsmittel · Vollstreckung | Vorhandene Schriftsätze, Eingangsstempel |
+| Eilfrist | **§ 15a I InsO: 3 Wochen** Insolvenzantragspflicht bei Zahlungsunfähigkeit / 6 Wochen bei Überschuldung (nach SanInsKG befristet). § 270b InsO: Schutzschirmverfahren — Antrag im Vorfeld der Insolvenz. § 174 InsO: Anmeldefrist Gläubiger nach öffentlicher Bekanntmachung. | Frist aus Zugangs-/Kenntnisdatum berechnen |
+| Hauptanspruch | Antragspflicht §§ 15a, 17 ff. InsO · Anfechtung §§ 129 ff. InsO · GF-Haftung § 64 GmbHG a. F. / § 15b InsO n. F. · Gläubigeranfechtung AnfG außerhalb Insolvenz · Schutzschirm § 270b InsO · Eigenverwaltung § 270 InsO · StaRUG (Stabilisierungs- und Restrukturierungsrahmen). | Sachverhaltsabgleich mit Tatbestandsmerkmalen |
+| Zuständigkeit | Insolvenzgericht (AG am Sitz, § 3 InsO). Restrukturierungsgericht nach StaRUG = LG (§§ 30 ff. StaRUG). Anfechtungsklage gegen Gläubiger: LG/AG nach Streitwert. | Gesetz, Vertrag, Gerichtsstandsklausel |
 
-- `absonderungsrecht-paragraf-50-inso` — Absonderungsrecht Paragraf 50 Inso
-- `anfechtung-vorsatz-paragraf-133-inso-bgh-ix-zr-65-16` — Anfechtung Vorsatz Paragraf 133 Inso BGH IX ZR 65 16
-- `eigenverwaltung-schutzschirm-paragraf-270b-inso` — Eigenverwaltung Schutzschirm Paragraf 270b Inso
-- `eroeffnung-behoerden-gericht-und-registerweg` — Eroeffnung Fachanwalt FAO Glaeubigerantrag
-- `fa-inso-sanierung-quellen-edge-case` — FA Inso Sanierung Quellen Edge Case
-- `fa-insolvenz-schuldschein-und-lma` — FA Schuldschein
-- `glaeubigerantrag` — Glaeubigerantrag Insolvenzanfechtung
-- `insolvenz-glaeubigerverhandlung-sanierung` — Glaeubigerverhandlung Sanierung IDW S6 Krypto
-- `insanw-eigenverwaltung-schutzschirm-spezial` — Insanw Eigenverwaltung Konzerninsolvenz
-- `einstieg-schnelltriage-fallrouting` — Insanw Fortbestehensprognose
-- `insolvenz-tatbestand-beweis-und-belege` — Insolvenz Insolvenzanfechtung Insolvenzrecht
-- `insolvenzgeld-paragraf-165-sgb-iii` — Insolvenzgeld Paragraf 165 SGB III
-- `insolvenzplan-paragraf-217-inso-bgh-ix-zb-66-19` — Insolvenzplan Paragraf 217 Inso BGH IX ZB 66 19
-- `anschluss-routing` — Anschluss Routing
-- `dokumente-intake` — Dokumente Intake
+## Risiko-Ampel
 
-## Arbeitsweg
+- **Frist:** 🔴 § 15a InsO: 3 Wochen ab Zahlungsunfähigkeit. Frist tickt taggenau — Kalender. 🟠 § 270b InsO: Vorbereitung vor Antrag in 4-8 Wochen.
+- **Beweislage:** 🔴 Zahlungsunfähigkeit § 17 II InsO: 3-Wochen-Liquiditätsstatus. Buchhaltungs- und Bankkontodaten sichern. 🟠 Überschuldung § 19 II InsO: Fortbestehensprognose dokumentieren.
+- **Wirtschaftlich:** 🔴 Geschäftsführerhaftung § 15b InsO (Zahlungen nach Insolvenzreife) — sofort einstellen. 🟠 Anfechtungsangriff in 4 Jahren (§ 133 InsO 10 Jahre Vorsatzanfechtung).
 
-- Rolle und Ziel klären: Welche Partei vertritt der Mandant, welcher Ergebnistyp wird gebraucht (Schriftsatz, Bescheidprüfung, Vertragsentwurf, Stellungnahme), welches Verfahren oder Dokument liegt vor?
-- Eilfristen isolieren: die im Fachgebiet einschlägigen Verfahrens- und materiellen Fristen pflichtmäßig vorab markieren und nicht aus Modellwissen finalisieren.
-- Fachpfad wählen: zentrale Anker im Fachanwalt Insolvenz Sanierungsrecht sind InsO, StaRUG, § 14, § 14 InsO, § 15a Gl, §§ 129 ff. Anhand des Sachverhalts in einen Sach-Cluster routen und den passenden Spezial-Skill aus der Fachlandkarte oben benennen.
-- Zuständige Stelle bestimmen: Mandant, Gegner, zuständiges Gericht oder Behörde, etwaige Sachverständige oder beauftragte Stellen.
-- Nur die Rückfragen stellen, die die nächste Weiche tatsächlich ändern.
+## Anschluss-Skills (Router)
 
-## Qualitätsanker
+| Wenn der Fall trägt … | dann Skill | Erwartung |
+| --- | --- | --- |
+| Fortbestehensprognose anwerfen | `insanw-fortbestehensprognose-workflow` | Liquiditätsplan 12 Monate, IDW S 11, Beweisdokument |
+| Eigenverwaltung / Schutzschirm § 270b | `insanw-eigenverwaltung-schutzschirm-spezial` | Antragsfähigkeit, Bescheinigung, Sachwalter |
+| **Antragspflicht § 15a InsO** | `inso-p015a-antragspflicht-bei-juristischen-personen-und-rechtsfa` | 3-Wochen-Frist, GF-Haftung, Strafrecht § 15a IV InsO |
+| Anfechtungsmandat (Gläubiger / Verwalter) | `insanw-anfechtungsmandat-leitfaden` | Tatbestände §§ 129 ff. InsO, Verteidigungsstrategie |
+| Konzerninsolvenz / Gruppenkoordination | `insanw-konzerninsolvenz-koordination-spezial` | Gruppen-Gerichtsstand § 3a InsO, Koordinationsverfahren |
 
-- Normen und Rechtsprechung nach `references/quellenhygiene.md` und `references/zitierweise.md` behandeln.
-- Wenn eine Spezialfrage sichtbar wird, den passenden Skill nennen und kurz erklären, warum genau dieser Arbeitsgang passt.
-- Bei Zeitdruck zuerst Frist, Zuständigkeit, Form und Beweislast sichern.
+## Norm-Radar (live verifizieren)
+
+- **§ 15a InsO** — Insolvenzantragspflicht — 3 Wochen / 6 Wochen
+- **§ 17 InsO** — Zahlungsunfähigkeit
+- **§ 19 InsO** — Überschuldung
+- **§ 270 InsO** — Eigenverwaltung; § 270b Schutzschirm
+- **§ 133 InsO** — Vorsatzanfechtung; 10-Jahres-Zeitraum
+- **§ 15b InsO** — Zahlungsverbot nach Insolvenzreife
+
+## Genau eine Rückfrage (nur wenn nötig)
+
+> Stehen wir **vor** der Antragstellung (Beratung GF / Sanierung) oder **nach** Verfahrenseröffnung (Verwalter, Gläubiger, Anfechtung)?
+
+Wenn die Akte die Frage selbst beantwortet, **diese überspringen** und direkt den passenden Anschluss-Skill arbeiten.
+
+## Hinweis
+
+Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte. Quellenhygiene nach `references/quellenhygiene.md`, Zitierform nach `references/zitierweise.md`. Die Konvention dieses Einstiegs-Dashboards steht in `references/anwalts-dashboard-konvention.md`.

--- a/fachanwalt-medizinrecht/skills/einstieg-routing/SKILL.md
+++ b/fachanwalt-medizinrecht/skills/einstieg-routing/SKILL.md
@@ -1,42 +1,55 @@
 ---
 name: einstieg-routing
-description: "Einstieg, Triage und Routing für Fachanwalt Medizinrecht: ordnet Rolle (Patient, Arzt/Krankenhaus, Krankenkasse), markiert Frist (Verjährung 3 Jahre § 195 BGB), wählt Norm (BGB §§ 630a ff. Behandlungsvertrag, AMG, MPDG, SGB V, BÄO, MBO-Ä) und Zuständigkeit (LG (Arzthaftung)), leitet zum passenden..."
+description: "Anwalts-Dashboard Fachanwalt Medizinrecht: Sofort-Triage als Tabelle (Rolle, Verfahrensstand, Eilfrist, Hauptanspruch, Zuständigkeit), Risiko-Ampel, Anschluss-Skill-Router mit echten Slugs, Norm-Radar; maximal eine Rückfrage. Der Anwalt bleibt im Driver Seat."
 ---
 
-# Einstieg und Routing
+# Anwalts-Dashboard Fachanwalt Medizinrecht
 
-## Einsatzlage
+> Behandlungsfehler, Aufklärungsmangel, Approbation, MVZ, Apothekenrecht — drei Welten: Haftung, Berufsrecht, Vergütung.
+>
+> Sie sehen unten die Sofort-Triage. Keine Rückfragen, bis die Tabelle steht. Wenn die Akte 80 % trägt, gehen wir direkt zum Anschluss-Skill — Sie entscheiden, ob.
 
-Dieser Einstieg routet **Fachanwalt Medizinrecht** vom ersten Sachverhalt zu Rollen, Fristen, zuständiger Stelle, passendem Spezialpfad und nächstem Arbeitsprodukt.
+## Sofort-Triage
 
-## Fachlandkarte dieses Plugins
+| Punkt | Schnellprüfung | Standardquelle / Hilfsweg |
+| --- | --- | --- |
+| Rolle | Wen vertrete ich? (Mandant · Gegenseite · Mehrere) | Mandantenmail, Vertretungsbestellung |
+| Verfahrensstand | Vorprozessual · außergerichtlich · Klage · Rechtsmittel · Vollstreckung | Vorhandene Schriftsätze, Eingangsstempel |
+| Eilfrist | Keine klassische 2-Wochen-Frist im Patientenrecht, aber: § 199 BGB Verjährung 3 Jahre ab Kenntnis (regelmäßig). § 41 BÄO i. V. m. VwGO: 1 Monat Widerspruch gegen Approbationsbescheid. § 80 V VwGO: Eilantrag bei Ruhensanordnung. § 287 ZPO/§ 287a ZPO Beweismaßerleichterung Patientenseite. | Frist aus Zugangs-/Kenntnisdatum berechnen |
+| Hauptanspruch | Behandlungsvertrag § 630a BGB · Aufklärung § 630e BGB · Dokumentation § 630f BGB · Beweisrechtsumkehr § 630h BGB · Schmerzensgeld § 253 II BGB · Schadensersatz §§ 280, 823 BGB · Approbation §§ 3, 5 BÄO · Verträge mit Krankenkassen § 75 SGB V. | Sachverhaltsabgleich mit Tatbestandsmerkmalen |
+| Zuständigkeit | Zivilklage Patient ↔ Arzt: LG (regelmäßig Spezialkammer Arzthaftung). Berufsrechtliche Sache: VG / OVG (§ 40 VwGO). Schlichtungsstelle Ärztekammer fakultativ. | Gesetz, Vertrag, Gerichtsstandsklausel |
 
-- `aerzte-quellenkarte` — Aerzte Quellenkarte
-- `aerztewerbung-innovative-therapie` — Aerztewerbung Innovative Amnog Millionen
-- `anaesthesie-hochrisiko-aufklaerung` — Anaesthesie Hochrisiko Approbation Digitales
-- `apothekenrecht-arzneimittel-paragraf-78-amg` — Apothekenrecht Arzneimittel Paragraf 78 AMG
-- `apothekenrecht-mehrparteien-konflikt-und-interessen` — Apothekenrecht Interessen Aufklaerung
-- `arzthaftung-aufklaerung-bgb` — Arzthaftung Aufklaerung BGB
-- `atmp-chain-of-identity` — Atmp Chain Classification
-- `atmp-pharmakovigilanz-rmp` — Atmp Pharmakovigilanz Aufklaerungsfehler
-- `aufklaerungsfehler` — Aufklaerungsfehler Behandlungsfehler
-- `aufklaerungspflicht-paragraf-630e-bgb` — Aufklaerungspflicht Paragraf 630e BGB
-- `behandlungsfehler-paragraf-630h-bgb` — Behandlungsfehler Paragraf 630h BGB
-- `berufsrecht-verhandlung-vergleich-und-eskalation` — Berufsrecht BGB Einwilligung Sonderfall
-- `beweislast-hightech-medizin` — Beweislast Hightech Biobank Consent
-- `anschluss-routing` — Anschluss Routing
-- `dokumente-intake` — Dokumente Intake
+## Risiko-Ampel
 
-## Arbeitsweg
+- **Frist:** 🟠 Verjährung Patientenanspruch tickt ab Kenntnis (§ 199 BGB) — Schweigen der Klinik schiebt die Frist NICHT hinaus. 🔴 Approbationswiderruf: 1 Monat Widerspruch + Aufschiebenhebungsantrag § 80 V VwGO.
+- **Beweislage:** 🔴 Dokumentationslücke § 630h III BGB: Beweisrechtsumkehr zugunsten Patient. 🟠 Aufklärungsbeweis trägt der Arzt (§ 630h II BGB) — Aufklärungsbogen lückenlos prüfen.
+- **Wirtschaftlich:** 🔴 Approbationsentzug = Berufsende — Eilrechtsschutz und parallel Strafverteidigung (z. B. § 95 BtMG, § 263 StGB). 🟠 MVZ-Anstellung: Wettbewerbsverbot und Übergangsversorgung.
 
-- Rolle und Ziel klären: Welche Partei vertritt der Mandant, welcher Ergebnistyp wird gebraucht (Schriftsatz, Bescheidprüfung, Vertragsentwurf, Stellungnahme), welches Verfahren oder Dokument liegt vor?
-- Eilfristen isolieren: die im Fachgebiet einschlägigen Verfahrens- und materiellen Fristen pflichtmäßig vorab markieren und nicht aus Modellwissen finalisieren.
-- Fachpfad wählen: zentrale Anker im Fachanwalt Medizinrecht sind BGB, MPDG, SGB V, §§ 630a ff. Anhand des Sachverhalts in einen Sach-Cluster routen und den passenden Spezial-Skill aus der Fachlandkarte oben benennen.
-- Zuständige Stelle bestimmen: Mandant, Gegner, zuständiges Gericht oder Behörde, etwaige Sachverständige oder beauftragte Stellen.
-- Nur die Rückfragen stellen, die die nächste Weiche tatsächlich ändern.
+## Anschluss-Skills (Router)
 
-## Qualitätsanker
+| Wenn der Fall trägt … | dann Skill | Erwartung |
+| --- | --- | --- |
+| **Behandlungsfehler-Verdacht prüfen** | `behandlungsfehler-anspruch-pruefen` | Anspruchsgrundlagen § 630a/h BGB, Beweisrechtsumkehr, Sachverständige |
+| Aufklärungspflichtverletzung | `aufklaerungspflicht-paragraf-630e-bgb` | Aufklärungsumfang, Zeitpunkt, Beweislast § 630h II BGB |
+| Schlichtungsstelle prüfen | `gutachterkommission-aek-schlichtung` | Verfahrensvorteile, Hemmung der Verjährung § 204 I Nr. 4 BGB |
+| Approbationsbescheid angreifen | `approbations-widerspruch` | Widerspruch 1 Monat, Aufschubantrag § 80 V VwGO, Berufseingriffsabwehr |
+| Akteneinsicht / Befundherausgabe | `befundherausgabe-epa-akte` | Anspruch § 630g BGB, ePA-Spezifika, Verweigerung Vermerkbarkeit |
 
-- Normen und Rechtsprechung nach `references/quellenhygiene.md` und `references/zitierweise.md` behandeln.
-- Wenn eine Spezialfrage sichtbar wird, den passenden Skill nennen und kurz erklären, warum genau dieser Arbeitsgang passt.
-- Bei Zeitdruck zuerst Frist, Zuständigkeit, Form und Beweislast sichern.
+## Norm-Radar (live verifizieren)
+
+- **§ 630a BGB** — Behandlungsvertrag
+- **§ 630e BGB** — Aufklärungspflicht
+- **§ 630f BGB** — Dokumentationspflicht
+- **§ 630h BGB** — Beweislast bei Behandlungsfehler
+- **§ 3 BÄO** — Approbation; Voraussetzungen und Widerruf
+- **§ 199 BGB** — Verjährungsbeginn
+
+## Genau eine Rückfrage (nur wenn nötig)
+
+> Geht es um **Patient ↔ Behandler (Haftung)**, **Arzt/MVZ ↔ Behörde (Berufsrecht)** oder um **Vergütung / Kassenzulassung**?
+
+Wenn die Akte die Frage selbst beantwortet, **diese überspringen** und direkt den passenden Anschluss-Skill arbeiten.
+
+## Hinweis
+
+Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte. Quellenhygiene nach `references/quellenhygiene.md`, Zitierform nach `references/zitierweise.md`. Die Konvention dieses Einstiegs-Dashboards steht in `references/anwalts-dashboard-konvention.md`.

--- a/fachanwalt-miet-wohnungseigentumsrecht/skills/einstieg-routing/SKILL.md
+++ b/fachanwalt-miet-wohnungseigentumsrecht/skills/einstieg-routing/SKILL.md
@@ -1,42 +1,55 @@
 ---
 name: einstieg-routing
-description: "Einstieg, Triage und Routing für Fachanwalt Miet- und Wohnungseigentumsrecht: ordnet Rolle (Mieter, Vermieter, WEG-Eigentümer), markiert Frist (§ 573c BGB Kündigung), wählt Norm (BGB §§ 535-580a, WEG, BetrKV, HeizkostenV) und Zuständigkeit (Amtsgericht Belegenheit (Miete + WEG)), leitet zum passe..."
+description: "Anwalts-Dashboard Fachanwalt Miet- und Wohnungseigentumsrecht: Sofort-Triage als Tabelle (Rolle, Verfahrensstand, Eilfrist, Hauptanspruch, Zuständigkeit), Risiko-Ampel, Anschluss-Skill-Router mit echten Slugs, Norm-Radar; maximal eine Rückfrage. Der Anwalt bleibt im Driver Seat."
 ---
 
-# Einstieg und Routing
+# Anwalts-Dashboard Fachanwalt Miet- und Wohnungseigentumsrecht
 
-## Einsatzlage
+> Kündigung, Mieterhöhung, Betriebskosten, Mietminderung, WEG-Beschlussanfechtung — Vertragstyp und Zeitpunkt bestimmen die Schiene.
+>
+> Sie sehen unten die Sofort-Triage. Keine Rückfragen, bis die Tabelle steht. Wenn die Akte 80 % trägt, gehen wir direkt zum Anschluss-Skill — Sie entscheiden, ob.
 
-Dieser Einstieg routet **Fachanwalt Miet Wohnungseigentumsrecht** vom ersten Sachverhalt zu Rollen, Fristen, zuständiger Stelle, passendem Spezialpfad und nächstem Arbeitsprodukt.
+## Sofort-Triage
 
-## Fachlandkarte dieses Plugins
+| Punkt | Schnellprüfung | Standardquelle / Hilfsweg |
+| --- | --- | --- |
+| Rolle | Wen vertrete ich? (Mandant · Gegenseite · Mehrere) | Mandantenmail, Vertretungsbestellung |
+| Verfahrensstand | Vorprozessual · außergerichtlich · Klage · Rechtsmittel · Vollstreckung | Vorhandene Schriftsätze, Eingangsstempel |
+| Eilfrist | **§ 45 WEG / § 46 WEG: 1 Monat** Beschlussanfechtungsklage. § 558b BGB: Zustimmungsverlangen Mieterhöhung 2 Monate. § 559 BGB: Modernisierungs-Ankündigung 3 Monate vor Beginn. § 574 BGB: Sozialklausel-Widerspruch 2 Monate vor Beendigung. § 573 III BGB: Schriftform Kündigung. | Frist aus Zugangs-/Kenntnisdatum berechnen |
+| Hauptanspruch | Räumung §§ 546, 985 BGB · Zahlungsklage (Miete, Betriebskosten) §§ 535 II, 556 BGB · Mietminderung § 536 BGB · Mängelbeseitigung § 535 I 2 BGB · WEG-Anfechtung § 44 ff. WEG · Hausgeld §§ 16 II, 28 WEG. | Sachverhaltsabgleich mit Tatbestandsmerkmalen |
+| Zuständigkeit | Mietsachen: AG am belegenen Ort, ausschließlich (§ 23 Nr. 2a GVG, § 29a ZPO). WEG-Streitigkeiten: AG am belegenen Ort (§ 43 WEG). | Gesetz, Vertrag, Gerichtsstandsklausel |
 
-- `einstieg-schnelltriage-fallrouting` — Abschlusskontrolle WEG Anschluss Router
-- `antennen-satellitenschuessel` — Antennen Satellitenschuessel Aufrechnung
-- `workflow-bauliche-veraenderung-routing` — Bauliche Veraenderung Betriebskosten
-- `baurecht-schnittstelle-miete` — Baurecht Schnittstelle Belegeinsicht
-- `beschlussanfechtung-spezial-fristen` — Beschlussanfechtung Abrechnungsfrist
-- `betriebskostenverordnung-anlage-3` — Betriebskostenverordnung Anlage 3
-- `betrkv-mehrparteien-konflikt-und-interessen` — Betrkv Interessen BGB Co2kostenaufteilung
-- `workflow-dokumentenstapel-sortieren` — Dokumentenstapel Sortieren First Year
-- `eigenbedarf-personenkreis` — Eigenbedarf Personenkreis Energieausweis
-- `steuer-schnittstelle-vermietung` — Fachanwalt Steuer Schnittstelle Erstgespraech
-- `gartenpflege-baumfaellung` — Gartenpflege Baumfaellung Gewerberaum
-- `workflow-geg-waermepumpe-routing` — GEG Waermepumpe Gerichtstermin Vorbereitung
-- `gewerberaum-umsatzmiete` — Gewerberaum Umsatzmiete Gewerberaummiete
-- `dokumente-intake` — Dokumente Intake
-- `output-waehlen` — Output Waehlen
+## Risiko-Ampel
 
-## Arbeitsweg
+- **Frist:** 🔴 WEG-Anfechtung: 1 Monat ab Beschlussfassung, NICHT ab Protokoll. 🟠 Mieterhöhung Zustimmungsklage § 558b II BGB. 🟠 Räumungsklage nach Kündigung — Widerspruchsfrist § 574b BGB.
+- **Beweislage:** 🟠 Zugang der Kündigung: § 130 BGB beim Empfänger. 🔴 Mietminderung: Mangelanzeige § 536c BGB lückenlos, sonst Schadensersatzpflicht.
+- **Wirtschaftlich:** 🔴 Räumung: Vollstreckungsschutz § 765a ZPO (Härtefall). 🟠 Betriebskostennachforderung > 1.000 €: Belegeinsicht und materielle Prüfung.
 
-- Rolle und Ziel klären: Welche Partei vertritt der Mandant, welcher Ergebnistyp wird gebraucht (Schriftsatz, Bescheidprüfung, Vertragsentwurf, Stellungnahme), welches Verfahren oder Dokument liegt vor?
-- Eilfristen isolieren: die im Fachgebiet einschlägigen Verfahrens- und materiellen Fristen pflichtmäßig vorab markieren und nicht aus Modellwissen finalisieren.
-- Fachpfad wählen: zentrale Anker im Fachanwalt Miet Wohnungseigentumsrecht sind GEG, WEG. Anhand des Sachverhalts in einen Sach-Cluster routen und den passenden Spezial-Skill aus der Fachlandkarte oben benennen.
-- Zuständige Stelle bestimmen: Mandant, Gegner, zuständiges Gericht oder Behörde, etwaige Sachverständige oder beauftragte Stellen.
-- Nur die Rückfragen stellen, die die nächste Weiche tatsächlich ändern.
+## Anschluss-Skills (Router)
 
-## Qualitätsanker
+| Wenn der Fall trägt … | dann Skill | Erwartung |
+| --- | --- | --- |
+| **Eigenbedarfskündigung erhalten** | `kuendigung-eigenbedarf-bgb-viii-zr-21-19` | Substantiierung Bedarf, Härtefall § 574 BGB, Sozialklausel |
+| Mietminderung wegen Mangel | `mietminderung-paragraf-536-bgb` | Quote, Anzeigeobliegenheit § 536c BGB, Zurückbehaltungsrecht |
+| Betriebskostenabrechnung prüfen | `miet-betriebskostenabrechnung-checkliste` | Formelle und materielle Prüfung, Abrechnungsfrist § 556 III BGB |
+| Mietpreisbremse / Rüge | `mietpreisbremse-paragraf-556d-bgb-bgh-viii-zr-25-22` | Rüge, Auskunft Vormiete, Rückforderung |
+| WEG-Beschlussanfechtung | `beschlussanfechtung-spezial-fristen` | 1-Monatsfrist § 45 WEG, Begründung 2 Monate, Form |
 
-- Normen und Rechtsprechung nach `references/quellenhygiene.md` und `references/zitierweise.md` behandeln.
-- Wenn eine Spezialfrage sichtbar wird, den passenden Skill nennen und kurz erklären, warum genau dieser Arbeitsgang passt.
-- Bei Zeitdruck zuerst Frist, Zuständigkeit, Form und Beweislast sichern.
+## Norm-Radar (live verifizieren)
+
+- **§ 573 BGB** — ordentliche Kündigung Wohnraum; berechtigtes Interesse
+- **§ 574 BGB** — Sozialklausel / Härtefall-Widerspruch
+- **§ 536 BGB** — Mietminderung wegen Mangel
+- **§ 556 BGB** — Betriebskosten; Abrechnungsfrist III
+- **§ 558 BGB** — Mieterhöhung bis ortsübliche Vergleichsmiete
+- **§ 45 WEG** — Anfechtungsklage 1-Monatsfrist
+
+## Genau eine Rückfrage (nur wenn nötig)
+
+> Geht es um **Wohnraummiete · Gewerbemiete · WEG-Beschluss** — und steht eine **Beendigung** (Kündigung, Räumung) oder eine **Zahlungs-/Mängel-Frage** im Vordergrund?
+
+Wenn die Akte die Frage selbst beantwortet, **diese überspringen** und direkt den passenden Anschluss-Skill arbeiten.
+
+## Hinweis
+
+Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte. Quellenhygiene nach `references/quellenhygiene.md`, Zitierform nach `references/zitierweise.md`. Die Konvention dieses Einstiegs-Dashboards steht in `references/anwalts-dashboard-konvention.md`.

--- a/fachanwalt-strafrecht/skills/einstieg-routing/SKILL.md
+++ b/fachanwalt-strafrecht/skills/einstieg-routing/SKILL.md
@@ -1,42 +1,55 @@
 ---
 name: einstieg-routing
-description: "Einstieg, Triage und Routing für Fachanwalt Strafrecht: ordnet Rolle (Beschuldigter/Angeklagter, Staatsanwaltschaft, Verletzte/Nebenkläger), markiert Frist (Revision 1 Woche/1 Mon. § 341 StPO), wählt Norm (StGB, StPO, JGG) und Zuständigkeit (Staatsanwaltschaft), leitet zum passenden Spezial-Skill."
+description: "Anwalts-Dashboard Fachanwalt Strafrecht: Sofort-Triage als Tabelle (Rolle, Verfahrensstand, Eilfrist, Hauptanspruch, Zuständigkeit), Risiko-Ampel, Anschluss-Skill-Router mit echten Slugs, Norm-Radar; maximal eine Rückfrage. Der Anwalt bleibt im Driver Seat."
 ---
 
-# Einstieg und Routing
+# Anwalts-Dashboard Fachanwalt Strafrecht
 
-## Einsatzlage
+> Vorladung, Durchsuchung, U-Haft, Anklage, Revision — Verfahrensphase entscheidet alles. Identität des Beschuldigten zuerst klären.
+>
+> Sie sehen unten die Sofort-Triage. Keine Rückfragen, bis die Tabelle steht. Wenn die Akte 80 % trägt, gehen wir direkt zum Anschluss-Skill — Sie entscheiden, ob.
 
-Dieser Einstieg routet **Fachanwalt Strafrecht** vom ersten Sachverhalt zu Rollen, Fristen, zuständiger Stelle, passendem Spezialpfad und nächstem Arbeitsprodukt.
+## Sofort-Triage
 
-## Fachlandkarte dieses Plugins
+| Punkt | Schnellprüfung | Standardquelle / Hilfsweg |
+| --- | --- | --- |
+| Rolle | Wen vertrete ich? (Mandant · Gegenseite · Mehrere) | Mandantenmail, Vertretungsbestellung |
+| Verfahrensstand | Vorprozessual · außergerichtlich · Klage · Rechtsmittel · Vollstreckung | Vorhandene Schriftsätze, Eingangsstempel |
+| Eilfrist | **§ 311 II StPO: 1 Woche** sofortige Beschwerde. § 314 StPO: Berufung 1 Woche ab Verkündung. § 341 StPO: Revision 1 Woche ab Verkündung; § 345 StPO: Begründung 1 Monat ab Zustellung. § 33a StPO (Haftprüfung jederzeit). § 67 OWiG: Einspruch Bußgeld 2 Wochen. | Frist aus Zugangs-/Kenntnisdatum berechnen |
+| Hauptanspruch | Hier kein klassischer Anspruch: Tatvorwurf benennen (Norm + StGB- bzw. Nebenstrafrechts-§). Mitwirkung: Akteneinsicht § 147 StPO, Beweisantrag § 244 StPO, Verteidigerwahl § 137 StPO, Pflichtverteidigung § 140 StPO. | Sachverhaltsabgleich mit Tatbestandsmerkmalen |
+| Zuständigkeit | AG Strafrichter / Schöffengericht (§§ 24 ff. GVG), LG große Strafkammer (§ 74 GVG), OLG (Staatsschutz, § 120 GVG). Bei Jugendlichen: JGG-Spruchkörper. | Gesetz, Vertrag, Gerichtsstandsklausel |
 
-- `workflow-redteam-qualitygate` — Adhaesionsverfahren Ermittlungsverfahren
-- `strafrecht-spezial-aussagepsychologie-staatsanwaltschaft-replik` — Aussagepsychologie Staatsanwaltschaft
-- `chatcontrol-csam-anwaltsgeheimnis-53-stpo` — Chatcontrol Csam Einlassung Vorbereiten
-- `ergaenzt-mandantenkommunikation-entscheidungsvorlage` — Ergaenzt Fachanwalt Insolvenzantrag RED Team Korrektur
-- `fa-strafrecht-quellen-frist-next` — FA Strafrecht Quellen Frist Next
-- `freiheitsstrafe-paragraf-57-stgb` — Freiheitsstrafe Paragraf 57 STGB
-- `hauptverhandlung-quellenkarte` — Hauptverhandlung Quellenkarte
-- `strafrecht-spezial-koerperverletzung-223-stgb-grund` — Koerperverletzung STGB Todesfolge
-- `mandat-triage-strafrecht` — Mandat Triage Plaedoyer Vorbereitung
-- `nebenklage-compliance-dokumentation-und-akte` — Nebenklage Nebenstrafrecht Opfervertretung
-- `notwehr-paragraf-32-stgb` — Notwehr Paragraf 32 STGB
-- `orientierung-mandat-fachanwaltschaft` — Orientierung
-- `strafrecht-spezial-raub-249-stgb` — Raub Rechtsbeugung
-- `anschluss-routing` — Anschluss Routing
-- `dokumente-intake` — Dokumente Intake
+## Risiko-Ampel
 
-## Arbeitsweg
+- **Frist:** 🔴 Sofortige Beschwerde (1 Woche), Revisionsfrist (1 Woche / 1 Monat) tickt ab Verkündung/Zustellung. 🟠 Hauptverhandlung in 30 Tagen — Beweisanträge vorbereiten.
+- **Beweislage:** 🟠 Beschuldigtenaussage NIE ohne Akteneinsicht. 🔴 Belastungszeugen: Konfrontationsrecht Art. 6 III d EMRK ausnutzen. 🟢 Selbstanzeige § 371 AO nur nach umfassender Aktenlage.
+- **Wirtschaftlich:** 🔴 Berufstauglichkeit gefährdet (Beamte, Heilberufe, Approbation): parallel berufsrechtliche Schiene mitdenken. 🟠 Vermögensabschöpfung §§ 73 ff. StGB im Blick.
 
-- Rolle und Ziel klären: Welche Partei vertritt der Mandant, welcher Ergebnistyp wird gebraucht (Schriftsatz, Bescheidprüfung, Vertragsentwurf, Stellungnahme), welches Verfahren oder Dokument liegt vor?
-- Eilfristen isolieren: § 341 StPO Revisionseinlegung 1 Woche, § 314 StPO Berufungseinlegung 1 Woche, § 345 StPO Revisionsbegründung 1 Monat nach Urteilszustellung, § 116 StPO HBÜ-Überprüfung 3/6 Monate, § 121 StPO 6-Monats-Grenze U-Haft.
-- Fachpfad wählen: zentrale Anker im Strafrecht und Strafprozessrecht sind StGB §§ 13, 22, 23, 25, 32, 35, 46, 47, 56, 57, StPO §§ 53, 53a, 100a, 100b, 102, 105, 112, 116, 136, 137, 140, 141, 147, 152, 153, 153a, 160, 163a, 168c, 169, 170, 200, 201, 203, 244, 257c, 261, 264, 265, 267, 268, 304, 341, 344, 349. Anhand des Sachverhalts in einen Sach-Cluster routen und den passenden Spezial-Skill aus der Fachlandkarte oben benennen.
-- Zuständige Stelle bestimmen: Beschuldigter, Strafverteidiger, Staatsanwaltschaft, Ermittlungsrichter, Vorsitzender, Schöffen, Zeuge, Nebenkläger, JVA.
-- Nur die Rückfragen stellen, die die nächste Weiche tatsächlich ändern.
+## Anschluss-Skills (Router)
 
-## Qualitätsanker
+| Wenn der Fall trägt … | dann Skill | Erwartung |
+| --- | --- | --- |
+| **Untersuchungshaft / Haftbefehl** | `strafr-haftpruefung-haftbeschwerde-workflow` | Haftbeschwerde § 304 StPO, Haftprüfung § 117 StPO, mündliche Verhandlung erzwingen |
+| Akteneinsicht & Strategie | `akteneinsicht-beantragen` | Antrag § 147 StPO, Wahl Verfahrensschiene, ggf. Schweigen / Einlassungsmemo |
+| Beweisantrag vorbereiten | `strafr-dysfunk-beweisantrag-fundament` | Substantiierte Tatsachenbehauptung, Beweismittel, Konnexität |
+| Revision prüfen | `revisionsbegruendung-paragraf-344-stpo` | Sach- vs. Verfahrensrüge, absolute Revisionsgründe § 338 StPO |
+| Wirtschafts-/Vermögensabschöpfung | `strafr-vermoegensabschoepfung-spezial` | Einziehung §§ 73 ff. StGB, vermögenssichernde Maßnahmen § 111b StPO |
 
-- Normen und Rechtsprechung nach `references/quellenhygiene.md` und `references/zitierweise.md` behandeln.
-- Wenn eine Spezialfrage sichtbar wird, den passenden Skill nennen und kurz erklären, warum genau dieser Arbeitsgang passt.
-- Bei Zeitdruck zuerst Frist, Zuständigkeit, Form und Beweislast sichern.
+## Norm-Radar (live verifizieren)
+
+- **§ 147 StPO** — Akteneinsicht des Verteidigers
+- **§ 137 StPO** — Recht auf Verteidiger jederzeit
+- **§ 244 StPO** — Beweisantragsrecht
+- **§ 117 StPO** — Haftprüfung
+- **§ 341 StPO** — Revisions-Einlegungsfrist (1 Woche)
+- **§ 73 StGB** — Einziehung von Taterträgen
+
+## Genau eine Rückfrage (nur wenn nötig)
+
+> Welche **Verfahrensphase** läuft (Ermittlung · Anklage · Hauptverhandlung · Rechtsmittel · Vollstreckung), und sitzt der Mandant **in Haft**?
+
+Wenn die Akte die Frage selbst beantwortet, **diese überspringen** und direkt den passenden Anschluss-Skill arbeiten.
+
+## Hinweis
+
+Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte. Quellenhygiene nach `references/quellenhygiene.md`, Zitierform nach `references/zitierweise.md`. Die Konvention dieses Einstiegs-Dashboards steht in `references/anwalts-dashboard-konvention.md`.

--- a/fachanwalt-verkehrsrecht/skills/einstieg-routing/SKILL.md
+++ b/fachanwalt-verkehrsrecht/skills/einstieg-routing/SKILL.md
@@ -1,42 +1,55 @@
 ---
 name: einstieg-routing
-description: "Einstieg, Triage und Routing für Fachanwalt Verkehrsrecht: ordnet Rolle (Betroffener/Geschädigter, Behörde, Versicherer), markiert Frist (§ 67 OWiG Einspruch 2 Wochen), wählt Norm (StGB §§ 142/315c, 316, StVG, StVO) und Zuständigkeit (AG (Bußgeld + Straf)), leitet zum passenden Spezial-Skill."
+description: "Anwalts-Dashboard Fachanwalt Verkehrsrecht: Sofort-Triage als Tabelle (Rolle, Verfahrensstand, Eilfrist, Hauptanspruch, Zuständigkeit), Risiko-Ampel, Anschluss-Skill-Router mit echten Slugs, Norm-Radar; maximal eine Rückfrage. Der Anwalt bleibt im Driver Seat."
 ---
 
-# Einstieg und Routing
+# Anwalts-Dashboard Fachanwalt Verkehrsrecht
 
-## Einsatzlage
+> Bußgeld, Fahrerlaubnis, Unfallregulierung, Trunkenheitsfahrt — drei Aktenbündel, oft parallel: OWi/Straf, FE-Behörde, Versicherer.
+>
+> Sie sehen unten die Sofort-Triage. Keine Rückfragen, bis die Tabelle steht. Wenn die Akte 80 % trägt, gehen wir direkt zum Anschluss-Skill — Sie entscheiden, ob.
 
-Dieser Einstieg routet **Fachanwalt Verkehrsrecht** vom ersten Sachverhalt zu Rollen, Fristen, zuständiger Stelle, passendem Spezialpfad und nächstem Arbeitsprodukt.
+## Sofort-Triage
 
-## Fachlandkarte dieses Plugins
+| Punkt | Schnellprüfung | Standardquelle / Hilfsweg |
+| --- | --- | --- |
+| Rolle | Wen vertrete ich? (Mandant · Gegenseite · Mehrere) | Mandantenmail, Vertretungsbestellung |
+| Verfahrensstand | Vorprozessual · außergerichtlich · Klage · Rechtsmittel · Vollstreckung | Vorhandene Schriftsätze, Eingangsstempel |
+| Eilfrist | **§ 67 OWiG: 2 Wochen** Einspruch Bußgeldbescheid ab Zustellung. § 80 III VwGO: Widerspruch gegen FE-Entzug 1 Monat. § 41 RL 2009/103/EG / § 115 VVG: Direktanspruch Versicherer (keine Verjährungsfalle, aber Verzug nach 6 Wochen). | Frist aus Zugangs-/Kenntnisdatum berechnen |
+| Hauptanspruch | OWi-Verteidigung (§§ 66, 67 OWiG), Straffahrlässigkeit/Vorsatz (§§ 315c, 316 StGB, § 21 StVG, § 24a StVG), Schadensersatz aus Unfall §§ 7 StVG, 18 StVG, 17 StVG (Quote), §§ 823, 249 BGB, 253 II BGB (Schmerzensgeld), Direktanspruch § 115 VVG. | Sachverhaltsabgleich mit Tatbestandsmerkmalen |
+| Zuständigkeit | OWi: AG am Tatort (§ 68 OWiG). Strafsachen: AG/LG nach §§ 24 ff. GVG. FE-Sache: Verwaltungsbehörde + VG. Zivilrechtlich: Wahlrecht §§ 17, 32 ZPO, AG/LG je Streitwert. | Gesetz, Vertrag, Gerichtsstandsklausel |
 
-- `autonom-abschlussprodukt-und-uebergabe` — Autonom Bezuege Fachanwalt
-- `blitzer-messung-paragraf-3-stvo` — Blitzer Messung Paragraf 3 Stvo
-- `bussgeld-zahlen-schwellen-und-berechnung` — Bussgeld Unfall Haftungsquote VKR
-- `dieselskandal-paragraf-826-bgb` — Dieselskandal Paragraf 826 BGB
-- `erstgespraech-mandatsannahme` — Erstgespraech Mandatsannahme Verkehr Autonom
-- `workflow-fristen-und-risikoampel` — FA Verkehrsrecht Fristen Risiko Mandant
-- `fahrerlaubnis-entzug-paragraf-3-stvg` — Fahrerlaubnis Entzug Paragraf 3 Stvg
-- `fahrerlaubnis-compliance-dokumentation-und-akte` — Fahrerlaubnis Kanzlei Personen
-- `haftpflicht-paragraf-115-vvg` — Haftpflicht Paragraf 115 VVG
-- `kaskoversicherung-paragraf-81-vvg-bgh-iv-zr-25-21` — Kaskoversicherung Paragraf 81 VVG BGH IV ZR 25 21
-- `kfz-handel-paragraf-434-bgb` — KFZ Handel Paragraf 434 BGB
-- `mandat-triage-sportrecht` — Mandat Triage Schriftsatzkern Substantiierung
-- `mpu-vorbereitung` — MPU Vorbereitung Orientierung
-- `anschluss-routing` — Anschluss Routing
-- `dokumente-intake` — Dokumente Intake
+## Risiko-Ampel
 
-## Arbeitsweg
+- **Frist:** 🔴 Bußgeld-Einspruch (2 Wochen) tickt ab Zustellung; Datum aus Akte verifizieren. 🟠 Verjährung OWi: 3 Monate bis Anhörung, 6 Monate gesamt (§ 26 III StVG für StVO-Verstöße).
+- **Beweislage:** 🟠 Messverfahren: Eichschein, Bauartzulassung, Toleranzabzug. 🔴 Trunkenheit: BAK-Analyse, Blutprobenrichter (§ 81a StPO!).
+- **Wirtschaftlich:** 🟠 1-Monats-Fahrverbot: Schonfrist § 25 IIa StVG (Beruf!). 🔴 FE-Entzug: MPU-Risiko und 6-Monats-Wiedererteilungssperre § 69a StGB.
 
-- Rolle und Ziel klären: Welche Partei vertritt der Mandant, welcher Ergebnistyp wird gebraucht (Schriftsatz, Bescheidprüfung, Vertragsentwurf, Stellungnahme), welches Verfahren oder Dokument liegt vor?
-- Eilfristen isolieren: die im Fachgebiet einschlägigen Verfahrens- und materiellen Fristen pflichtmäßig vorab markieren und nicht aus Modellwissen finalisieren.
-- Fachpfad wählen: zentrale Anker im Fachanwalt Verkehrsrecht sind PflVG, StVG, VVG, §§ 315c 316 StGB. Anhand des Sachverhalts in einen Sach-Cluster routen und den passenden Spezial-Skill aus der Fachlandkarte oben benennen.
-- Zuständige Stelle bestimmen: Mandant, Gegner, zuständiges Gericht oder Behörde, etwaige Sachverständige oder beauftragte Stellen.
-- Nur die Rückfragen stellen, die die nächste Weiche tatsächlich ändern.
+## Anschluss-Skills (Router)
 
-## Qualitätsanker
+| Wenn der Fall trägt … | dann Skill | Erwartung |
+| --- | --- | --- |
+| **Bußgeldbescheid eingegangen** | `bussgeld-einspruch-pruefen` | Einspruch fristgerecht, Akteneinsicht, Messverfahren-Check |
+| Fahrerlaubnis-Entzug droht | `fahrerlaubnis-entzug` | MPU-Anordnung prüfen, vorläufige Entziehung § 111a StPO |
+| MPU steht an | `mpu-vorbereitung` | Begutachtungsanlass, Abstinenzbelege, Vorbereitungsphase |
+| Unfallregulierung Versicherer | `verk-unfallregulierung-workflow` | Haftungsquote, Schadensersatzpositionen, Anlagensatz § 287 ZPO |
+| Trunkenheits-/Drogenfahrt | `verk-trunkenheit-drogenfahrt-spezial` | BAK/AAK-Bewertung, § 316 StGB vs. § 24a StVG, FE-Folgen |
 
-- Normen und Rechtsprechung nach `references/quellenhygiene.md` und `references/zitierweise.md` behandeln.
-- Wenn eine Spezialfrage sichtbar wird, den passenden Skill nennen und kurz erklären, warum genau dieser Arbeitsgang passt.
-- Bei Zeitdruck zuerst Frist, Zuständigkeit, Form und Beweislast sichern.
+## Norm-Radar (live verifizieren)
+
+- **§ 67 OWiG** — Einspruchsfrist 2 Wochen Bußgeld
+- **§ 25 StVG** — Fahrverbot; Schonfrist Abs. 2a
+- **§ 69 StGB** — Entziehung Fahrerlaubnis; Wiedererteilungssperre § 69a
+- **§ 316 StGB** — Trunkenheit im Verkehr
+- **§ 7 StVG** — Halterhaftung Unfall
+- **§ 115 VVG** — Direktanspruch gegen KH-Versicherer
+
+## Genau eine Rückfrage (nur wenn nötig)
+
+> Welche **Schiene** dominiert (OWi/Straf · FE-Behörde · Versicherer-Regulierung) — und welche Frist tickt zuerst?
+
+Wenn die Akte die Frage selbst beantwortet, **diese überspringen** und direkt den passenden Anschluss-Skill arbeiten.
+
+## Hinweis
+
+Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte. Quellenhygiene nach `references/quellenhygiene.md`, Zitierform nach `references/zitierweise.md`. Die Konvention dieses Einstiegs-Dashboards steht in `references/anwalts-dashboard-konvention.md`.

--- a/fachanwalt-versicherungsrecht/skills/einstieg-routing/SKILL.md
+++ b/fachanwalt-versicherungsrecht/skills/einstieg-routing/SKILL.md
@@ -1,42 +1,55 @@
 ---
 name: einstieg-routing
-description: "Einstieg, Triage und Routing für Fachanwalt Versicherungsrecht: ordnet Rolle (Versicherungsnehmer, Versicherer, Geschädigter), markiert Frist (§ 12 VVG Klagefrist), wählt Norm (VVG, PflVG, ZPO/Versicherungs-Streit) und Zuständigkeit (Zivilgerichte), leitet zum passenden Spezial-Skill."
+description: "Anwalts-Dashboard Fachanwalt Versicherungsrecht: Sofort-Triage als Tabelle (Rolle, Verfahrensstand, Eilfrist, Hauptanspruch, Zuständigkeit), Risiko-Ampel, Anschluss-Skill-Router mit echten Slugs, Norm-Radar; maximal eine Rückfrage. Der Anwalt bleibt im Driver Seat."
 ---
 
-# Einstieg und Routing
+# Anwalts-Dashboard Fachanwalt Versicherungsrecht
 
-## Einsatzlage
+> Leistungsablehnung, BU, D&O, Rechtsschutz, Obliegenheiten — Bedingungen prüfen, Obliegenheit prüfen, Beweislast verteilen.
+>
+> Sie sehen unten die Sofort-Triage. Keine Rückfragen, bis die Tabelle steht. Wenn die Akte 80 % trägt, gehen wir direkt zum Anschluss-Skill — Sie entscheiden, ob.
 
-Dieser Einstieg routet **Fachanwalt Versicherungsrecht** vom ersten Sachverhalt zu Rollen, Fristen, zuständiger Stelle, passendem Spezialpfad und nächstem Arbeitsprodukt.
+## Sofort-Triage
 
-## Fachlandkarte dieses Plugins
+| Punkt | Schnellprüfung | Standardquelle / Hilfsweg |
+| --- | --- | --- |
+| Rolle | Wen vertrete ich? (Mandant · Gegenseite · Mehrere) | Mandantenmail, Vertretungsbestellung |
+| Verfahrensstand | Vorprozessual · außergerichtlich · Klage · Rechtsmittel · Vollstreckung | Vorhandene Schriftsätze, Eingangsstempel |
+| Eilfrist | **§ 12 VVG: 1 Monat** (a. F.) ist überholt; Klagefrist gibt es nicht mehr. Aber: § 195 BGB Verjährung 3 Jahre. § 28 IV VVG: Obliegenheitsverletzung — Belehrungspflicht des Versicherers. § 19 VVG: Anzeigepflicht vorvertraglich; Rücktritt 1 Monat ab Kenntnis. § 14 VVG: Fälligkeit nach Erhebung der nötigen Erhebungen. | Frist aus Zugangs-/Kenntnisdatum berechnen |
+| Hauptanspruch | Versicherungsleistung aus jeweiligem Vertrag (BU, D&O, RS, Kasko, Haftpflicht, KH); §§ 1, 100, 115 VVG; § 86 VVG Regress; § 28 VVG Obliegenheitsverletzung; § 19 VVG Anzeigepflicht; § 215 VVG Gerichtsstand. | Sachverhaltsabgleich mit Tatbestandsmerkmalen |
+| Zuständigkeit | § 215 VVG: Wohnsitz Versicherungsnehmer (zwingend für Verbraucher). Sonst §§ 12, 17 ZPO. Bei BU/PKV häufig LG (Streitwert). | Gesetz, Vertrag, Gerichtsstandsklausel |
 
-- `berufsunfaehigkeit-paragraf-172-vvg` — Berufsunfaehigkeit Paragraf 172 VVG
-- `versr-bu-anerkennt-was-spezial` — BU Anerkennt Leistungspruefung
-- `cyber-loesegeld-sanktionsrecht` — Cyber Loesegeld Versr Deckungsanfrage
-- `versr-d-o-claims-made-ausschluesse` — D O Spezialfall Deckungsklage Leitfaden
-- `deckungsklage-mehrparteien-konflikt-und-interessen` — Deckungsklage Interessen Deckungspruefung
-- `versr-deckungsprozess-215-vvg-beweislast` — Deckungsprozess VVG Einfuehrung Themen
-- `do-deckungsabwehr` — DO Deckungsabwehr Lebensversicherung
-- `erstgespraech-mandatsannahme` — Erstgespraech Mandatsannahme
-- `einstieg-schnelltriage-fallrouting` — FA Versicherungsrecht Start Chronologie Fristen
-- `erstpruefung-und-mandatsziel` — Fachanwalt Kanzlei Krankenversicherung
-- `fehlerkatalog` — Fehlerkatalog
-- `gebaeudeversicherung-paragraf-86-vvg` — Gebaeudeversicherung Paragraf 86 VVG
-- `haftpflicht-paragraf-100-vvg` — Haftpflicht Paragraf 100 VVG
-- `anschluss-routing` — Anschluss Routing
-- `dokumente-intake` — Dokumente Intake
+## Risiko-Ampel
 
-## Arbeitsweg
+- **Frist:** 🟠 Verjährung 3 Jahre ab Kenntnis (§ 199 BGB). 🔴 D&O Claims-made: Eintrittsdatum innerhalb Versicherungsperiode — Melde-Obliegenheit!
+- **Beweislage:** 🔴 Obliegenheit § 28 VVG: Belehrungserfordernis und Kausalitätsgegenbeweis. 🟠 Anzeigepflicht § 19 VVG: Vorvertragliche Fragen Wortlaut konkret abgleichen.
+- **Wirtschaftlich:** 🔴 BU-Anerkennung: Rückwirkung der Leistungspflicht bei verspäteter Anerkenntnis. 🟠 RS: Stichentscheid-/Schiedsgutachten.
 
-- Rolle und Ziel klären: Welche Partei vertritt der Mandant, welcher Ergebnistyp wird gebraucht (Schriftsatz, Bescheidprüfung, Vertragsentwurf, Stellungnahme), welches Verfahren oder Dokument liegt vor?
-- Eilfristen isolieren: die im Fachgebiet einschlägigen Verfahrens- und materiellen Fristen pflichtmäßig vorab markieren und nicht aus Modellwissen finalisieren.
-- Fachpfad wählen: zentrale Anker im Fachanwalt Versicherungsrecht sind VAG, VVG. Anhand des Sachverhalts in einen Sach-Cluster routen und den passenden Spezial-Skill aus der Fachlandkarte oben benennen.
-- Zuständige Stelle bestimmen: Mandant, Gegner, zuständiges Gericht oder Behörde, etwaige Sachverständige oder beauftragte Stellen.
-- Nur die Rückfragen stellen, die die nächste Weiche tatsächlich ändern.
+## Anschluss-Skills (Router)
 
-## Qualitätsanker
+| Wenn der Fall trägt … | dann Skill | Erwartung |
+| --- | --- | --- |
+| **BU-Leistung verweigert** | `versr-bu-leistungspruefung-spezial` | Definition Beruf, Prognose 6 Monate, Verweisung, Anerkenntnisstrategie |
+| D&O-Anspruch / Claims-made | `versr-d-und-o-spezialfall` | Versicherungsfall-Definition, Anzeigepflicht, Verteidigungskosten |
+| Rechtsschutzdeckung verweigert | `versr-rechtsschutz-deckungsklage-spezial` | Deckungsklage § 3 ARB, Stichentscheid, vorvertraglich |
+| Obliegenheitsverletzung Vorwurf | `versr-obliegenheitsverletzung-praxis` | Belehrungserfordernis § 28 IV VVG, Kausalitätsgegenbeweis |
+| Anzeigepflicht § 19 VVG / Rücktritt | `versr-vvg-anzeigepflicht-19-arglist` | Frage-/Fragebogenklarheit, Arglist, Rücktritt 1 Monat |
 
-- Normen und Rechtsprechung nach `references/quellenhygiene.md` und `references/zitierweise.md` behandeln.
-- Wenn eine Spezialfrage sichtbar wird, den passenden Skill nennen und kurz erklären, warum genau dieser Arbeitsgang passt.
-- Bei Zeitdruck zuerst Frist, Zuständigkeit, Form und Beweislast sichern.
+## Norm-Radar (live verifizieren)
+
+- **§ 1 VVG** — Hauptleistung des Versicherers
+- **§ 19 VVG** — vorvertragliche Anzeigepflicht; Rücktritt
+- **§ 28 VVG** — Obliegenheitsverletzung; Belehrungserfordernis
+- **§ 100 VVG** — Haftpflichtversicherung: Versicherungsschutz
+- **§ 115 VVG** — Direktanspruch gegen KH-Versicherer
+- **§ 215 VVG** — Gerichtsstand am Wohnsitz VN
+
+## Genau eine Rückfrage (nur wenn nötig)
+
+> Welche **Sparte** (BU · D&O · KH/Haftpflicht · RS · Sachversicherung) — und welcher **Streitpunkt**: Deckung, Obliegenheit, Anzeigepflicht oder Höhe?
+
+Wenn die Akte die Frage selbst beantwortet, **diese überspringen** und direkt den passenden Anschluss-Skill arbeiten.
+
+## Hinweis
+
+Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte. Quellenhygiene nach `references/quellenhygiene.md`, Zitierform nach `references/zitierweise.md`. Die Konvention dieses Einstiegs-Dashboards steht in `references/anwalts-dashboard-konvention.md`.

--- a/references/anwalts-dashboard-konvention.md
+++ b/references/anwalts-dashboard-konvention.md
@@ -1,0 +1,115 @@
+# Anwalts-Dashboard-Konvention für Einstiegs-Skills
+
+> Diese Konvention gilt für `allgemein`/`einstieg-routing`/`kaltstart-triage`-Skills der **Anwalts-Plugins**. Ergänzt `references/dashboard-template.md` (das die Output-Form behandelt) um die **Einstiegs-Form**: Was sieht ein Anwalt im ersten Bildschirm, der durch den Fall führt, ohne ihn zu entmündigen.
+
+## Leitprinzipien
+
+1. **Geschwindigkeit vor Höflichkeit.** Kein Vorgeplänkel, keine Plugin-Selbstvorstellung. Erste sichtbare Zeile zeigt die Triage-Tabelle.
+2. **Tabelle vor Prosa.** Strukturen werden als Tabellen, Ampeln und Routenkarten gerendert, nicht als Fließtext. Tabellen sind scanbar, Fließtext nicht.
+3. **Eine Rückfrage maximal.** Wenn die Akte 80 % der Triage trägt, wird der Rest mit `[noch zu klären: …]`-Platzhaltern markiert und sofort gearbeitet, nicht abgefragt.
+4. **Human lawyers stay in charge.** Jede Empfehlung ist als Empfehlung markiert, nicht als Auto-Antwort. Entscheidungen treffen Menschen.
+5. **Anschluss-Skills offen benannt.** Der Einstiegs-Skill ist nur eine Tür — der nächste Skill mit Slug, Aufgabe und Erwartung muss klar genannt sein.
+
+## Standardaufbau (von oben nach unten)
+
+### Block 1 — Sofort-Triage (Tabelle, vor jeder Rückfrage)
+
+| Punkt | Schnellprüfung | Standardquelle / Hilfsweg |
+|---|---|---|
+| Rolle | Wen vertrete ich? (Mandant / Gegenseite / Mehrere) | Mandantenmail, Vertretungsbestellung |
+| Verfahrensstand | Vorprozessual / Außergerichtlich / Klage / Rechtsmittel / Vollstreckung | Vorhandene Schriftsätze, Eingangsstempel |
+| Eilfrist | Welche Frist läuft heute, in 7, in 30 Tagen? | Frist berechnen aus Zugangsdatum |
+| Hauptanspruch | Welche Anspruchsgrundlage(n) tragen den Fall? | Plugin-spezifisch (siehe Norm-Radar unten) |
+| Zuständigkeit | Welches Gericht / welche Behörde? | Gesetzliche Zuständigkeit, vertragliche Gerichtsstandsklausel |
+
+### Block 2 — Risiko-Ampel
+
+Drei Achsen, je drei Stufen 🔴/🟠/🟢:
+
+- **Frist:** 🔴 ≤ 7 Tage · 🟠 8-30 Tage · 🟢 > 30 Tage oder ohne harte Frist
+- **Beweislage:** 🔴 Beweisnot · 🟠 lückenhaft, aber heilbar · 🟢 Beweisstand belastbar
+- **Wirtschaftlich:** 🔴 existentiell · 🟠 erheblich · 🟢 überschaubar
+
+Pro Ampel ein Satz Begründung, kein Lehrbuch.
+
+### Block 3 — Anschluss-Skill-Router
+
+Tabelle mit den 3-5 passendsten Spezial-Skills aus demselben Plugin:
+
+| Wenn der Fall trägt … | dann Skill | Erwartung |
+|---|---|---|
+| Konkretes Sachverhaltsmerkmal | `slug-des-spezial-skills` | Welcher Output / welche Frist / welcher Beweisbedarf |
+
+Höchstens fünf Zeilen. Eine vorrangige Empfehlung wird mit Fettung markiert; alternative Pfade darunter.
+
+### Block 4 — Norm-Radar (eine Zeile pro Norm)
+
+Maximal sechs tragende Normen mit kurzer Funktionsangabe. Beispiel: `§ 4 KSchG — 3-Wochen-Frist Kündigungsschutzklage`. Keine Kommentierung, kein Lehrbuch. Diese Zeilen sind Anker für die Spezial-Skills.
+
+### Block 5 — Genau eine Rückfrage (nur wenn nötig)
+
+Wenn die Akte 80 % der Triage trägt: keine Rückfrage, stattdessen sofort ein erster Entwurf mit klar gesetzten `[noch zu klären: …]`-Platzhaltern. Wenn doch eine Frage nötig ist: **eine** Frage, die die nächste Weiche tatsächlich umstellt. Keine Liste von zehn Punkten.
+
+### Block 6 — Driver-Seat-Reminder
+
+Genau ein Satz, am Ende des Dashboards: *„Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte."*
+
+## Was bewusst weggelassen wird
+
+- **Keine Plugin-Selbstvorstellung am Anfang.** Wer den Skill startet, weiß welches Plugin.
+- **Keine Quellenhygiene-Predigt.** Die zentrale Quellenhygiene steht in `references/quellenhygiene.md`. Im Dashboard genügt ein Verweis am Ende.
+- **Keine Lehrbuchpassagen.** Wer Dogmatik braucht, ruft den Spezial-Skill auf.
+- **Keine sechs-Punkte-Pflichtfragen.** Eine.
+
+## Beispiel-Skelett (für jedes Anwalts-Plugin gleich gegliedert)
+
+```markdown
+# Einstieg <Plugin> — Anwalts-Dashboard
+
+## Sofort-Triage
+
+| Punkt | Schnellprüfung | Standardquelle |
+| --- | --- | --- |
+| Rolle | … | … |
+| Verfahrensstand | … | … |
+| Eilfrist | <Plugin-spezifische Frist> | … |
+| Hauptanspruch | <plugin-spezifisch> | … |
+| Zuständigkeit | <plugin-spezifisch> | … |
+
+## Risiko-Ampel
+
+- 🔴/🟠/🟢 Frist — <Satz>
+- 🔴/🟠/🟢 Beweis — <Satz>
+- 🔴/🟠/🟢 Wirtschaftlich — <Satz>
+
+## Anschluss-Skills
+
+| Wenn … | dann | Erwartung |
+| --- | --- | --- |
+| <Sachverhaltsmerkmal> | `<slug>` | <Output/Frist/Beweis> |
+
+## Norm-Radar
+
+- `<Norm>` — <Funktion>
+- …
+
+## Genau eine Rückfrage (falls nötig)
+
+> [Eine konkrete Frage, die die nächste Weiche umstellt]
+
+## Hinweis
+
+Diese Triage ist Vorbereitung, nicht Entscheidung. Sie führen das Mandat; der Skill liefert die Karte. Quellenhygiene nach `references/quellenhygiene.md`, Zitierform nach `references/zitierweise.md`.
+```
+
+## Self-Test vor Freigabe
+
+Bevor ein Einstiegs-Skill ausgeliefert wird, wird gegen diese fünf Fragen geprüft:
+
+1. Sieht der Anwalt in den ersten 15 Zeilen die Triage-Tabelle?
+2. Steht die Risiko-Ampel auf einer Seite mit der Triage?
+3. Ist mindestens ein Anschluss-Skill konkret mit Slug benannt?
+4. Wird höchstens **eine** Rückfrage gestellt?
+5. Steht der Driver-Seat-Hinweis sichtbar am Ende?
+
+Wenn ein Punkt fehlt, ist der Skill nicht freigegeben.

--- a/scripts/build-testakte-gesamt-pdf.py
+++ b/scripts/build-testakte-gesamt-pdf.py
@@ -641,6 +641,10 @@ def build_text_pdf(testakte_dir: Path, files: dict[str, list[Path]], cover: list
     if not flow:
         flow.append(Paragraph("Dateiablage: Original-PDFs folgen.", s_meta))
 
+    # Trailing PageBreak entfernen, damit am Ende keine Leerseite entsteht.
+    while flow and isinstance(flow[-1], PageBreak):
+        flow.pop()
+
     hf = header_footer_factory(testakte_dir.name)
     try:
         doc.build(flow, onFirstPage=no_header_footer, onLaterPages=hf)


### PR DESCRIPTION
## Summary

- **Neue Single-Source-of-Truth** `references/anwalts-dashboard-konvention.md`: 6-Block-Struktur für Einstiegs-Skills (Sofort-Triage / Risiko-Ampel / Anschluss-Skill-Router / Norm-Radar / max. 1 Rückfrage / Driver-Seat-Hinweis) plus 5-Punkte-Self-Test.
- **10 Fachanwalts-Einstiegs-Skills neu geschrieben** (`fachanwalt-{arbeits,familien,straf,verkehrs,miet-wohnungseigentums,erb,medizin,handels-gesellschafts,insolvenz-sanierungs,versicherungs}recht/skills/einstieg-routing/SKILL.md`). Jede Anschluss-Skill-Zeile zeigt jetzt einen REAL existierenden Slug — 50/50 gegen die Plugin-Skill-Verzeichnisse verifiziert.
- **PDF-Build-Tweak** in `scripts/build-testakte-gesamt-pdf.py`: nachlaufende `PageBreak`-Flowables werden vor `doc.build` entfernt, damit am Ende des Gesamt-PDF keine Leerseite entsteht (jedes Aktenstück beginnt weiter auf neuer Seite).

## Was ein Anwalt sieht (Beispiel ArbR)

```
| Punkt | Schnellprüfung | Standardquelle |
| Rolle | Wen vertrete ich? | Mandantenmail |
| Eilfrist | § 4 KSchG: 3 Wochen … | Frist aus Zugangsdatum |
...
| Wenn der Fall trägt … | dann Skill | Erwartung |
| Kündigung erhalten | ar-kuendigungspruefung-workflow | Klageschrift …
| Aufhebungsvertrag | ar-aufhebungsvertrag-praxis | Risikomatrix …
```

Driver-Seat-Hinweis am Ende jedes Dashboards.

## Self-Korrektur-Verlauf

- Erster Wurf der 10 Dashboards enthielt 46 von 50 erfundenen Anschluss-Slugs. Self-Correction-Loop hat die Slug-Liste gegen `ls fachanwalt-*/skills/` verifiziert und 46 ersetzt; der Render-Script bricht ab, falls ein Slug fehlt.
- Description-Längen: 255–300 Zeichen (Grenze 1024).
- `Zahl,Zahl` in YAML-Frontmatter: keine Treffer.
- `node scripts/validate-plugin-structure.mjs`: OK.

## Test plan

- [x] Alle 50 Anschluss-Slugs als Verzeichnisse existent (Python-Check)
- [x] `validate-plugin-structure.mjs` grün
- [x] Description ≤ 1024, kein Zahl-Komma-Zahl
- [ ] Stichprobe: Gesamt-PDF einer Testakte neu bauen und Leerseiten-Check
- [ ] Manuelle Sichtprüfung eines Dashboards in Claude Cowork

https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL


---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_