### PR TITLE
Qualitätsoffensive Finale: CLAUDE.md, Visual-Routenkarte, Dashboard-Hinweise in 10 Plugin-READMEs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ Dieses Repository enthält Plugins für deutsche Kanzleien. Wenn du in diesem Re
 - Aufsätze: Autor, Zeitschrift, Jahrgang, Anfangsseite (konkrete Seite).
 - Reihenfolge: Rspr. vor Lit., neueste zuerst.
 - Keine Kommentar-, Handbuch- oder Aufsatzfundstellen aus Modellwissen zitieren. Literatur nur nutzen, wenn der Nutzer die Quelle bereitstellt oder ein lizenzierter Live-Zugriff sie verifiziert.
+- **Leitentscheidungs-Anker:** [`references/leitentscheidungen-anker.md`](./references/leitentscheidungen-anker.md) ist die kuratierte Themen-Anker-Liste je Rechtsgebiet. Sie ersetzt nicht die Live-Verifikation, aber sie liefert sichere Sucheinstiege ohne Modellwissens-Halluzination.
 
 ## Verboten
 

--- a/fachanwalt-arbeitsrecht/README.md
+++ b/fachanwalt-arbeitsrecht/README.md
@@ -20,6 +20,19 @@ Direkt-Downloads ohne Umwege. Die URLs sind stabil und zeigen immer auf die aktu
 
 <!-- END plugin-sofort-download-section (autogen) -->
 
+## Anwalts-Dashboard fuer den Schnelleinstieg
+
+Der Skill `einstieg-routing` ist das Anwalts-Dashboard zu diesem Plugin:
+Sofort-Triage als Tabelle (Rolle, Verfahrensstand, Eilfrist, Hauptanspruch,
+Zustaendigkeit), Risiko-Ampel, Anschluss-Skill-Router mit echten Slugs,
+Norm-Radar, Leitentscheidungs-Anker und genau eine Rueckfrage - bei
+klarer Faktenlage sofort zum Spezial-Skill. Der Anwalt bleibt im Driver Seat.
+
+Konvention: [`references/anwalts-dashboard-konvention.md`](../references/anwalts-dashboard-konvention.md)
+| Quellen-Anker: [`references/leitentscheidungen-anker.md`](../references/leitentscheidungen-anker.md)
+| Quellenhygiene: [`references/quellenhygiene.md`](../references/quellenhygiene.md).
+
+
 Plugin Fachanwalt für Arbeitsrecht nach FAO § 10. Orientierung, Kündigungsschutzklage, Betriebsratsanhörung, Befristung. Schnittstellen zum Plugin `arbeitsrecht` (operative Mandatsführung) und `kanzlei-allgemein`.
 
 ## Installation in Claude Code

--- a/fachanwalt-erbrecht/README.md
+++ b/fachanwalt-erbrecht/README.md
@@ -19,6 +19,19 @@ Direkt-Downloads ohne Umwege. Die URLs sind stabil und zeigen immer auf die aktu
 
 <!-- END plugin-sofort-download-section (autogen) -->
 
+## Anwalts-Dashboard fuer den Schnelleinstieg
+
+Der Skill `einstieg-routing` ist das Anwalts-Dashboard zu diesem Plugin:
+Sofort-Triage als Tabelle (Rolle, Verfahrensstand, Eilfrist, Hauptanspruch,
+Zustaendigkeit), Risiko-Ampel, Anschluss-Skill-Router mit echten Slugs,
+Norm-Radar, Leitentscheidungs-Anker und genau eine Rueckfrage - bei
+klarer Faktenlage sofort zum Spezial-Skill. Der Anwalt bleibt im Driver Seat.
+
+Konvention: [`references/anwalts-dashboard-konvention.md`](../references/anwalts-dashboard-konvention.md)
+| Quellen-Anker: [`references/leitentscheidungen-anker.md`](../references/leitentscheidungen-anker.md)
+| Quellenhygiene: [`references/quellenhygiene.md`](../references/quellenhygiene.md).
+
+
 Plugin Fachanwalt für Erbrecht. Orientierung BGB Erbrecht §§ 1922 ff. Pflichtteil Testament Erbschein Erbauseinandersetzung Erbschaft- und Schenkungsteuer ErbStG EU-ErbVO. Schnittstellen steuerrecht-anwalt-und-berater und gesellschaftsrecht.
 
 ## Installation in Claude Code

--- a/fachanwalt-familienrecht/README.md
+++ b/fachanwalt-familienrecht/README.md
@@ -15,6 +15,19 @@ Dieses Plugin hat (bewusst) keine eigene Demonstrations-Akte.
 
 <!-- END plugin-sofort-download-section (autogen) -->
 
+## Anwalts-Dashboard fuer den Schnelleinstieg
+
+Der Skill `einstieg-routing` ist das Anwalts-Dashboard zu diesem Plugin:
+Sofort-Triage als Tabelle (Rolle, Verfahrensstand, Eilfrist, Hauptanspruch,
+Zustaendigkeit), Risiko-Ampel, Anschluss-Skill-Router mit echten Slugs,
+Norm-Radar, Leitentscheidungs-Anker und genau eine Rueckfrage - bei
+klarer Faktenlage sofort zum Spezial-Skill. Der Anwalt bleibt im Driver Seat.
+
+Konvention: [`references/anwalts-dashboard-konvention.md`](../references/anwalts-dashboard-konvention.md)
+| Quellen-Anker: [`references/leitentscheidungen-anker.md`](../references/leitentscheidungen-anker.md)
+| Quellenhygiene: [`references/quellenhygiene.md`](../references/quellenhygiene.md).
+
+
 Quellenregel: Keine Kommentar-, Handbuch- oder Aufsatzfundstellen aus Modellwissen; Literatur nur mit Nutzerquelle oder lizenziertem Live-Zugriff.
 
 ## Installation in Claude Code

--- a/fachanwalt-handels-gesellschaftsrecht/README.md
+++ b/fachanwalt-handels-gesellschaftsrecht/README.md
@@ -22,6 +22,19 @@ Direkt-Downloads ohne Umwege. Die URLs sind stabil und zeigen immer auf die aktu
 
 <!-- END plugin-sofort-download-section (autogen) -->
 
+## Anwalts-Dashboard fuer den Schnelleinstieg
+
+Der Skill `einstieg-routing` ist das Anwalts-Dashboard zu diesem Plugin:
+Sofort-Triage als Tabelle (Rolle, Verfahrensstand, Eilfrist, Hauptanspruch,
+Zustaendigkeit), Risiko-Ampel, Anschluss-Skill-Router mit echten Slugs,
+Norm-Radar, Leitentscheidungs-Anker und genau eine Rueckfrage - bei
+klarer Faktenlage sofort zum Spezial-Skill. Der Anwalt bleibt im Driver Seat.
+
+Konvention: [`references/anwalts-dashboard-konvention.md`](../references/anwalts-dashboard-konvention.md)
+| Quellen-Anker: [`references/leitentscheidungen-anker.md`](../references/leitentscheidungen-anker.md)
+| Quellenhygiene: [`references/quellenhygiene.md`](../references/quellenhygiene.md).
+
+
 Plugin Fachanwalt für Handels- und Gesellschaftsrecht nach FAO § 14i. HGB, AktG, GmbHG, PartGG, UmwG, MoPeG (GbR seit 2024). Geschäftsführerhaftung §§ 43 GmbHG, 93 AktG. Gesellschafterstreit und Beschlussanfechtung. Handelsvertreterausgleich § 89b HGB.
 
 ## Installation in Claude Code

--- a/fachanwalt-insolvenz-sanierungsrecht/README.md
+++ b/fachanwalt-insolvenz-sanierungsrecht/README.md
@@ -20,6 +20,19 @@ Direkt-Downloads ohne Umwege. Die URLs sind stabil und zeigen immer auf die aktu
 
 <!-- END plugin-sofort-download-section (autogen) -->
 
+## Anwalts-Dashboard fuer den Schnelleinstieg
+
+Der Skill `einstieg-routing` ist das Anwalts-Dashboard zu diesem Plugin:
+Sofort-Triage als Tabelle (Rolle, Verfahrensstand, Eilfrist, Hauptanspruch,
+Zustaendigkeit), Risiko-Ampel, Anschluss-Skill-Router mit echten Slugs,
+Norm-Radar, Leitentscheidungs-Anker und genau eine Rueckfrage - bei
+klarer Faktenlage sofort zum Spezial-Skill. Der Anwalt bleibt im Driver Seat.
+
+Konvention: [`references/anwalts-dashboard-konvention.md`](../references/anwalts-dashboard-konvention.md)
+| Quellen-Anker: [`references/leitentscheidungen-anker.md`](../references/leitentscheidungen-anker.md)
+| Quellenhygiene: [`references/quellenhygiene.md`](../references/quellenhygiene.md).
+
+
 Plugin Fachanwalt für Insolvenz- und Sanierungsrecht nach FAO § 14 (idF nach Aufnahme StaRUG-Bereiche). Orientierung, Gläubigerantrag, Restrukturierungsplan StaRUG, Insolvenzanfechtung. Schnittstellen zum Plugin `insolvenzrecht` (operativ) und `steuerrecht-anwalt-und-berater`.
 
 ## InsO-Paragraphen-Navigator

--- a/fachanwalt-medizinrecht/README.md
+++ b/fachanwalt-medizinrecht/README.md
@@ -21,6 +21,19 @@ Direkt-Downloads ohne Umwege. Die URLs sind stabil und zeigen immer auf die aktu
 
 <!-- END plugin-sofort-download-section (autogen) -->
 
+## Anwalts-Dashboard fuer den Schnelleinstieg
+
+Der Skill `einstieg-routing` ist das Anwalts-Dashboard zu diesem Plugin:
+Sofort-Triage als Tabelle (Rolle, Verfahrensstand, Eilfrist, Hauptanspruch,
+Zustaendigkeit), Risiko-Ampel, Anschluss-Skill-Router mit echten Slugs,
+Norm-Radar, Leitentscheidungs-Anker und genau eine Rueckfrage - bei
+klarer Faktenlage sofort zum Spezial-Skill. Der Anwalt bleibt im Driver Seat.
+
+Konvention: [`references/anwalts-dashboard-konvention.md`](../references/anwalts-dashboard-konvention.md)
+| Quellen-Anker: [`references/leitentscheidungen-anker.md`](../references/leitentscheidungen-anker.md)
+| Quellenhygiene: [`references/quellenhygiene.md`](../references/quellenhygiene.md).
+
+
 Plugin Fachanwalt für Medizinrecht. Orientierung Arzthaftung §§ 630a ff. BGB Patientenrechte Vertragsarztrecht Berufsrecht Ärzte und Heilberufe SGB V Krankenversicherung MPDG Apothekenrecht. Schnittstellen fachanwalt-sozialrecht und kanzlei-allgemein.
 
 ## Installation in Claude Code

--- a/fachanwalt-miet-wohnungseigentumsrecht/README.md
+++ b/fachanwalt-miet-wohnungseigentumsrecht/README.md
@@ -19,6 +19,19 @@ Direkt-Downloads ohne Umwege. Die URLs sind stabil und zeigen immer auf die aktu
 
 <!-- END plugin-sofort-download-section (autogen) -->
 
+## Anwalts-Dashboard fuer den Schnelleinstieg
+
+Der Skill `einstieg-routing` ist das Anwalts-Dashboard zu diesem Plugin:
+Sofort-Triage als Tabelle (Rolle, Verfahrensstand, Eilfrist, Hauptanspruch,
+Zustaendigkeit), Risiko-Ampel, Anschluss-Skill-Router mit echten Slugs,
+Norm-Radar, Leitentscheidungs-Anker und genau eine Rueckfrage - bei
+klarer Faktenlage sofort zum Spezial-Skill. Der Anwalt bleibt im Driver Seat.
+
+Konvention: [`references/anwalts-dashboard-konvention.md`](../references/anwalts-dashboard-konvention.md)
+| Quellen-Anker: [`references/leitentscheidungen-anker.md`](../references/leitentscheidungen-anker.md)
+| Quellenhygiene: [`references/quellenhygiene.md`](../references/quellenhygiene.md).
+
+
 Plugin Fachanwalt für Miet- und Wohnungseigentumsrecht nach FAO § 14e, jetzt als großer Praxis-Kompass mit über 200 Skills: Wohnraummiete, Gewerberaummiete, Betriebskosten, Heizkosten, CO2-Kosten, Kündigung, Räumung, Mängel, Modernisierung, Mietpreisbremse, Kaution, WEG-Beschlüsse, Hausverwaltung, bauliche Veränderungen, GEG/Wärmepumpe, E-Ladung, Photovoltaik, Protokolle, Beweise, Fristen und Schriftsatz-/Beschlussentwürfe. Der Einstiegsskill routet Laien, Berufsanfänger und erfahrene Praktiker in den passenden Workflow.
 
 ## Installation in Claude Code

--- a/fachanwalt-strafrecht/README.md
+++ b/fachanwalt-strafrecht/README.md
@@ -22,6 +22,19 @@ Direkt-Downloads ohne Umwege. Die URLs sind stabil und zeigen immer auf die aktu
 
 <!-- END plugin-sofort-download-section (autogen) -->
 
+## Anwalts-Dashboard fuer den Schnelleinstieg
+
+Der Skill `einstieg-routing` ist das Anwalts-Dashboard zu diesem Plugin:
+Sofort-Triage als Tabelle (Rolle, Verfahrensstand, Eilfrist, Hauptanspruch,
+Zustaendigkeit), Risiko-Ampel, Anschluss-Skill-Router mit echten Slugs,
+Norm-Radar, Leitentscheidungs-Anker und genau eine Rueckfrage - bei
+klarer Faktenlage sofort zum Spezial-Skill. Der Anwalt bleibt im Driver Seat.
+
+Konvention: [`references/anwalts-dashboard-konvention.md`](../references/anwalts-dashboard-konvention.md)
+| Quellen-Anker: [`references/leitentscheidungen-anker.md`](../references/leitentscheidungen-anker.md)
+| Quellenhygiene: [`references/quellenhygiene.md`](../references/quellenhygiene.md).
+
+
 ## Was dieses Plugin im Strafprozess leistet
 
 Dieses Plugin ist als Arbeitscockpit für Strafverteidigung gedacht: nicht nur für die große Strategie, sondern für die täglichen Schritte einer laufenden Strafakte. Es ordnet Eingänge, markiert Fristen, baut Aktenlog und Wiedervorlagen, steuert Akteneinsicht, U-Haft, Pflichtverteidigung, Hauptverhandlung, Antragslog, Mandanteninstruktionen, Rechtsmittel und Vollstreckungsnachlauf.

--- a/fachanwalt-verkehrsrecht/README.md
+++ b/fachanwalt-verkehrsrecht/README.md
@@ -20,6 +20,19 @@ Direkt-Downloads ohne Umwege. Die URLs sind stabil und zeigen immer auf die aktu
 
 <!-- END plugin-sofort-download-section (autogen) -->
 
+## Anwalts-Dashboard fuer den Schnelleinstieg
+
+Der Skill `einstieg-routing` ist das Anwalts-Dashboard zu diesem Plugin:
+Sofort-Triage als Tabelle (Rolle, Verfahrensstand, Eilfrist, Hauptanspruch,
+Zustaendigkeit), Risiko-Ampel, Anschluss-Skill-Router mit echten Slugs,
+Norm-Radar, Leitentscheidungs-Anker und genau eine Rueckfrage - bei
+klarer Faktenlage sofort zum Spezial-Skill. Der Anwalt bleibt im Driver Seat.
+
+Konvention: [`references/anwalts-dashboard-konvention.md`](../references/anwalts-dashboard-konvention.md)
+| Quellen-Anker: [`references/leitentscheidungen-anker.md`](../references/leitentscheidungen-anker.md)
+| Quellenhygiene: [`references/quellenhygiene.md`](../references/quellenhygiene.md).
+
+
 Plugin Fachanwalt für Verkehrsrecht. Orientierung StVG StVO PflVG VVG-Bezüge. Verkehrsunfall Personenschaden Sachschaden Bußgeld Fahrerlaubnis OWi-Verfahren Verkehrsstrafrecht (§§ 315c 316 StGB). Schnittstellen zu Versicherungs- und Strafrecht.
 
 ## Installation in Claude Code

--- a/fachanwalt-versicherungsrecht/README.md
+++ b/fachanwalt-versicherungsrecht/README.md
@@ -20,6 +20,19 @@ Direkt-Downloads ohne Umwege. Die URLs sind stabil und zeigen immer auf die aktu
 
 <!-- END plugin-sofort-download-section (autogen) -->
 
+## Anwalts-Dashboard fuer den Schnelleinstieg
+
+Der Skill `einstieg-routing` ist das Anwalts-Dashboard zu diesem Plugin:
+Sofort-Triage als Tabelle (Rolle, Verfahrensstand, Eilfrist, Hauptanspruch,
+Zustaendigkeit), Risiko-Ampel, Anschluss-Skill-Router mit echten Slugs,
+Norm-Radar, Leitentscheidungs-Anker und genau eine Rueckfrage - bei
+klarer Faktenlage sofort zum Spezial-Skill. Der Anwalt bleibt im Driver Seat.
+
+Konvention: [`references/anwalts-dashboard-konvention.md`](../references/anwalts-dashboard-konvention.md)
+| Quellen-Anker: [`references/leitentscheidungen-anker.md`](../references/leitentscheidungen-anker.md)
+| Quellenhygiene: [`references/quellenhygiene.md`](../references/quellenhygiene.md).
+
+
 Plugin Fachanwalt für Versicherungsrecht. Orientierung VVG VAG Berufsunfähigkeit private Krankenversicherung Lebens- und Rentenversicherung Sachversicherung Haftpflicht D-und-O. Schnittstellen kanzlei-allgemein und fachanwalt-verkehrsrecht.
 
 ## Installation in Claude Code

--- a/references/anwalts-dashboard-konvention.md
+++ b/references/anwalts-dashboard-konvention.md
@@ -12,6 +12,20 @@
 
 ## Standardaufbau (von oben nach unten)
 
+### Visueller Anker (optional, vor Block 1)
+
+Wenn der Fall typischerweise einen mehrstufigen Verfahrensablauf hat, darf am Anfang eine kompakte **Routenkarte als ASCII-Block** stehen — eine Zeile pro Phase, mit Pfeilen, ohne Lehrbuch. Beispiel Insolvenzrecht:
+
+```
+Antragsphase  -->  Eroeffnung 27/28 InsO  -->  Berichtstermin 156 InsO
+     |                     |                          |
+     |                     v                          v
+$ 15a InsO       VVB $ 80 InsO              Verwertung 159 ff. InsO
+3 Wochen         Treuhandkonten              Glaeubigerausschuss 160 InsO
+```
+
+Höchstens 10 Zeilen, klar lesbar in Monospace. Keine ASCII-Kunst um ihrer selbst willen — die Karte muss eine Frage beantworten, die die Tabelle nicht beantwortet (typischerweise: „wo stehe ich im Verfahrenslauf?").
+
 ### Block 1 — Sofort-Triage (Tabelle, vor jeder Rückfrage)
 
 | Punkt | Schnellprüfung | Standardquelle / Hilfsweg |


### PR DESCRIPTION
## Summary

Finale der Qualitätsoffensive — alle Stränge zusammengeführt.

### CLAUDE.md
- Neuer Bullet-Point unter "Quellen und Zitierweise" verweist auf `references/leitentscheidungen-anker.md` als kuratierte Themen-Anker-Liste.

### references/anwalts-dashboard-konvention.md
- Neue **„Visueller Anker"**-Sektion vor Block 1: optionale ASCII-Routenkarte (≤ 10 Zeilen, Monospace), beantwortet die Frage „wo stehe ich im Verfahrenslauf?".

### 10 Fachanwalt-Plugin-READMEs
Jede Plugin-README erhält eine neue Sektion **„Anwalts-Dashboard für den Schnelleinstieg"** direkt nach dem autogen Sofort-Download-Block. Sie erläutert den Skill `einstieg-routing` und verlinkt drei zentrale Referenzen:
- `references/anwalts-dashboard-konvention.md`
- `references/leitentscheidungen-anker.md`
- `references/quellenhygiene.md`

### Audit-Befund

Cross-Check `grep '(NJW|NZA|MMR|GRUR|ZIP|DStR) \d{4}, \d+'` über alle SKILL.md: keine systemischen Halluzinationen. Audit `task_275` hat den Bestand bereits bereinigt; bestehende NJW-Zitate sind überwiegend mit `dejure.org`-Verifikationsstempel oder als Audit-Removals/-Korrekturen dokumentiert.

### Gesamtbild der Offensive

- PR #248 — `references/leitentscheidungen-anker.md` (Such-Gerüst je Rechtsgebiet)
- PR #250 — 10 Einstiegs-Dashboards um Block 6 (Anker) erweitert
- PR #251 — finale Verkettung in CLAUDE.md, Konvention, Plugin-READMEs

## Test plan

- [x] `validate-plugin-structure.mjs` grün
- [x] Cross-Check halluzinierte Zitate
- [x] Dashboard-Hinweis in allen 10 Plugin-READMEs

https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL


---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_