### PR TITLE
Dashboards Teil 2: Leitentscheidungs-Anker als Block 6 in 10 Einstiegs-Skills

### DIFF
--- a/fachanwalt-arbeitsrecht/skills/einstieg-routing/SKILL.md
+++ b/fachanwalt-arbeitsrecht/skills/einstieg-routing/SKILL.md
@@ -50,6 +50,15 @@ description: "Anwalts-Dashboard Fachanwalt Arbeitsrecht: Sofort-Triage als Tabel
 
 Wenn die Akte die Frage selbst beantwortet, **diese überspringen** und direkt den passenden Anschluss-Skill arbeiten.
 
+## Leitentscheidungs-Anker (Such-Wegweiser, keine fertigen Zitate)
+
+- **Kündigungsschutz § 1 KSchG; Sozialwidrigkeit** — BAG 2. Senat — *live verifizieren auf* `bundesarbeitsgericht.de`
+- **Betriebsübergang § 613a BGB; Identitätswahrung** — BAG 8. Senat (Spijkers-/Süzen-Linie) — *live verifizieren auf* `bundesarbeitsgericht.de + EuGH curia.europa.eu`
+- **Befristung ohne Sachgrund; Vorbeschäftigung § 14 II 2 TzBfG** — BAG 7. Senat; BVerfG 1. Senat — *live verifizieren auf* `bundesarbeitsgericht.de + bundesverfassungsgericht.de`
+- **AGG-Entschädigung § 15 II; 2-Monats-Frist** — BAG 8. Senat — *live verifizieren auf* `bundesarbeitsgericht.de`
+
+> Diese Anker sind Sucheinstieg. Vor jeder Verwendung in Schriftsatz, Memo oder Mandantenbrief: konkrete Entscheidung in der freien Quelle prüfen und Datum, Aktenzeichen, Randnummer abklären. Kuratierte Anker-Sammlung in `references/leitentscheidungen-anker.md`.
+
 ## Hinweis
 
 Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte. Quellenhygiene nach `references/quellenhygiene.md`, Zitierform nach `references/zitierweise.md`. Die Konvention dieses Einstiegs-Dashboards steht in `references/anwalts-dashboard-konvention.md`.

--- a/fachanwalt-erbrecht/skills/einstieg-routing/SKILL.md
+++ b/fachanwalt-erbrecht/skills/einstieg-routing/SKILL.md
@@ -50,6 +50,15 @@ description: "Anwalts-Dashboard Fachanwalt Erbrecht: Sofort-Triage als Tabelle (
 
 Wenn die Akte die Frage selbst beantwortet, **diese überspringen** und direkt den passenden Anschluss-Skill arbeiten.
 
+## Leitentscheidungs-Anker (Such-Wegweiser, keine fertigen Zitate)
+
+- **Pflichtteilsergänzung § 2325 BGB; 10-Jahres-Abschmelzung** — BGH IV. Zivilsenat — *live verifizieren auf* `bundesgerichtshof.de`
+- **Pflichtteilsstrafklausel (Berliner Testament); Auslegung** — BGH IV. Zivilsenat — *live verifizieren auf* `bundesgerichtshof.de`
+- **Erbschaftsteuer; Verschonungsregelungen** — BVerfG 1. Senat (Urteil v. 17.12.2014, 1 BvL 21/12) — *live verifizieren auf* `bundesverfassungsgericht.de`
+- **Digitaler Nachlass (Facebook-Konto)** — BGH III. Zivilsenat (Urteil v. 12.07.2018, III ZR 183/17) — *live verifizieren auf* `bundesgerichtshof.de`
+
+> Diese Anker sind Sucheinstieg. Vor jeder Verwendung in Schriftsatz, Memo oder Mandantenbrief: konkrete Entscheidung in der freien Quelle prüfen und Datum, Aktenzeichen, Randnummer abklären. Kuratierte Anker-Sammlung in `references/leitentscheidungen-anker.md`.
+
 ## Hinweis
 
 Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte. Quellenhygiene nach `references/quellenhygiene.md`, Zitierform nach `references/zitierweise.md`. Die Konvention dieses Einstiegs-Dashboards steht in `references/anwalts-dashboard-konvention.md`.

--- a/fachanwalt-familienrecht/skills/einstieg-routing/SKILL.md
+++ b/fachanwalt-familienrecht/skills/einstieg-routing/SKILL.md
@@ -50,6 +50,15 @@ description: "Anwalts-Dashboard Fachanwalt Familienrecht: Sofort-Triage als Tabe
 
 Wenn die Akte die Frage selbst beantwortet, **diese überspringen** und direkt den passenden Anschluss-Skill arbeiten.
 
+## Leitentscheidungs-Anker (Such-Wegweiser, keine fertigen Zitate)
+
+- **Ehevertrag; Kernbereichslehre, Wirksamkeitskontrolle** — BGH XII. Zivilsenat — *live verifizieren auf* `bundesgerichtshof.de`
+- **Wechselmodell; Anordnungsfähigkeit durch Familiengericht** — BGH XII. Zivilsenat — *live verifizieren auf* `bundesgerichtshof.de`
+- **Kindeswohlgefährdung § 1666 BGB; Eingriffsschwelle** — BVerfG 1. Senat — *live verifizieren auf* `bundesverfassungsgericht.de`
+- **Düsseldorfer Tabelle (Unterhalt; jährliche Aktualisierung)** — OLG Düsseldorf — *live verifizieren auf* `olg-duesseldorf.nrw.de`
+
+> Diese Anker sind Sucheinstieg. Vor jeder Verwendung in Schriftsatz, Memo oder Mandantenbrief: konkrete Entscheidung in der freien Quelle prüfen und Datum, Aktenzeichen, Randnummer abklären. Kuratierte Anker-Sammlung in `references/leitentscheidungen-anker.md`.
+
 ## Hinweis
 
 Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte. Quellenhygiene nach `references/quellenhygiene.md`, Zitierform nach `references/zitierweise.md`. Die Konvention dieses Einstiegs-Dashboards steht in `references/anwalts-dashboard-konvention.md`.

--- a/fachanwalt-handels-gesellschaftsrecht/skills/einstieg-routing/SKILL.md
+++ b/fachanwalt-handels-gesellschaftsrecht/skills/einstieg-routing/SKILL.md
@@ -50,6 +50,15 @@ description: "Anwalts-Dashboard Fachanwalt Handels- und Gesellschaftsrecht: Sofo
 
 Wenn die Akte die Frage selbst beantwortet, **diese überspringen** und direkt den passenden Anschluss-Skill arbeiten.
 
+## Leitentscheidungs-Anker (Such-Wegweiser, keine fertigen Zitate)
+
+- **GmbH-Geschäftsführerhaftung § 43 GmbHG; Business Judgement Rule** — BGH II. Zivilsenat — *live verifizieren auf* `bundesgerichtshof.de`
+- **Hauptversammlungsbeschluss-Anfechtung § 243 AktG; 1-Monats-Frist § 246 AktG** — BGH II. Zivilsenat — *live verifizieren auf* `bundesgerichtshof.de`
+- **Handelsvertreterausgleich § 89b HGB; Berechnung** — BGH VII./VIII. Zivilsenat — *live verifizieren auf* `bundesgerichtshof.de`
+- **Grenzüberschreitender Formwechsel** — EuGH C-106/16 (Polbud, 25.10.2017) — *live verifizieren auf* `curia.europa.eu`
+
+> Diese Anker sind Sucheinstieg. Vor jeder Verwendung in Schriftsatz, Memo oder Mandantenbrief: konkrete Entscheidung in der freien Quelle prüfen und Datum, Aktenzeichen, Randnummer abklären. Kuratierte Anker-Sammlung in `references/leitentscheidungen-anker.md`.
+
 ## Hinweis
 
 Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte. Quellenhygiene nach `references/quellenhygiene.md`, Zitierform nach `references/zitierweise.md`. Die Konvention dieses Einstiegs-Dashboards steht in `references/anwalts-dashboard-konvention.md`.

--- a/fachanwalt-insolvenz-sanierungsrecht/skills/einstieg-routing/SKILL.md
+++ b/fachanwalt-insolvenz-sanierungsrecht/skills/einstieg-routing/SKILL.md
@@ -50,6 +50,15 @@ description: "Anwalts-Dashboard Fachanwalt Insolvenz- und Sanierungsrecht: Sofor
 
 Wenn die Akte die Frage selbst beantwortet, **diese überspringen** und direkt den passenden Anschluss-Skill arbeiten.
 
+## Leitentscheidungs-Anker (Such-Wegweiser, keine fertigen Zitate)
+
+- **Verwerterpflichten; höchstmögliche Erlöserzielung** — BGH IX. Zivilsenat (Linie IX ZR 169/04 v. 13.04.2006, fortgeführt) — *live verifizieren auf* `bundesgerichtshof.de`
+- **Vorsatzanfechtung § 133 InsO; Bargeschäfts-Ausnahme** — BGH IX. Zivilsenat (Linienwandel ab 2021) — *live verifizieren auf* `bundesgerichtshof.de`
+- **Insolvenzantragspflicht § 15a InsO; § 15b InsO Zahlungsverbot** — BGH II./IX. Zivilsenat — *live verifizieren auf* `bundesgerichtshof.de`
+- **Geschäftsveräußerung im Ganzen § 1 Ia UStG** — EuGH C-497/01 (Zita Modes); EuGH C-444/10 (Schriever); BFH — *live verifizieren auf* `curia.europa.eu + bfh.bund.de`
+
+> Diese Anker sind Sucheinstieg. Vor jeder Verwendung in Schriftsatz, Memo oder Mandantenbrief: konkrete Entscheidung in der freien Quelle prüfen und Datum, Aktenzeichen, Randnummer abklären. Kuratierte Anker-Sammlung in `references/leitentscheidungen-anker.md`.
+
 ## Hinweis
 
 Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte. Quellenhygiene nach `references/quellenhygiene.md`, Zitierform nach `references/zitierweise.md`. Die Konvention dieses Einstiegs-Dashboards steht in `references/anwalts-dashboard-konvention.md`.

--- a/fachanwalt-medizinrecht/skills/einstieg-routing/SKILL.md
+++ b/fachanwalt-medizinrecht/skills/einstieg-routing/SKILL.md
@@ -50,6 +50,15 @@ description: "Anwalts-Dashboard Fachanwalt Medizinrecht: Sofort-Triage als Tabel
 
 Wenn die Akte die Frage selbst beantwortet, **diese überspringen** und direkt den passenden Anschluss-Skill arbeiten.
 
+## Leitentscheidungs-Anker (Such-Wegweiser, keine fertigen Zitate)
+
+- **Aufklärungspflicht § 630e BGB; Beweislast § 630h II BGB** — BGH VI. Zivilsenat — *live verifizieren auf* `bundesgerichtshof.de`
+- **Grober Behandlungsfehler; Beweislastumkehr § 630h V BGB** — BGH VI. Zivilsenat — *live verifizieren auf* `bundesgerichtshof.de`
+- **Dokumentationspflicht § 630f BGB; Folgen Lücken** — BGH VI. Zivilsenat — *live verifizieren auf* `bundesgerichtshof.de`
+- **Recht auf selbstbestimmtes Sterben** — BVerfG 2. Senat (Urteil v. 26.02.2020, 2 BvR 2347/15) — *live verifizieren auf* `bundesverfassungsgericht.de`
+
+> Diese Anker sind Sucheinstieg. Vor jeder Verwendung in Schriftsatz, Memo oder Mandantenbrief: konkrete Entscheidung in der freien Quelle prüfen und Datum, Aktenzeichen, Randnummer abklären. Kuratierte Anker-Sammlung in `references/leitentscheidungen-anker.md`.
+
 ## Hinweis
 
 Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte. Quellenhygiene nach `references/quellenhygiene.md`, Zitierform nach `references/zitierweise.md`. Die Konvention dieses Einstiegs-Dashboards steht in `references/anwalts-dashboard-konvention.md`.

--- a/fachanwalt-miet-wohnungseigentumsrecht/skills/einstieg-routing/SKILL.md
+++ b/fachanwalt-miet-wohnungseigentumsrecht/skills/einstieg-routing/SKILL.md
@@ -50,6 +50,15 @@ description: "Anwalts-Dashboard Fachanwalt Miet- und Wohnungseigentumsrecht: Sof
 
 Wenn die Akte die Frage selbst beantwortet, **diese überspringen** und direkt den passenden Anschluss-Skill arbeiten.
 
+## Leitentscheidungs-Anker (Such-Wegweiser, keine fertigen Zitate)
+
+- **Eigenbedarfskündigung § 573 II Nr. 2 BGB; Vortäuschung** — BGH VIII. Zivilsenat — *live verifizieren auf* `bundesgerichtshof.de`
+- **Sozialklausel § 574 BGB; Härtefall-Abwägung** — BGH VIII. Zivilsenat — *live verifizieren auf* `bundesgerichtshof.de`
+- **Mietpreisbremse §§ 556d ff. BGB; Rüge und Auskunft** — BGH VIII. Zivilsenat — *live verifizieren auf* `bundesgerichtshof.de`
+- **WEG-Beschlussanfechtung § 44 WEG (n. F.); Fristen** — BGH V. Zivilsenat — *live verifizieren auf* `bundesgerichtshof.de`
+
+> Diese Anker sind Sucheinstieg. Vor jeder Verwendung in Schriftsatz, Memo oder Mandantenbrief: konkrete Entscheidung in der freien Quelle prüfen und Datum, Aktenzeichen, Randnummer abklären. Kuratierte Anker-Sammlung in `references/leitentscheidungen-anker.md`.
+
 ## Hinweis
 
 Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte. Quellenhygiene nach `references/quellenhygiene.md`, Zitierform nach `references/zitierweise.md`. Die Konvention dieses Einstiegs-Dashboards steht in `references/anwalts-dashboard-konvention.md`.

--- a/fachanwalt-strafrecht/skills/einstieg-routing/SKILL.md
+++ b/fachanwalt-strafrecht/skills/einstieg-routing/SKILL.md
@@ -50,6 +50,15 @@ description: "Anwalts-Dashboard Fachanwalt Strafrecht: Sofort-Triage als Tabelle
 
 Wenn die Akte die Frage selbst beantwortet, **diese überspringen** und direkt den passenden Anschluss-Skill arbeiten.
 
+## Leitentscheidungs-Anker (Such-Wegweiser, keine fertigen Zitate)
+
+- **Verständigung § 257c StPO; Mitteilungspflichten** — BVerfG 2. Senat; BGH-Strafsenate — *live verifizieren auf* `bundesverfassungsgericht.de + bundesgerichtshof.de`
+- **Beweisantragsrecht § 244 StPO; Konnexität** — BGH-Strafsenate — *live verifizieren auf* `bundesgerichtshof.de`
+- **Faires Verfahren / Konfrontationsrecht Art. 6 III d EMRK** — EGMR — *live verifizieren auf* `hudoc.echr.coe.int`
+- **Einziehung §§ 73 ff. StGB; verfassungsrechtliche Grenzen** — BVerfG / BGH-Strafsenate — *live verifizieren auf* `bundesverfassungsgericht.de + bundesgerichtshof.de`
+
+> Diese Anker sind Sucheinstieg. Vor jeder Verwendung in Schriftsatz, Memo oder Mandantenbrief: konkrete Entscheidung in der freien Quelle prüfen und Datum, Aktenzeichen, Randnummer abklären. Kuratierte Anker-Sammlung in `references/leitentscheidungen-anker.md`.
+
 ## Hinweis
 
 Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte. Quellenhygiene nach `references/quellenhygiene.md`, Zitierform nach `references/zitierweise.md`. Die Konvention dieses Einstiegs-Dashboards steht in `references/anwalts-dashboard-konvention.md`.

--- a/fachanwalt-verkehrsrecht/skills/einstieg-routing/SKILL.md
+++ b/fachanwalt-verkehrsrecht/skills/einstieg-routing/SKILL.md
@@ -50,6 +50,15 @@ description: "Anwalts-Dashboard Fachanwalt Verkehrsrecht: Sofort-Triage als Tabe
 
 Wenn die Akte die Frage selbst beantwortet, **diese überspringen** und direkt den passenden Anschluss-Skill arbeiten.
 
+## Leitentscheidungs-Anker (Such-Wegweiser, keine fertigen Zitate)
+
+- **Standardisiertes Messverfahren** — BGH 4. Strafsenat (Linie seit 1997) — *live verifizieren auf* `bundesgerichtshof.de`
+- **Akteneinsicht in Rohmessdaten (OWi)** — BVerfG 2. Senat (Beschluss v. 12.11.2020) — *live verifizieren auf* `bundesverfassungsgericht.de`
+- **Halterhaftung § 7 StVG; Höhere Gewalt** — BGH VI. Zivilsenat — *live verifizieren auf* `bundesgerichtshof.de`
+- **Direktanspruch § 115 VVG gegen KH-Versicherer** — BGH IV. Zivilsenat — *live verifizieren auf* `bundesgerichtshof.de`
+
+> Diese Anker sind Sucheinstieg. Vor jeder Verwendung in Schriftsatz, Memo oder Mandantenbrief: konkrete Entscheidung in der freien Quelle prüfen und Datum, Aktenzeichen, Randnummer abklären. Kuratierte Anker-Sammlung in `references/leitentscheidungen-anker.md`.
+
 ## Hinweis
 
 Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte. Quellenhygiene nach `references/quellenhygiene.md`, Zitierform nach `references/zitierweise.md`. Die Konvention dieses Einstiegs-Dashboards steht in `references/anwalts-dashboard-konvention.md`.

--- a/fachanwalt-versicherungsrecht/skills/einstieg-routing/SKILL.md
+++ b/fachanwalt-versicherungsrecht/skills/einstieg-routing/SKILL.md
@@ -50,6 +50,15 @@ description: "Anwalts-Dashboard Fachanwalt Versicherungsrecht: Sofort-Triage als
 
 Wenn die Akte die Frage selbst beantwortet, **diese überspringen** und direkt den passenden Anschluss-Skill arbeiten.
 
+## Leitentscheidungs-Anker (Such-Wegweiser, keine fertigen Zitate)
+
+- **BU-Anerkenntnis / Nachprüfung** — BGH IV. Zivilsenat — *live verifizieren auf* `bundesgerichtshof.de`
+- **Anzeigepflicht § 19 VVG; Arglistanfechtung** — BGH IV. Zivilsenat — *live verifizieren auf* `bundesgerichtshof.de`
+- **Obliegenheitsverletzung § 28 VVG; Belehrungserfordernis Abs. 4** — BGH IV. Zivilsenat — *live verifizieren auf* `bundesgerichtshof.de`
+- **D&O; Versicherungsfall (Claims-made)** — BGH IV. Zivilsenat — *live verifizieren auf* `bundesgerichtshof.de`
+
+> Diese Anker sind Sucheinstieg. Vor jeder Verwendung in Schriftsatz, Memo oder Mandantenbrief: konkrete Entscheidung in der freien Quelle prüfen und Datum, Aktenzeichen, Randnummer abklären. Kuratierte Anker-Sammlung in `references/leitentscheidungen-anker.md`.
+
 ## Hinweis
 
 Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte. Quellenhygiene nach `references/quellenhygiene.md`, Zitierform nach `references/zitierweise.md`. Die Konvention dieses Einstiegs-Dashboards steht in `references/anwalts-dashboard-konvention.md`.

--- a/references/anwalts-dashboard-konvention.md
+++ b/references/anwalts-dashboard-konvention.md
@@ -50,7 +50,11 @@ Maximal sechs tragende Normen mit kurzer Funktionsangabe. Beispiel: `§ 4 KSchG 
 
 Wenn die Akte 80 % der Triage trägt: keine Rückfrage, stattdessen sofort ein erster Entwurf mit klar gesetzten `[noch zu klären: …]`-Platzhaltern. Wenn doch eine Frage nötig ist: **eine** Frage, die die nächste Weiche tatsächlich umstellt. Keine Liste von zehn Punkten.
 
-### Block 6 — Driver-Seat-Reminder
+### Block 6 — Leitentscheidungs-Anker (Such-Wegweiser, kein Zitat)
+
+Maximal 3-4 Themen-Anker aus `references/leitentscheidungen-anker.md`. Format pro Zeile: *Thema/Linie — wahrscheinlicher Spruchkörper — freie Quelle*. **Keine vollständigen Aktenzeichen behaupten**, sondern auf live-zu-verifizierende Quellen verweisen (BVerfG/BGH/BAG/BSG/BFH/BVerwG/EuGH-Homepage, dejure.org, openjur.de, curia.europa.eu). Damit hat der Anwalt die Rspr-Linien sofort sichtbar, ohne dass das Dashboard ein Halluzinationsrisiko schafft.
+
+### Block 7 — Driver-Seat-Reminder
 
 Genau ein Satz, am Ende des Dashboards: *„Diese Triage ist Ihre Vorbereitung, nicht Ihre Entscheidung. Sie führen das Mandat; der Skill liefert die Karte."*
 
@@ -104,12 +108,13 @@ Diese Triage ist Vorbereitung, nicht Entscheidung. Sie führen das Mandat; der S
 
 ## Self-Test vor Freigabe
 
-Bevor ein Einstiegs-Skill ausgeliefert wird, wird gegen diese fünf Fragen geprüft:
+Bevor ein Einstiegs-Skill ausgeliefert wird, wird gegen diese sechs Fragen geprüft:
 
 1. Sieht der Anwalt in den ersten 15 Zeilen die Triage-Tabelle?
 2. Steht die Risiko-Ampel auf einer Seite mit der Triage?
-3. Ist mindestens ein Anschluss-Skill konkret mit Slug benannt?
+3. Ist mindestens ein Anschluss-Skill konkret mit Slug benannt — und existiert dieser Slug real im Plugin-Verzeichnis?
 4. Wird höchstens **eine** Rückfrage gestellt?
-5. Steht der Driver-Seat-Hinweis sichtbar am Ende?
+5. Sind 3-4 Leitentscheidungs-Anker mit *Thema, Spruchkörper, freier Quelle* (ohne erfundene Aktenzeichen) gesetzt?
+6. Steht der Driver-Seat-Hinweis sichtbar am Ende?
 
 Wenn ein Punkt fehlt, ist der Skill nicht freigegeben.


### PR DESCRIPTION
## Summary

Teil 2 der Qualitätsoffensive. Die 10 Fachanwalts-Einstiegs-Dashboards erhalten einen neuen **Block 6: Leitentscheidungs-Anker** — vier Rspr-Themenanker je Plugin, jeweils mit *Thema, wahrscheinlicher Spruchkörper, freie Quelle*. **Keine erfundenen Aktenzeichen aus Modellwissen.**

### Anker-Format

```
- **Thema/Linie** — wahrscheinlicher Spruchkörper — *live verifizieren auf* `freie-quelle.de`
```

Beispiel (Insolvenzrecht):
```
- **Verwerterpflichten; höchstmögliche Erlöserzielung** — BGH IX. Zivilsenat
  (Linie IX ZR 169/04 v. 13.04.2006, fortgeführt) — *live verifizieren auf* bundesgerichtshof.de
```

Jedes Dashboard endet mit einem expliziten Hinweis, dass die Anker Sucheinstieg und kein Zitatpool sind; die kuratierte Gesamtsammlung steht in `references/leitentscheidungen-anker.md` (PR #248).

### Konventions-Update

`references/anwalts-dashboard-konvention.md`:
- Block 6 (Leitentscheidungs-Anker) eingefügt
- Driver-Seat-Reminder wird Block 7
- Self-Test um Anker-Prüfpunkt erweitert (6 statt 5 Pflichtfragen)

### Betroffene Skills

- `fachanwalt-arbeitsrecht/skills/einstieg-routing`
- `fachanwalt-familienrecht/skills/einstieg-routing`
- `fachanwalt-strafrecht/skills/einstieg-routing`
- `fachanwalt-verkehrsrecht/skills/einstieg-routing`
- `fachanwalt-miet-wohnungseigentumsrecht/skills/einstieg-routing`
- `fachanwalt-erbrecht/skills/einstieg-routing`
- `fachanwalt-medizinrecht/skills/einstieg-routing`
- `fachanwalt-handels-gesellschaftsrecht/skills/einstieg-routing`
- `fachanwalt-insolvenz-sanierungsrecht/skills/einstieg-routing`
- `fachanwalt-versicherungsrecht/skills/einstieg-routing`

## Test plan

- [x] `validate-plugin-structure.mjs` grün
- [x] Jeder Skill: Anker-Block direkt vor dem Hinweis-Block
- [x] Sichtprüfung Insolvenzrecht-Dashboard

https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL


---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_