### PR TITLE
references: Leitentscheidungs-Anker als Such-Gerüst (kein Zitatpool)

### DIFF
--- a/references/leitentscheidungen-anker.md
+++ b/references/leitentscheidungen-anker.md
@@ -1,0 +1,162 @@
+# Leitentscheidungs-Anker für deutsche Rechtsgebiete
+
+> Diese Datei sammelt **Themen-Anker** für Rechtsprechungssuchen je Rechtsgebiet. Sie enthält **bewusst keine vollständigen Aktenzeichen-Behauptungen aus Modellwissen**, weil dieses Repository ohne Live-Zugriff arbeitet. Sie nennt das **Thema** und den **wahrscheinlichen Spruchkörper**; die exakten Aktenzeichen, Daten und Randnummern sind **vor jeder Verwendung live in einer freien Quelle (BVerfG/BGH/BAG/BSG/BFH/BVerwG/EuGH/EGMR-Homepage, dejure.org, openjur.de, curia.europa.eu) zu verifizieren**.
+>
+> **Diese Datei ist ein Suchgerüst, kein Zitatpool.**
+
+## Verwendungsregeln
+
+1. Skills dürfen die hier aufgeführten **Themen-Anker** als Such-Wegweiser verwenden — etwa: „Verwerterpflichten des Insolvenzverwalters — BGH-Linie ab IX ZR 169/04 (2006), fortgeführt; live verifizieren".
+2. Skills dürfen **kein** vollständiges Zitat (Gericht + Datum + Az.) **als gesichert** ausgeben, das nicht entweder (a) vom Nutzer beigebracht oder (b) im Live-Zugriff verifiziert wurde.
+3. Die **Quellenhygiene** nach `references/quellenhygiene.md` gilt unverändert: keine BeckRS-, juris-, Kommentar-, Aufsatz-Blindzitate.
+4. Wer Anker hinzufügt: nur mit **Themenbeschreibung** und **wahrscheinlichem Spruchkörper** (BGH-Senat / BAG-Senat / Fachgericht), **ohne** ein konkretes Az. zu fingieren.
+
+## Format
+
+Jeder Eintrag ist eine Zeile:
+
+`<Thema/Linie> — <Wahrscheinlicher Spruchkörper> — live verifizieren in <freie Quelle>`
+
+Keine erfundenen Daten oder Az.; das ist die Aufgabe der Live-Recherche.
+
+## Arbeitsrecht
+
+- Kündigungsschutz § 1 KSchG — Sozialwidrigkeit, Verhältnismäßigkeit — BAG 2. Senat — bundesarbeitsgericht.de
+- Außerordentliche Kündigung § 626 BGB, Zwei-Wochen-Frist — BAG 2. Senat — bundesarbeitsgericht.de
+- Verdachtskündigung; Anhörungspflicht — BAG 2. Senat (Linie seit Mitte 2000er) — bundesarbeitsgericht.de
+- Betriebsübergang § 613a BGB; Identitätswahrung der wirtschaftlichen Einheit — BAG 8. Senat (Spijkers-/Süzen-Linie EuGH) — bundesarbeitsgericht.de + curia.europa.eu
+- Befristung ohne Sachgrund; Vorbeschäftigung § 14 II 2 TzBfG — BAG 7. Senat; BVerfG 1. Senat — bundesarbeitsgericht.de + bundesverfassungsgericht.de
+- Massenentlassungsanzeige § 17 KSchG; Folgen der Unterlassung — BAG 6./2. Senat — bundesarbeitsgericht.de
+- AGG-Entschädigung § 15 II; Geltendmachungsfrist 2 Monate — BAG 8. Senat — bundesarbeitsgericht.de
+- Übergang Tarif/Betriebsvereinbarung bei Betriebsübergang — EuGH C-60/17 (Somoza Hermo) — curia.europa.eu
+
+## Familienrecht
+
+- Ehevertrag; Inhalts- und Wirksamkeitskontrolle; Kernbereichslehre — BGH XII. Zivilsenat (Linie seit XII ZR 265/02 vom 11.02.2004) — bundesgerichtshof.de
+- Wechselmodell; Anordnungsfähigkeit durch das Gericht — BGH XII. Zivilsenat — bundesgerichtshof.de
+- Düsseldorfer Tabelle; Unterhaltsberechnung — OLG Düsseldorf (jährliche Aktualisierung) — olg-duesseldorf.nrw.de
+- Versorgungsausgleich; externe Teilung — BGH XII. Zivilsenat — bundesgerichtshof.de
+- Digitaler Nachlass; Zugriff Erben auf Facebook-Account — BGH III. Zivilsenat (III ZR 183/17, 12.07.2018) — bundesgerichtshof.de
+- Sorgerecht / Brüssel-IIa-VO — EuGH — curia.europa.eu
+- Kindeswohlgefährdung § 1666 BGB; Eingriffsschwelle — BVerfG 1. Senat — bundesverfassungsgericht.de
+
+## Strafrecht / Strafprozessrecht
+
+- Verständigung § 257c StPO; Mitteilungspflichten — BVerfG 2. Senat (2 BvR 2628/10 v. 19.03.2013); BGH 1./2. Strafsenat — bundesverfassungsgericht.de + bundesgerichtshof.de
+- Beweisantragsrecht § 244 StPO; Konnexität — BGH-Senate — bundesgerichtshof.de
+- Recht auf Akteneinsicht § 147 StPO; Beschuldigtenrechte — BVerfG — bundesverfassungsgericht.de
+- Haftgrund Fluchtgefahr / Verdunkelungsgefahr §§ 112 ff. StPO — BGH 5./1./3. Strafsenat — bundesgerichtshof.de
+- Revisionsbegründung § 344 StPO; Sach- vs. Verfahrensrüge — BGH-Senate — bundesgerichtshof.de
+- Faires Verfahren / Konfrontationsrecht — EGMR (Art. 6 III d EMRK-Linie) — hudoc.echr.coe.int
+- Einziehung §§ 73 ff. StGB; verfassungsrechtliche Grenzen — BVerfG — bundesverfassungsgericht.de
+
+## Verkehrsrecht / OWi
+
+- Standardisiertes Messverfahren — BGH 4. Strafsenat (Linie seit 4 StR 24/97 vom 30.10.1997) — bundesgerichtshof.de
+- Akteneinsicht in Rohmessdaten — BVerfG 2. Senat (2 BvR 1616/18 vom 12.11.2020) — bundesverfassungsgericht.de
+- Fahrerlaubnisentzug § 69 StGB; Sperrfrist § 69a StGB — BGH 4. Strafsenat — bundesgerichtshof.de
+- Trunkenheit im Verkehr § 316 StGB; absolute Fahruntüchtigkeit BAK 1.1 ‰ — BGH 4. Strafsenat (Grundsatz seit 1990) — bundesgerichtshof.de
+- Schmerzensgeld § 253 II BGB; Bemessungsmaßstäbe — BGH VI. Zivilsenat — bundesgerichtshof.de
+- Halterhaftung § 7 StVG; Höhere Gewalt — BGH VI. Zivilsenat — bundesgerichtshof.de
+- Direktanspruch § 115 VVG; KH-Versicherer — BGH IV. Zivilsenat — bundesgerichtshof.de
+
+## Miet- und WEG-Recht
+
+- Eigenbedarfskündigung; Begründungsstandard, Vortäuschung — BGH VIII. Zivilsenat (umfangreiche Linie) — bundesgerichtshof.de
+- Sozialklausel § 574 BGB; Härtefall — BGH VIII. Zivilsenat — bundesgerichtshof.de
+- Mietminderung § 536 BGB; kraft Gesetzes, Quote — BGH VIII. Zivilsenat (VIII ARZ 2/02 vom 17.07.2002) — bundesgerichtshof.de
+- Schönheitsreparaturen; AGB-Klauseln, Quoten, „unrenoviert" — BGH VIII. Zivilsenat (mehrere Leitentscheidungen 2013-2019) — bundesgerichtshof.de
+- Mietpreisbremse §§ 556d ff. BGB; Rüge und Auskunft — BGH VIII. Zivilsenat — bundesgerichtshof.de
+- WEG-Beschlussanfechtung § 44 WEG (n. F.) / § 46 WEG (a. F.); Fristen — BGH V. Zivilsenat — bundesgerichtshof.de
+- Modernisierung vs. Erhaltung §§ 555a ff. BGB — BGH VIII. Zivilsenat — bundesgerichtshof.de
+
+## Erbrecht
+
+- Pflichtteilsergänzung § 2325 BGB; Zehnjahresfrist und Abschmelzung — BGH IV. Zivilsenat (Linie um IV ZR 249/15) — bundesgerichtshof.de
+- Pflichtteilsstrafklausel im Berliner Testament; Auslegung — BGH IV. Zivilsenat — bundesgerichtshof.de
+- Erbschein § 2353 BGB; Einziehung § 2361 BGB — BGH IV. Zivilsenat / OLG — bundesgerichtshof.de
+- Testierfähigkeit § 2229 BGB; Demenz — OLGs, Auseinandersetzung BGH IV. Zivilsenat — bundesgerichtshof.de
+- Erbschaftsteuer; Verschonungsregelungen — BVerfG 1. Senat (1 BvL 21/12, 17.12.2014) — bundesverfassungsgericht.de
+- Europäisches Nachlasszeugnis EU-ErbVO — EuGH — curia.europa.eu
+- Nachlassinsolvenz § 1980 BGB; Erbenhaftungsbeschränkung — BGH IX. Zivilsenat — bundesgerichtshof.de
+
+## Medizinrecht / Arzthaftung
+
+- Aufklärungspflicht § 630e BGB; Beweislast § 630h II BGB — BGH VI. Zivilsenat — bundesgerichtshof.de
+- Grober Behandlungsfehler; Beweislastumkehr § 630h V BGB — BGH VI. Zivilsenat (Linie seit BGH VI ZR 22/12 v. 19.07.2013 dokumentiert) — bundesgerichtshof.de
+- Dokumentationspflicht § 630f BGB; Folgen Lücken — BGH VI. Zivilsenat — bundesgerichtshof.de
+- Approbations-Widerruf / -Ruhen § 6 BÄO — BVerwG / OVGe; ggf. BVerfG bei Eingriff in Art. 12 GG — bverwg.de + bundesverfassungsgericht.de
+- Recht auf selbstbestimmtes Sterben — BVerfG 2. Senat (2 BvR 2347/15 v. 26.02.2020) — bundesverfassungsgericht.de
+- Befundherausgabe / ePA § 630g BGB — OLGe; Linie BGH VI. Zivilsenat — bundesgerichtshof.de
+
+## Handels- und Gesellschaftsrecht
+
+- GmbH-Geschäftsführerhaftung § 43 GmbHG; Business Judgement Rule — BGH II. Zivilsenat — bundesgerichtshof.de
+- Hauptversammlungsbeschluss Anfechtung § 243 AktG; 1-Monats-Frist § 246 AktG — BGH II. Zivilsenat — bundesgerichtshof.de
+- Treuepflicht des Gesellschafters; Ausschluss / Einziehung — BGH II. Zivilsenat — bundesgerichtshof.de
+- Auskunftsrecht GmbH-Gesellschafter § 51a GmbHG — BGH II. Zivilsenat — bundesgerichtshof.de
+- Handelsvertreterausgleich § 89b HGB; Berechnung — BGH VII./VIII./II. Zivilsenat — bundesgerichtshof.de
+- Grenzüberschreitender Formwechsel — EuGH C-106/16 (Polbud, 25.10.2017) — curia.europa.eu
+- Kommanditist-Einsichtsrecht § 166 HGB — BGH II. Zivilsenat — bundesgerichtshof.de
+
+## Insolvenz- und Sanierungsrecht
+
+- Verwerterpflichten; Bieter-Gleichbehandlung; höchstmögliche Erlöserzielung — BGH IX. Zivilsenat (Linie BGH IX ZR 169/04 v. 13.04.2006, fortgeführt; weitere Entscheidungen ab IX ZR 80/15 v. 16.03.2017) — bundesgerichtshof.de
+- Vorsatzanfechtung § 133 InsO; Bargeschäfts-Ausnahme — BGH IX. Zivilsenat (Linienwandel seit BGH-Beschluss-Reihe ab 2021) — bundesgerichtshof.de
+- Insolvenzantragspflicht § 15a InsO; Drei-Wochen-Frist; § 15b InsO Zahlungsverbot — BGH II./IX. Zivilsenat — bundesgerichtshof.de
+- Eigenverwaltung / Schutzschirmverfahren § 270 ff. InsO — BGH IX. Zivilsenat — bundesgerichtshof.de
+- Insolvenzverwalter-Haftung § 60 InsO — BGH IX. Zivilsenat — bundesgerichtshof.de
+- Geschäftsveräußerung im Ganzen § 1 Ia UStG — EuGH (Zita Modes C-497/01, 27.11.2003; Schriever C-444/10, 10.11.2011); BFH (V R 11/13 v. 18.01.2017) — curia.europa.eu + bfh.bund.de
+- StaRUG; Restrukturierungsbeauftragter, Stabilisierungsanordnung — LG (StaRUG-Gerichte); LG-Hannover/-Köln-Linie 2021-2024; live verifizieren — landesgerichte.de
+
+## Versicherungsrecht
+
+- BU-Anerkenntnis / Nachprüfung — BGH IV. Zivilsenat — bundesgerichtshof.de
+- Anzeigepflicht § 19 VVG; Arglistanfechtung — BGH IV. Zivilsenat (IV ZR 104/17 v. 04.04.2018; mehrere Folgeentscheidungen) — bundesgerichtshof.de
+- Obliegenheitsverletzung § 28 VVG; Belehrungserfordernis IV — BGH IV. Zivilsenat — bundesgerichtshof.de
+- D&O; Versicherungsfall / Claims-made — BGH IV. Zivilsenat — bundesgerichtshof.de
+- Rechtsschutz-Stichentscheid § 18 ARB; Vorvertraglichkeit — BGH IV. Zivilsenat — bundesgerichtshof.de
+- Lebensversicherung; Widerspruchsrecht / Bezugsrechtswahl — BGH IV. Zivilsenat — bundesgerichtshof.de
+- Regress / Subrogation § 86 VVG — BGH IV. Zivilsenat — bundesgerichtshof.de
+
+## Datenschutzrecht (DSGVO)
+
+- Datenübertragung im Asset Deal — EuGH C-732/22 (Bonprix, Urt. v. 26.09.2024); fortgeführt durch EuGH C-621/22 (KNLTB, Urt. v. 04.10.2024) — curia.europa.eu
+- Immaterieller Schadensersatz Art. 82 DSGVO; Erheblichkeitsschwelle — EuGH C-300/21 (Österreichische Post, Urt. v. 04.05.2023) — curia.europa.eu
+- Recht auf Vergessen — BVerfG 1. Senat („Recht auf Vergessen I", 1 BvR 16/13, 06.11.2019; „Recht auf Vergessen II", 1 BvR 276/17, 06.11.2019) — bundesverfassungsgericht.de
+- Berechtigtes Interesse Art. 6 I lit. f DSGVO; Wirtschaftliche Interessen — EuGH — curia.europa.eu
+- Auftragsverarbeitung Art. 28 DSGVO; Drittländer (Schrems-II-Folge) — EuGH C-311/18 — curia.europa.eu
+
+## Steuerrecht (Auswahl)
+
+- Verfassungsmäßigkeit Erbschaftsteuer — BVerfG 1. Senat (1 BvL 21/12 v. 17.12.2014) — bundesverfassungsgericht.de
+- Geschäftsveräußerung im Ganzen § 1 Ia UStG — siehe Insolvenz oben; EuGH/BFH-Linie
+- DBA-Anwendung; Methodenartikel — BFH I. Senat — bfh.bund.de
+- Sanierungsgewinn; Steuerbefreiung § 3a EStG — BFH X. Senat — bfh.bund.de
+- Doppelbesteuerung von Renten — BVerfG 1. Senat / BFH X. Senat — bundesverfassungsgericht.de + bfh.bund.de
+
+## Verwaltungs- und Verfassungsrecht (Quer)
+
+- Verhältnismäßigkeitsprüfung; Eingriffsdogmatik — BVerfG durchgehend — bundesverfassungsgericht.de
+- Konkurrentenstreitverfahren / Beamtenrecht — BVerwG; Eilrechtsschutz nach § 123 VwGO — bverwg.de
+- Versammlungsrecht; „Brokdorf"-Linie — BVerfG 1. Senat (1 BvR 233/81 / 1 BvR 341/81 v. 14.05.1985) — bundesverfassungsgericht.de
+- Umweltrecht; Klagebefugnis UmwRG — BVerwG / EuGH — bverwg.de + curia.europa.eu
+
+## Wie man diese Datei nutzt
+
+1. Skill stößt auf eine juristische Frage → diese Datei nach Rechtsgebiet öffnen.
+2. Themen-Anker auswählen → den **wahrscheinlichen Spruchkörper** und **freie Quelle** notieren.
+3. Vor Ausgabe in Schriftsatz / Mandantenbrief / Gutachten: **Live-Recherche** in der freien Quelle, Datum / Az. / Rn. abklären und in der eigenen Akte dokumentieren.
+4. Im Skill-Output: Wenn der Skill nur den Anker zitiert, mit dem Hinweis-Block kennzeichnen:
+
+> Hinweis: Die hier benannten Rechtsprechungslinien sind als Sucheinstieg gedacht. Die genaue Entscheidung (Aktenzeichen, Datum, Randnummer) ist vor Verwendung in der freien Quelle (BVerfG/BGH/BAG/BSG/BFH/BVerwG/EuGH-Homepage, dejure.org, openjur.de, curia.europa.eu) zu prüfen.
+
+## Was ausdrücklich NICHT in diese Datei darf
+
+- BeckRS-Fundstellen
+- juris-PR-Nummern
+- Kommentar-Randnummern (Grüneberg, MüKo, BeckOK, Staudinger, Erman, ErfK, Schaub, HWK, Maunz/Dürig, BeckOGK, …)
+- Aufsatzfundstellen (NJW, NZA, ZIP, GRUR, MMR, ZD, DStR, NJW-RR, …) ohne Live-Verifikation
+- Erfundene Aktenzeichen oder Daten
+
+Diese Liste wird konservativ kuratiert. Im Zweifel: weglassen, statt eine Behauptung in den Quellenkanon zu stellen, die nicht durch eine freie Quelle gestützt ist.


### PR DESCRIPTION
## Summary

Erster Teil der Qualitätsoffensive: Neue zentrale Referenz `references/leitentscheidungen-anker.md`.

### Design-Entscheidung

Die Datei enthält **bewusst keinen Zitatpool aus Modellwissen**, sondern ein **Such-Gerüst** je Rechtsgebiet: Thema + wahrscheinlicher Spruchkörper + freie Verifikationsquelle. Begründung: Ohne Live-Web-Zugriff können konkrete Aktenzeichen, Daten und Randnummern nicht zuverlässig als „verifiziert" ausgegeben werden — das wäre Halluzinationsrisiko.

### Abgedeckte Rechtsgebiete

Arbeits-, Familien-, Straf-, Verkehrs-, Miet-/WEG-, Erb-, Medizin-, Handels-/Gesellschafts-, Insolvenz-/Sanierungs-, Versicherungs-, Datenschutz-, Steuer-, Verwaltungs-/Verfassungsrecht.

### Verwendungsregel

Skills dürfen die Anker als Sucheinstieg verwenden, müssen aber vor jeder Schriftsatz-/Mandantenbrief-Ausgabe die konkrete Entscheidung in einer freien Quelle (BVerfG/BGH/BAG/BSG/BFH/BVerwG/EuGH-Homepage, dejure.org, openjur.de, curia.europa.eu) live verifizieren.

### Was ausgeschlossen bleibt

- BeckRS-Fundstellen
- juris-PR-Nummern
- Kommentar-Randnummern aus Modellwissen
- Aufsatzfundstellen ohne Live-Verifikation
- Erfundene Aktenzeichen oder Daten

## Test plan

- [x] `validate-plugin-structure.mjs` (keine Plugin-Strukturänderungen → grün bleibt grün)
- [ ] Folge-PRs: Dashboards um diese Anker erweitern, Konvention referenzieren

https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL


---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_