### PR TITLE
Insolvenz-READMEs: Asset-Deal-Vertragsvorlage verlinken (Word/PDF/ZIP)

### DIFF
--- a/fachanwalt-insolvenz-sanierungsrecht/README.md
+++ b/fachanwalt-insolvenz-sanierungsrecht/README.md
@@ -43,6 +43,19 @@ Besonders hilfreich ist das bei Akten, in denen viele Ebenen gleichzeitig laufen
 
 Vor verbindlichen Aussagen prüft der jeweilige Skill den aktuellen Gesetzeswortlaut und verlangt für Rechtsprechung Gericht, Datum, Aktenzeichen und möglichst eine frei zugängliche amtliche oder gerichtliche Quelle. Literatur- und Datenbankfundstellen werden nicht aus Modellwissen behauptet.
 
+## Vorlage Asset-Purchase-Agreement (Insolvenz-Asset-Deal)
+
+Das ausgefuellte Mustervertrag ChainCortex AI GmbH (i. Ins.) -> Voracis Ventures GmbH (vom Anwalts-Dashboard genutzte Testakte) steht als sofort einsetzbares Template zum Direkt-Download:
+
+| Format | Direkt-Download |
+| --- | --- |
+| **Word (DOCX, Times New Roman, 12 pt)** | [`asset-purchase-agreement-chaincortex-voracis.docx`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/insolvenz-asset-deal-chaincortex-ai-berlin/docx/asset-purchase-agreement-chaincortex-voracis.docx) |
+| **PDF (Times Roman, A4)** | [`asset-purchase-agreement-chaincortex-voracis.pdf`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/insolvenz-asset-deal-chaincortex-ai-berlin/pdfs/asset-purchase-agreement-chaincortex-voracis.pdf) |
+| Markdown-Volltext (zum Lesen auf GitHub) | [`09_asset-purchase-agreement-text.md`](../testakten/insolvenz-asset-deal-chaincortex-ai-berlin/09_asset-purchase-agreement-text.md) |
+| Gesamte Testakte als ZIP (34 Dateien, 7 Formate) | [`testakte-insolvenz-asset-deal-chaincortex-ai-berlin.zip`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/testakte-insolvenz-asset-deal-chaincortex-ai-berlin.zip) |
+
+Das Template umfasst 11 Paragraphen (Praeambel, Vertragsgegenstand mit DSGVO- und $ 613a-Bausteinen, Kaufpreis [400.000 EUR], Vollzugsvoraussetzungen, eIDAS-2.0-Signatur-Klausel, Haftung mit $ 60 InsO-Ausschluss, LkSG-Klarstellung, HinSchG-Compliance-Klausel, Schlussbestimmungen) plus sechs Anlagen. Vor Verwendung im Mandat: Anpassung an konkrete Parteien, IP-Liste und Kaufpreis erforderlich; Live-Verifikation der Rspr.-Anker (Bonprix-EuGH, BGH IX. Zivilsenat).
+
 ## Installation in Claude Code
 
 1. ZIP herunterladen (Link oben).

--- a/insolvenzrecht/README.md
+++ b/insolvenzrecht/README.md
@@ -30,6 +30,19 @@ Direkt-Downloads ohne Umwege. Die URLs sind stabil und zeigen immer auf die aktu
 Insolvenz- und sanierungsrechtliche Skills nach deutschem Recht (InsO, StaRUG, COVInsAG-Nachwirkungen). Zielgruppe: Insolvenzverwalter, beratende Rechtsanwälte (Insolvenz-/Sanierungsrecht), Geschäftsführer, Vorstände, Sanierungsberater, Wirtschaftsprüfer (IDW-S-11-/S-6-/S-9-Praxis).
 
 
+## Vorlage Asset-Purchase-Agreement (Insolvenz-Asset-Deal)
+
+Das ausgefuellte Mustervertrag ChainCortex AI GmbH (i. Ins.) -> Voracis Ventures GmbH (vom Anwalts-Dashboard genutzte Testakte) steht als sofort einsetzbares Template zum Direkt-Download:
+
+| Format | Direkt-Download |
+| --- | --- |
+| **Word (DOCX, Times New Roman, 12 pt)** | [`asset-purchase-agreement-chaincortex-voracis.docx`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/insolvenz-asset-deal-chaincortex-ai-berlin/docx/asset-purchase-agreement-chaincortex-voracis.docx) |
+| **PDF (Times Roman, A4)** | [`asset-purchase-agreement-chaincortex-voracis.pdf`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/insolvenz-asset-deal-chaincortex-ai-berlin/pdfs/asset-purchase-agreement-chaincortex-voracis.pdf) |
+| Markdown-Volltext (zum Lesen auf GitHub) | [`09_asset-purchase-agreement-text.md`](../testakten/insolvenz-asset-deal-chaincortex-ai-berlin/09_asset-purchase-agreement-text.md) |
+| Gesamte Testakte als ZIP (34 Dateien, 7 Formate) | [`testakte-insolvenz-asset-deal-chaincortex-ai-berlin.zip`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/testakte-insolvenz-asset-deal-chaincortex-ai-berlin.zip) |
+
+Das Template umfasst 11 Paragraphen (Praeambel, Vertragsgegenstand mit DSGVO- und $ 613a-Bausteinen, Kaufpreis [400.000 EUR], Vollzugsvoraussetzungen, eIDAS-2.0-Signatur-Klausel, Haftung mit $ 60 InsO-Ausschluss, LkSG-Klarstellung, HinSchG-Compliance-Klausel, Schlussbestimmungen) plus sechs Anlagen. Vor Verwendung im Mandat: Anpassung an konkrete Parteien, IP-Liste und Kaufpreis erforderlich; Live-Verifikation der Rspr.-Anker (Bonprix-EuGH, BGH IX. Zivilsenat).
+
 ## Enthaltene Skills
 
 | Skill | Zweck |

--- a/insolvenzverwaltung/README.md
+++ b/insolvenzverwaltung/README.md
@@ -29,6 +29,19 @@ Großes freistehendes Plugin für die Insolvenzverwaltung aus Sicht des Insolven
 
 **Freistehend:** Dieses Plugin enthält eigene Skills, Vorlagen, Quellenhinweise, Vorschau und Testakte. Es verweist nicht auf andere Plugins als Voraussetzung.
 
+## Vorlage Asset-Purchase-Agreement (Insolvenz-Asset-Deal)
+
+Das ausgefuellte Mustervertrag ChainCortex AI GmbH (i. Ins.) -> Voracis Ventures GmbH (vom Anwalts-Dashboard genutzte Testakte) steht als sofort einsetzbares Template zum Direkt-Download:
+
+| Format | Direkt-Download |
+| --- | --- |
+| **Word (DOCX, Times New Roman, 12 pt)** | [`asset-purchase-agreement-chaincortex-voracis.docx`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/insolvenz-asset-deal-chaincortex-ai-berlin/docx/asset-purchase-agreement-chaincortex-voracis.docx) |
+| **PDF (Times Roman, A4)** | [`asset-purchase-agreement-chaincortex-voracis.pdf`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/insolvenz-asset-deal-chaincortex-ai-berlin/pdfs/asset-purchase-agreement-chaincortex-voracis.pdf) |
+| Markdown-Volltext (zum Lesen auf GitHub) | [`09_asset-purchase-agreement-text.md`](../testakten/insolvenz-asset-deal-chaincortex-ai-berlin/09_asset-purchase-agreement-text.md) |
+| Gesamte Testakte als ZIP (34 Dateien, 7 Formate) | [`testakte-insolvenz-asset-deal-chaincortex-ai-berlin.zip`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/testakte-insolvenz-asset-deal-chaincortex-ai-berlin.zip) |
+
+Das Template umfasst 11 Paragraphen (Praeambel, Vertragsgegenstand mit DSGVO- und $ 613a-Bausteinen, Kaufpreis [400.000 EUR], Vollzugsvoraussetzungen, eIDAS-2.0-Signatur-Klausel, Haftung mit $ 60 InsO-Ausschluss, LkSG-Klarstellung, HinSchG-Compliance-Klausel, Schlussbestimmungen) plus sechs Anlagen. Vor Verwendung im Mandat: Anpassung an konkrete Parteien, IP-Liste und Kaufpreis erforderlich; Live-Verifikation der Rspr.-Anker (Bonprix-EuGH, BGH IX. Zivilsenat).
+
 ## Installation
 
 1. ZIP aus dem Release herunterladen.


### PR DESCRIPTION
## Summary

Zwei Themen:

### 1. ZIP-Problem diagnostiziert

Das Release `latest` auf GitHub ist **noch auf v292** (vom 10.06.2026, 05:49 Uhr UTC) und enthält keine Assets mit `chaincortex` im Namen. Der Download-Link `releases/latest/download/testakte-insolvenz-asset-deal-chaincortex-ai-berlin.zip` führt deshalb auf eine Fehlerseite, die sich nicht als ZIP entpacken lässt.

Das ZIP selbst (lokal gebaut) ist **technisch einwandfrei** (1 MB, 34 Dateien, alle valide). 

**Fix:** Tag `v293.0.0` pushen → Release-Workflow läuft → neue ZIPs mit ChainCortex-Asset-Deal werden veröffentlicht. Das mache ich direkt nach dem Merge dieser PR.

### 2. Vertragsvorlage in 3 Insolvenz-READMEs verlinkt

`fachanwalt-insolvenz-sanierungsrecht`, `insolvenzrecht`, `insolvenzverwaltung` erhalten eine neue Sektion **„Vorlage Asset-Purchase-Agreement (Insolvenz-Asset-Deal)"** mit vier Direkt-Downloads:

| Format | Link-Typ |
|---|---|
| **Word (DOCX, Times New Roman 12pt)** | raw.githubusercontent (direkt) — funktioniert sofort |
| **PDF (Times Roman, A4)** | raw.githubusercontent (direkt) — funktioniert sofort |
| Markdown-Volltext | Repo-Pfad |
| Gesamte Testakte (ZIP) | Release-Asset — wird mit v293-Tag verfügbar |

Die DOCX- und PDF-Links via `raw.githubusercontent.com` sind sofort funktional und unabhängig vom Release-Tag.

## Test plan

- [x] `validate-plugin-structure.mjs` grün
- [x] Lokales ZIP getestet (`unzip -t` OK, 34 Dateien)
- [ ] Nach Merge: Tag v293.0.0 pushen → Release-Workflow

https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL


---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_