### PR TITLE
v301.0.0 — Versions-Bump + CHANGELOG

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "agb-recht-pruefer",
       "source": "./agb-recht-pruefer",
       "description": "Gigantischer AGB-Rechtsprüfer und Klausel-Entwerfer für deutsches Recht: §§ 305 bis 310 BGB, UKlaG, B2C/B2B, Branchen-AGB, Redlining, Klauselrisiko und rechtssichere Entwurfsworkflows.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -19,7 +19,7 @@
       "name": "aktenaufbereiter-strafrecht",
       "source": "./aktenaufbereiter-strafrecht",
       "description": "Aktenaufbereiter für die Strafverteidigung. Sechs Excel-fähige Übersichten — Aktenvorblatt; Personenverzeichnis; Tatkomplexe; Beziehungen; Chronologie; Fristen. Fortlaufend ergaenzbar. Erkennt Luecken und Widersprueche. Kein Ersatz für Aktenlektuere.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -28,7 +28,7 @@
       "name": "aktenauszug-gerichtsverfahren",
       "source": "./aktenauszug-gerichtsverfahren",
       "description": "Strukturierter Aktenauszug für deutsche Gerichtsverfahren: Verfahrensidentifikation Einleitungssatz Verfahrenszusammenfassung Sachverhaltschronologie Verfahrensgeschichte tabellarische Gegenüberstellung der Parteivortraege Beweismittel und Rechtsargumente für schnelle Einarbeitung in Akten.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -37,7 +37,7 @@
       "name": "aktienrecht-hauptversammlung-ag-se",
       "source": "./aktienrecht-hauptversammlung-ag-se",
       "description": "Hauptversammlungs-Vorbereiter, Leitfaden-Ersteller und Durchführungsplugin für kleine AG, normale AG, börsennotierte AG und SE: Einberufung, Tagesordnung, virtuelle HV, Q&A, Abstimmung, Niederschrift, Anfechtungsrisiko und Post-HV.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -46,7 +46,7 @@
       "name": "anlagen-zu-schriftsaetzen",
       "source": "./anlagen-zu-schriftsaetzen",
       "description": "Anlagenmanagement fuer gerichtliche Schriftsaetze: sortiert chaotische Mandantenordner, E-Mails, Scans, Tabellen und Vorversionen zu beA-tauglichen K/B/AST/AG-Anlagen mit Verzeichnis, Konvolutdeckblaettern, Stempel-/Dateinamenregeln, Hashlog, Lueckenliste und Qualitygate.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -55,7 +55,7 @@
       "name": "apothekenrecht",
       "source": "./apothekenrecht",
       "description": "Super-Plugin für Apothekenrecht: Betriebserlaubnis, ApBetrO, Versand, E-Rezept, BtM, Retaxation, Aufsicht und Compliance.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -64,7 +64,7 @@
       "name": "arbeitsrecht",
       "source": "./arbeitsrecht",
       "description": "Arbeitsrechtliche Workflows fuer Kuendigung, Befristung, Urlaub, AGG, Aufhebungsvertrag, Betriebsrat, Arbeitszeit, Lohn und Expansion. Rechtsprechung wird nur mit Gericht, Datum, Aktenzeichen und verifizierbarer Quelle verwendet.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -73,7 +73,7 @@
       "name": "arbeitszeugnis-analyse",
       "source": "./arbeitszeugnis-analyse",
       "description": "Analyse deutscher Arbeitszeugnisse nach Ampelsystem (Rot/Orange/Grün). Geheimcodes, Schaufenster-Drift, negative Codeworte, Steigerungsadverbien. Satzweise Notenmatrix, begründete Gesamtnotenspanne. Vollständiger Mandatsablauf: Erstgespräch, Mandantenbericht, Aufforderungsschreiben, Klagestrategie.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -82,7 +82,7 @@
       "name": "aufsichtsrat-ag-se-praxis",
       "source": "./aufsichtsrat-ag-se-praxis",
       "description": "Praxisplugin für Aufsichtsräte in AG und SE: Überwachung, Informationsrechte, Vorstand bestellen/abberufen, Vergütung, Ausschüsse, Protokoll, Business Judgment, Haftungsvermeidung, Börse, SE und Mitbestimmung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -91,7 +91,7 @@
       "name": "aussenwirtschaft-zoll-sanktionen",
       "source": "./aussenwirtschaft-zoll-sanktionen",
       "description": "Freistehendes Plugin für Außenwirtschaft, Sanktionen, Zoll, Exportkontrolle, BAFA, TARIC, CBAM, Verbrauchsteuer, AWV, AML/KYC und Ermittlungen.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -100,7 +100,7 @@
       "name": "bank-rechtsabteilung",
       "source": "./bank-rechtsabteilung",
       "description": "Rechtsabteilung einer mittelgroßen deutschen Bank: Aufsicht, Kredit, Avale, Bürgschaft, Garantien, Trade Finance, ZAG/PSD2, PSD3/PSR-Vorschau, eWpG, MiCAR, Tokenisierung, BaFin, Vorstand, HV und Kanzleisteuerung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -109,7 +109,7 @@
       "name": "barrierefreiheit-web-checker",
       "source": "./barrierefreiheit-web-checker",
       "description": "Web-Barrierefreiheits-Checker für BFSG, BFSGV, BITV 2.0, EN 301 549 und WCAG: Scope, Audit, Tastatur, Screenreader, Formulare, PDFs, Erklärung, Roadmap und Abnahme.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -118,7 +118,7 @@
       "name": "bav-strategie-konzern",
       "source": "./bav-strategie-konzern",
       "description": "Strategische Beratung zur betrieblichen Altersversorgung in Konzernen: Pensionsmodelle alle fuenf Durchführungswege CTA Pension Buyouts Drei-Stufen-Theorie Versorgungssystem-Harmonisierung internationale Benefits Restrukturierung DB-zu-DC im Duesseldorfer Boutique-Stil.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -127,7 +127,7 @@
       "name": "beamtenrecht",
       "source": "./beamtenrecht",
       "description": "Beamtenrecht für Bund, Länder und Richterdienst: Status, Laufbahn, Besoldung, Versorgung, Konkurrentenstreit, Disziplinarrecht, Dienstunfähigkeit, Richterlaufbahn, Landesrecht und verständliche Mandatsführung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -136,7 +136,7 @@
       "name": "bereicherungs-und-anfechtungsrecht-pruefer",
       "source": "./bereicherungs-und-anfechtungsrecht-pruefer",
       "description": "Mechanisches Durchprüfen von Bereicherungsrecht §§ 812 ff. BGB, AnfG und Insolvenzanfechtung §§ 129-147 InsO. Mit KI-Screening von Schuldnerakten, § 135 Gesellschafterdarlehen, Bargeschäft § 142 und Verteidigung des Anfechtungsgegners. Keine Rechtsberatung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -145,7 +145,7 @@
       "name": "berichtspflichten-erlediger",
       "source": "./berichtspflichten-erlediger",
       "description": "Berichtspflichten-Erlediger für mittelständische Unternehmen: amtliche Statistik, Portale, Umwelt-, Produkt-, Steuer-, Sozial-, Lieferketten-, Datenschutz- und Aufsichtsmeldungen mit Fristenboard, Datenquellen, Plausibilitätscheck und Behördenkommunikation.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -154,7 +154,7 @@
       "name": "berufsgerichtliche-verfahren-freie-berufe",
       "source": "./berufsgerichtliche-verfahren-freie-berufe",
       "description": "Plugin für anwaltsgerichtliche und berufsgerichtliche Verfahren gegen Anwälte, Patentanwälte, Steuerberater, Wirtschaftsprüfer und Notare: Kammeraufsicht, Rüge, Disziplinarverfahren, Zulassung, Vermögensverfall, beA, Werbung, Sachlichkeit und Rechtsmittel.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -163,7 +163,7 @@
       "name": "berufsrecht-anwaelte",
       "source": "./berufsrecht-anwaelte",
       "description": "Plugin für anwaltliches Berufsrecht: BRAO, BORA, FAO, beA, Kanzleisitz, Werbung, Interessenkollision, Verschwiegenheit, KI-/Cloud-Outsourcing, Schatten-KI, Berufsausübungsgesellschaft, Gebühren, Kammeraufsicht und anwaltsgerichtliche Risiken.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -172,7 +172,7 @@
       "name": "berufsrecht-ki-vertragspruefung",
       "source": "./berufsrecht-ki-vertragspruefung",
       "description": "Berufsrechtliche und strafrechtliche Vorprüfung von Verträgen mit Legal-AI-Anbietern: § 43e BRAO, § 203 StGB, Consumer-Tool-Abgrenzung, No-Training, Telemetrie, Drittstaat, KI-VO-Rollen, Art.-50-Transparenz, Schatten-KI und Klauselvorschläge.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -181,7 +181,7 @@
       "name": "berufsrecht-notare",
       "source": "./berufsrecht-notare",
       "description": "Plugin für Notarrecht: BNotO, BeurkG, DONot, Dienstaufsicht, Urkundspflichten, Neutralität, Verwahrung, Amtspflichten, Vertreter/Verwalter, Disziplinarverfahren und notarielle Berufspraxis.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -190,7 +190,7 @@
       "name": "berufsrecht-patentanwaelte",
       "source": "./berufsrecht-patentanwaelte",
       "description": "Plugin für Patentanwaltsrecht: PAO, Patentanwaltskammer, Vertretungsbefugnis, Schutzrechtsmandate, Verschwiegenheit, Interessenkollision, Werbung, Berufsausübungsgesellschaft und berufsgerichtliche Risiken.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -199,7 +199,7 @@
       "name": "berufsrecht-steuerberater",
       "source": "./berufsrecht-steuerberater",
       "description": "Plugin für Steuerberaterrecht: StBerG, BOStB, Steuerberaterkammer, Vorbehaltsaufgaben, Werbung, Verschwiegenheit, Gebühren, Geldwäsche, Berufsgericht, Berufsausübungsgesellschaft und Haftungsprävention.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -208,7 +208,7 @@
       "name": "berufsrecht-wirtschaftspruefer",
       "source": "./berufsrecht-wirtschaftspruefer",
       "description": "Plugin für Wirtschaftsprüferrecht: WPO, Berufssatzung, WPK, APAS, Unabhängigkeit, Qualitätskontrolle, Abschlussprüfung, Bestätigungsvermerk, PIE, Berufsaufsicht und berufsgerichtliche Risiken.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -217,7 +217,7 @@
       "name": "betaeubungsmittelrecht",
       "source": "./betaeubungsmittelrecht",
       "description": "Betäubungsmittelrecht-Plugin für BtMG, BtMVV, KCanG/MedCanG-Schnittstellen, Strafverfahren, Therapie, ärztliche Praxis, Apotheken und Compliance.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -226,7 +226,7 @@
       "name": "betreuungsrecht",
       "source": "./betreuungsrecht",
       "description": "Betreuungsrechtliche Skills für ehrenamtliche Familienbetreuer, Berufs- und Vereinsbetreuer: Kaltstart, Scan-Akte, Kalender, Gerichtskommunikation, Jahresbericht, Vermögensverzeichnis, Genehmigungspflichten, Wunschermittlung, Kontoanalyse und Schutzplan nach BtOG und BGB.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -235,7 +235,7 @@
       "name": "bgb-at-pruefer",
       "source": "./bgb-at-pruefer",
       "description": "Großes Prüfplugin zum BGB Allgemeiner Teil: Vertragsschluss, Willenserklärung, Zugang, Geschäftsfähigkeit, Form, qES, beA, Anfechtung, Stellvertretung, Fristen, Verjährung und Routing für digitale Elemente, Update- und Reparaturrecht.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -244,7 +244,7 @@
       "name": "bgb-bt-pruefer",
       "source": "./bgb-bt-pruefer",
       "description": "Großer BGB-BT-Prüfer für Schuldrecht Besonderer Teil: Kauf einschließlich Verbrauchsgüterkauf, Waren mit digitalen Elementen, Updatepflichten und Right-to-Repair-Schnittstellen, außerdem Miete, Werk, Bürgschaft, GoA, Bereicherung, Delikt und Rückabwicklung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -253,7 +253,7 @@
       "name": "buerokratieversteher-entbuerokratisierer",
       "source": "./buerokratieversteher-entbuerokratisierer",
       "description": "Allgemeiner Bürokratieversteher und Entbürokratisierer für Laien, Menschen mit Deutsch als Zweitsprache und alle, die Bescheide, Anträge, Vorladungen, Behördenbriefe, Jugendamt-, Schul-, Bau-, Sozial-, Familien- oder Kommunalverfahren verstehen und vorsichtig bearbeiten wollen.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -262,7 +262,7 @@
       "name": "bundesnetzagentur-verfahren",
       "source": "./bundesnetzagentur-verfahren",
       "description": "Großes Regulierungs-Plugin für anwaltliche Arbeit mit der Bundesnetzagentur in Energie, Telekommunikation, Post, Eisenbahn und Digital Services.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -271,7 +271,7 @@
       "name": "bundeswehrrecht-wehrrecht",
       "source": "./bundeswehrrecht-wehrrecht",
       "description": "Super-Plugin für Soldatenrecht, Wehrbeschwerde, Disziplinarrecht, Wehrpflicht, Reservisten, Versorgung und Bundeswehrverwaltung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -280,7 +280,7 @@
       "name": "commercial-courts-deutschland",
       "source": "./commercial-courts-deutschland",
       "description": "Commercial-Courts-Plugin für englischsprachige Wirtschaftsverfahren in Deutschland: Zuständigkeit, Wahlklauseln, Klage, Case Management, Beweis, Geheimnisschutz, Wortprotokoll/Transcript, Rechtsmittel, BGH, Kosten, Vollstreckung und bilingualer Schriftsatz-/Hearing-Workflow.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -289,7 +289,7 @@
       "name": "common-law-kompass",
       "source": "./common-law-kompass",
       "description": "Freistehendes Common-Law-Plugin für deutsche Wirtschaftsjuristen: UK/US-False-Friends, Vertragsbegriffe, Consideration, Suretyship, Indemnity, UCC, Precedent, Discovery und bilinguale Drafting-Reviews.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -298,7 +298,7 @@
       "name": "corporate-kanzlei",
       "source": "./corporate-kanzlei",
       "description": "Corporate-Kanzlei-Plugin: Deal-Kommandocenter, Datenraum, Due Diligence, SPA/APA, Umwandlung, StaRUG, Insolvenzplan, W&I, Signing/Closing, PMI.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -307,7 +307,7 @@
       "name": "datenbankrecht",
       "source": "./datenbankrecht",
       "description": "Großes Plugin zum deutschen und europäischen Datenbankrecht: UrhG §§ 87a ff., Datenbankrichtlinie, Investitionsschutz, Scraping, API, KI-Training, Vertrags- und Plattformkonflikte.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -316,7 +316,7 @@
       "name": "datenschutz-sanktionsverfahren-verteidigung",
       "source": "./datenschutz-sanktionsverfahren-verteidigung",
       "description": "Spezialplugin für Vertretung und Verteidigung in datenschutzrechtlichen Sanktionsverfahren: DSGVO-Bußgeld, OWiG/StPO, Art.-58-Anordnung, Verwaltungsgericht, Aufsichtsbehördenkommunikation, EuGH/EDPB und Behördenstrategie.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -325,7 +325,7 @@
       "name": "datenschutzrecht",
       "source": "./datenschutzrecht",
       "description": "DSGVO/BDSG/TDDDG – PIA/DPIA, AVV-Review, Auskunft Art. 15, Datenpanne Art. 33/34, Drittlandstransfer Art. 44 ff. inkl. US-Transfer, DPF, SCC, TIA, Behördenpaket und Brückenskills zur Sanktionsverteidigung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -334,7 +334,7 @@
       "name": "designrecht-geschmacksmusterrecht",
       "source": "./designrecht-geschmacksmusterrecht",
       "description": "Eigenständiges Plugin für deutsches und europäisches Designrecht: DesignG, EU-Design, DPMA, EUIPO, WIPO-Hague, Neuheit, Eigenart, Anmeldung, Nichtigkeit, Verletzung, Eilrechtsschutz, Zoll, Plattformen und Designverträge.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -343,7 +343,7 @@
       "name": "deutsche-rechtsgeschichte",
       "source": "./deutsche-rechtsgeschichte",
       "description": "Mega-Plugin zur deutschen Rechtsgeschichte: Epochen, Quellenkritik, Rezeption, Reichsrecht, BGB, Weimar, NS-Unrecht, DDR/BRD und rechtsgeschichtliche Argumentation.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -352,7 +352,7 @@
       "name": "dfg-foerderantrag",
       "source": "./dfg-foerderantrag",
       "description": "DFG-Förderantragssteller für Sachbeihilfe, adaptive Anfänger-/Profi-Führung, kleine schnelle Anträge, große Koselleck-Strategien, elan-Formalia, Finanzplan, Reviewer-Red-Team, Forschungsdaten, KI-/Ethik-Check und Wiedereinreichung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -361,7 +361,7 @@
       "name": "dsa-dma-digitalregulierung",
       "source": "./dsa-dma-digitalregulierung",
       "description": "Digitalregulierung der EU: DSA (VO 2022/2065) und DMA (VO 2022/1925) plus Data Act DGA AI Act NIS-2 DORA CRA eIDAS 2.0 DDG P2B-VO und § 19a GWB. Gatekeeper-Schwellen VLOP-Einordnung Risikobewertung Art. 34 Forschungsdatenzugang Art. 40 Account-Sperre Art. 20-23 Zustellung Art. 13 DSA Klagewege.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -370,7 +370,7 @@
       "name": "ecommerce-recht",
       "source": "./ecommerce-recht",
       "description": "Super-Plugin für Online-Shops, Plattformen, Marktplätze und digitale Verbraucherprozesse.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -379,7 +379,7 @@
       "name": "einfache-leichte-sprache-jura",
       "source": "./einfache-leichte-sprache-jura",
       "description": "Juristische Texte in Einfache Sprache oder Leichte Sprache übertragen: experimentelle Standard-Annäherung, Zielgruppe klären, Rechtsinhalt sichern und Qualitätsgate nutzen.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -388,7 +388,7 @@
       "name": "einigungsvertrag-vermoegensrecht",
       "source": "./einigungsvertrag-vermoegensrecht",
       "description": "Einigungsvertrag-Plugin für DDR/BRD-Übergangsrecht, Volksvermögen, Parteivermögen, Treuhand, Bodenreform, Mauergrundstücke, VermG und Restitution.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -397,7 +397,7 @@
       "name": "email-umformulierer-berufsrecht",
       "source": "./email-umformulierer-berufsrecht",
       "description": "Formuliert unfreundliche, emotionale oder unsachliche E-Mails in hoefliche, sachliche und berufsrechtskonform formulierte Texte um. Fokus auf BRAO/BORA-Konformität, mit Varianten für Steuerberater, Notare und allgemeine berufliche Korrespondenz.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -406,7 +406,7 @@
       "name": "energierecht",
       "source": "./energierecht",
       "description": "Freistehendes Energierecht-Plugin für Stadtwerke, Versorger, Wärme, Netze, Vertrieb, Industrie, EEG, KWKG, Verfahren, Transaktionen und Projektfinanzierung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -415,7 +415,7 @@
       "name": "erbbaurecht-praxis",
       "source": "./erbbaurecht-praxis",
       "description": "Praxisplugin für Erbbaurecht und Erbbaugrundbuch: Erbbaurechtsvertrag, Erbbauzins, Wertsicherung, Heimfall, Zustimmung, Belastung, Finanzierung, Veräußerung, Laufzeit, Entschädigung, Zwangsversteigerung, Rang und Grundbuchvollzug.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -424,7 +424,7 @@
       "name": "europarecht-kompass",
       "source": "./europarecht-kompass",
       "description": "Freistehendes Europarecht-Plugin gegen deutsche Denkfehler: Vorrang, unmittelbare Wirkung, Richtlinien, Verordnungen, Charta, Grundfreiheiten, Beihilfen, Vorlageverfahren und EU-Drafting.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -433,7 +433,7 @@
       "name": "fachanwalt-agrarrecht",
       "source": "./fachanwalt-agrarrecht",
       "description": "Plugin Fachanwalt für Agrarrecht. Höferecht (HöfeO Anerbenrecht Länder) Landpachtrecht BGB §§ 581 ff. GAP EU-Direktzahlungen Cross-Compliance Düngeverordnung Pflanzenschutz Tierschutz Forstrecht. Schnittstelle Plugin fachanwalt-erbrecht.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -442,7 +442,7 @@
       "name": "fachanwalt-arbeitsrecht",
       "source": "./fachanwalt-arbeitsrecht",
       "description": "Fachanwalt-Arbeitsrecht nach FAO Paragraf 10: KSchG, BetrVG, TzBfG, AGG, EntgTranspG, Urlaub, Betriebsrat, Befristung und Vergleichspraxis. Rechtsprechung nur mit Datum, Aktenzeichen und verifizierter Quelle.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -451,7 +451,7 @@
       "name": "fachanwalt-bank-kapitalmarktrecht",
       "source": "./fachanwalt-bank-kapitalmarktrecht",
       "description": "Plugin Fachanwalt für Bank- und Kapitalmarktrecht. KWG ZAG WpHG WpIG MiFID-II MAR MiCAR Verbraucherkredit Bürgschaft Aval Bankgarantie Vermögensanlage Beratungshaftung. Schnittstellen Plugin gesellschaftsrecht regulatorisches-recht.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -460,7 +460,7 @@
       "name": "fachanwalt-bau-architektenrecht",
       "source": "./fachanwalt-bau-architektenrecht",
       "description": "Plugin Fachanwalt für Bau- und Architektenrecht. BGB Werkvertrag VOB-A VOB-B VOB-C HOAI Bauordnungsrecht. Bauvertrag Maengelhaftung Abnahme Vergaberecht. Schnittstellen Plugin fachanwalt-vergaberecht kanzlei-allgemein.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -469,7 +469,7 @@
       "name": "fachanwalt-erbrecht",
       "source": "./fachanwalt-erbrecht",
       "description": "Plugin Fachanwalt für Erbrecht. BGB Erbrecht §§ 1922 ff. Pflichtteil Testament Erbschein Erbauseinandersetzung Erbschaftsteuer EU-ErbVO. Schnittstellen Plugin steuerrecht-anwalt-und-berater kanzlei-allgemein.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -478,7 +478,7 @@
       "name": "fachanwalt-familienrecht",
       "source": "./fachanwalt-familienrecht",
       "description": "Plugin Fachanwalt für Familienrecht. Orientierung Normen Mandate Fristen Literatur. Familiengericht FamFG Scheidung Sorge Umgang Unterhalt Zugewinn Ehevertrag eingetragene Lebenspartnerschaft. Ergaenzend zum Plugin kanzlei-allgemein.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -487,7 +487,7 @@
       "name": "fachanwalt-gewerblicher-rechtsschutz",
       "source": "./fachanwalt-gewerblicher-rechtsschutz",
       "description": "Plugin Fachanwalt für gewerblichen Rechtsschutz nach FAO § 14k. MarkenG. DesignG. UWG. PatG GebrMG. UrhG-Bezuege. Markenanmeldung DPMA EUIPO. UWG-Abmahnung §§ 8 ff. UWG. Designverletzung. Einstweilige Verfuegung Verletzungsklage Lizenzanaloger Schadensersatz.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -496,7 +496,7 @@
       "name": "fachanwalt-handels-gesellschaftsrecht",
       "source": "./fachanwalt-handels-gesellschaftsrecht",
       "description": "Plugin Fachanwalt für Handels- und Gesellschaftsrecht nach FAO § 14i. HGB. AktG. GmbHG. PartGG. UmwG. Geschäftsführerhaftung §§ 43 GmbHG 93 AktG. Gesellschafterstreit Beschlussanfechtung. Handelsvertreterausgleich § 89b HGB. MoPeG GbR seit 2024. Schnittstellen kanzlei-allgemein.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -505,7 +505,7 @@
       "name": "fachanwalt-insolvenz-sanierungsrecht",
       "source": "./fachanwalt-insolvenz-sanierungsrecht",
       "description": "Plugin Fachanwalt für Insolvenz- und Sanierungsrecht nach FAO § 14. InsO Eroeffnung Antragspflicht § 15a Gläubigerantrag § 14 InsO. StaRUG Restrukturierungsplan. Insolvenzanfechtung §§ 129 ff. InsO. Schnittstellen insolvenzrecht und steuerrecht-anwalt-und-berater.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -514,7 +514,7 @@
       "name": "fachanwalt-internationales-wirtschaftsrecht",
       "source": "./fachanwalt-internationales-wirtschaftsrecht",
       "description": "Plugin Fachanwalt für Internationales Wirtschaftsrecht. CISG Bruessel Ia Rom I Rom II Schiedsverfahren ICC UNCITRAL Investitionsschutz ICSID WTO EU-Aussenhandel LkSG. Schnittstelle Plugin kanzlei-allgemein.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -523,7 +523,7 @@
       "name": "fachanwalt-it-recht",
       "source": "./fachanwalt-it-recht",
       "description": "Plugin Fachanwalt für Informationstechnologierecht. SaaS Software-Lizenz DSGVO BDSG TTDSG TKG NIS2 DDG DSA DMA EU-KI-VO Open-Source. Schnittstellen Plugin datenschutzrecht ki-governance kanzlei-allgemein.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -532,7 +532,7 @@
       "name": "fachanwalt-medizinrecht",
       "source": "./fachanwalt-medizinrecht",
       "description": "Plugin Fachanwalt für Medizinrecht. Arzthaftung §§ 630a ff. BGB Patientenrechte Vertragsarztrecht Berufsrecht Aerzte SGB V Krankenversicherung MPDG Apothekenrecht. Schnittstellen Plugin fachanwalt-sozialrecht und kanzlei-allgemein.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -541,7 +541,7 @@
       "name": "fachanwalt-miet-wohnungseigentumsrecht",
       "source": "./fachanwalt-miet-wohnungseigentumsrecht",
       "description": "Großer Fachanwalt-Kompass Miet- und Wohnungseigentumsrecht mit über 200 Skills für Wohnraum, Gewerberaum, Betriebskosten, WEG, Hausverwaltung, Beschlüsse, GEG, Beweise, Fristen und Workflows.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -550,7 +550,7 @@
       "name": "fachanwalt-migrationsrecht",
       "source": "./fachanwalt-migrationsrecht",
       "description": "Großer Fachanwalt-Kompass Migrationsrecht mit über 200 Skills für Aufenthalt, Blaue Karte EU, Fachkräfte, Asyl, Dublin/GEAS, Einbürgerung, Staaten-/Gebietschecks und spanische/einfache Erklärung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -559,7 +559,7 @@
       "name": "fachanwalt-sozialrecht",
       "source": "./fachanwalt-sozialrecht",
       "description": "Plugin Fachanwalt für Sozialrecht nach FAO § 11. SGB I-XII und Sozialgerichtsbarkeit SGG. Widerspruch § 84 SGG Klage § 87 SGG Eilantrag § 86b SGG. Buergergeld Erwerbsminderung GdB Pflegegrad Hilfsmittel Eingliederungshilfe. Bescheidanalyse Akteneinsicht PKH Fristenbuch.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -568,7 +568,7 @@
       "name": "fachanwalt-sportrecht",
       "source": "./fachanwalt-sportrecht",
       "description": "Plugin Fachanwalt für Sportrecht. Verbandsrecht (DFB FIFA UEFA IOC DOSB) CAS Schiedsverfahren Spielerverträge Doping WADA-Code NADA Sponsoring Persönlichkeitsrechte Veranstalterhaftung. Schnittstelle Plugin gesellschaftsrecht.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -577,7 +577,7 @@
       "name": "fachanwalt-strafrecht",
       "source": "./fachanwalt-strafrecht",
       "description": "Plugin Fachanwalt Strafrecht: StPO/StGB, Nebenstrafrecht, Verteidigung, Ermittlungsverfahren, HV, Revision, Nebenklage und Zeugenbeistand plus Strafprozess-Cockpit fuer Fristen, Aktenlog, U-Haft, Akteneinsicht, HV-Tagesmappe, Antragslog und Mandanteninstruktionen.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -586,7 +586,7 @@
       "name": "fachanwalt-transport-speditionsrecht",
       "source": "./fachanwalt-transport-speditionsrecht",
       "description": "Plugin Fachanwalt für Transport- und Speditionsrecht. HGB §§ 407 ff. Frachtvertrag §§ 453 ff. Spedition CMR COTIF Montrealer Übereinkommen Haager Visby Regeln ADSp. Schnittstelle Plugin kanzlei-allgemein.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -595,7 +595,7 @@
       "name": "fachanwalt-urheber-medienrecht",
       "source": "./fachanwalt-urheber-medienrecht",
       "description": "Plugin Fachanwalt für Urheber- und Medienrecht. UrhG UWG KUG Recht am eigenen Bild Presserecht Persoenlichkeitsrecht Medienstaatsvertrag. Schnittstellen Plugin gewerblicher-rechtsschutz verlagsredaktion kanzlei-allgemein.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -604,7 +604,7 @@
       "name": "fachanwalt-vergaberecht",
       "source": "./fachanwalt-vergaberecht",
       "description": "Plugin Fachanwalt fuer Vergaberecht als Vergabe-Workbench: GWB 97 ff., VgV, UVgO, SektVO, KonzVgV, VOB/A, Schwellenwerte 2026/2027, Vergabeakte, Ruge, Nachpruefung, TED/eForms, Wettbewerbsregister und Foerdermittel.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -613,7 +613,7 @@
       "name": "fachanwalt-verkehrsrecht",
       "source": "./fachanwalt-verkehrsrecht",
       "description": "Plugin Fachanwalt für Verkehrsrecht. StVG StVO PflVG VVG-Bezuege. Verkehrsunfall Personen- und Sachschaden Bußgeld Fahrerlaubnis Verkehrsstrafrecht (§§ 315c 316 StGB). Schnittstelle Plugin kanzlei-allgemein.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -622,7 +622,7 @@
       "name": "fachanwalt-versicherungsrecht",
       "source": "./fachanwalt-versicherungsrecht",
       "description": "Plugin Fachanwalt für Versicherungsrecht. VVG VAG Berufsunfähigkeit private Krankenversicherung Lebens- und Rentenversicherung Sachversicherung Haftpflicht D-und-O. Schnittstelle Plugin kanzlei-allgemein.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -631,7 +631,7 @@
       "name": "fachanwalt-verwaltungsrecht",
       "source": "./fachanwalt-verwaltungsrecht",
       "description": "Plugin Fachanwalt für Verwaltungsrecht. VwGO VwVfG. Anfechtungs- und Verpflichtungsklage Eilrechtsschutz § 80 Abs 5 VwGO einstweilige Anordnung Normenkontrolle Polizei- und Ordnungsrecht. Schnittstelle Plugin kanzlei-allgemein.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -640,7 +640,7 @@
       "name": "factoring-recht",
       "source": "./factoring-recht",
       "description": "Super-Plugin für Factoring, Forderungskauf, Aufsichtsrecht, Vertragsgestaltung, Debitorenkommunikation, Insolvenz- und Sanierungsfragen.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -649,7 +649,7 @@
       "name": "fahrgastrechte",
       "source": "./fahrgastrechte",
       "description": "Fahrgastrechte im Eisenbahnverkehr nach VO (EU) 2021/782 und EVO 2023: Verspaetung/Ausfall einordnen, Entschaedigung berechnen (25/50 Prozent), Forderung an die DB, Widerspruch, Schlichtung und Klage zum AG. Katalog DB-Ablehnungsgruende.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -658,7 +658,7 @@
       "name": "fashion-law-moderecht",
       "source": "./fashion-law-moderecht",
       "description": "Praxisplugin Fashion Law/Moderecht für Modeunternehmen, Designer, Händler und Kanzleien: IP, Designs, Marken, Textilkennzeichnung, Produktsicherheit, Nachhaltigkeit, Lieferkette, Plattformen, E-Commerce, Vertrieb, Influencer und Krisen.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -667,7 +667,7 @@
       "name": "festlandchina-wirtschaftsverkehr",
       "source": "./festlandchina-wirtschaftsverkehr",
       "description": "Mega-Plugin für wirtschaftlichen Umgang mit Festlandchina: Fabrik, Import, Export, Investition, De-Risking, Lieferkette, IP, Daten, Exportkontrolle und politisches Risiko.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -676,7 +676,7 @@
       "name": "fluggastrechte",
       "source": "./fluggastrechte",
       "description": "Fluggastrechte selber geltend machen nach VO (EG) Nr. 261/2004. Tickets erfassen, Annullierung oder Verspaetung pruefen, aussergewoehnliche Umstaende, Distanz, Ausgleich, Forderungsschreiben, Mahnung und Klage. Rechtsprechung nur nach Live-Verifikation.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -685,7 +685,7 @@
       "name": "forderungsmanagement-klagewerkstatt",
       "source": "./forderungsmanagement-klagewerkstatt",
       "description": "Klagewerkstatt für Forderungsmanagement mit Zuständigkeitsprüfung, Mahnvorlauf, Inkasso-Zahlungsklage und Anspruchs-Gatekeeper: Nur klare, fällige und belegte Forderungen werden zur Klage freigegeben.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -694,7 +694,7 @@
       "name": "forschungszulage-antragstellung",
       "source": "./forschungszulage-antragstellung",
       "description": "Forschungszulage-Antragstellung nach FZulG: adaptiver Fördercheck, BSFZ-Portaltexte mit Zeichenbudgets, Finanzamt-Antrag, FuE-Abgrenzung, Bemessungsgrundlage 2026, Auszahlung, Verlust-/Insolvenzlage, Dokumentation, Beihilfen, Einspruch und Mehrjahresroadmap.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -703,7 +703,7 @@
       "name": "fortbestehensprognose",
       "source": "./fortbestehensprognose",
       "description": "Fortbestehensprognose § 19 Abs. 2 InsO als Geschäftsführer-Selbstdokumentation. Bilanzstatus Annahmen Plausibilisierung Zwoelf-Monats-Liquiditaet. Sanierungsbausteine Patronatserklärung Comfortletter Rangrücktritt Stundung Forderungsverzicht. IDW S 11 StaRUG. Eskalation bei negativer Prognose.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -712,7 +712,7 @@
       "name": "franchiserecht-praxis",
       "source": "./franchiserecht-praxis",
       "description": "Wirtschaftsrechtliches Plugin für Franchise-Systeme: vorvertragliche Aufklärung, Handbuch, Gebühren, Gebietsschutz, Kartellrecht, Kündigung, Expansion, Streit und Insolvenz.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -721,7 +721,7 @@
       "name": "gebrauchsmusterrecht",
       "source": "./gebrauchsmusterrecht",
       "description": "Eigenständiges Plugin für deutsches Gebrauchsmusterrecht: GebrMG, DPMA-Anmeldung, Recherche nach § 7 GebrMG, Abzweigung, Neuheitsschonfrist, Verletzung, Löschung, BPatG-Beschwerde, Lizenz, FTO und Schnellschutz für technische Produkte.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -730,7 +730,7 @@
       "name": "geldwaeschepraevention-aml-kyc",
       "source": "./geldwaeschepraevention-aml-kyc",
       "description": "Freistehendes Plugin für Geldwäscheprävention, AML, KYC, GwG-Risikoanalyse, UBO, PEP, Sanktionen, FIU/goAML, Transparenzregister und Behördenverfahren.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -739,7 +739,7 @@
       "name": "gesellschaftsgruender",
       "source": "./gesellschaftsgruender",
       "description": "Anfängerfreundlicher Gründungsassistent für deutsche Gesellschaften: Rechtsformwahl, Satzung, SHA, Cap Table, Notar, Handelsregister, Bank/KYC, Behörden, Steuerstart, IP, Datenschutz, erste 100 Tage und Streitprävention.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -748,7 +748,7 @@
       "name": "gesellschaftsrecht",
       "source": "./gesellschaftsrecht",
       "description": "Gesellschaftsrecht – GmbH/AG/Personengesellschaften, M&A-Due-Diligence ohne Discovery (Q&A + Datenraum), Gesellschafterbeschlüsse, HRB/HRA-Anmeldungen, Closing Checklists, Compliance-Fristen.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -757,7 +757,7 @@
       "name": "gesellschaftsrecht-legal-english",
       "source": "./gesellschaftsrecht-legal-english",
       "description": "Didaktisches Gesellschaftsrecht — English Business Terms: Corporate Legal English fuer Big-Law-Anfaenger. Dealroom: Cap Table vs Gesellschafterliste; Term Sheet; SHA; Vesting; Drag/Tag; Liquidation Preference; Anti-Dilution; SPA; DD; Notar/HR; Multi-Format-Auswertung; Frankfurt-Startup-Akte.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -766,7 +766,7 @@
       "name": "gesellschaftsrechtliche-treuepflicht",
       "source": "./gesellschaftsrechtliche-treuepflicht",
       "description": "Großes Prüfplugin zur gesellschaftsrechtlichen Treuepflicht in GmbH, AG, SE, Personengesellschaft, Familiengesellschaft und Konzern: Stimmrecht, Minderheitenschutz, Gesellschafterliste, Einziehung, Ausschluss, Konkurrenz, Sanierung, Treuepflichtverletzung und Rechtsfolgen.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -775,7 +775,7 @@
       "name": "gewerblicher-rechtsschutz",
       "source": "./gewerblicher-rechtsschutz",
       "description": "Gewerblicher Rechtsschutz – DPMA/EUIPO-Markenrecherche und -anmeldung, Freedom-to-Operate, Patentscreening, UWG- und Urheberrechts-Abmahnung (Versand und Reaktion), Open-Source-Compliance, IP-Klausel-Review, Schutzrechts-Fristen.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -784,7 +784,7 @@
       "name": "goae-gebuehrenordnung-aerzte",
       "source": "./goae-gebuehrenordnung-aerzte",
       "description": "Super-Plugin zur GOÄ: private Arztrechnungen prüfen, erstellen, begründen, beanstanden und prozessual verwerten.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -793,7 +793,7 @@
       "name": "grosskanzlei-corporate-ma",
       "source": "./grosskanzlei-corporate-ma",
       "description": "Freistehendes Big-Law-Corporate/M&A-Plugin: Deal-OS, Padlet-Canvas, Anfänger-/First-Year-Coach, Aktenanlage, Datenraum, Legal DD, Tabellenreview, SPA/APA, W&I, Public M&A, UmwG/UmwStG, StaRUG, Fusionskontrolle, FDI, FSR, Signing/Closing, PMI und 125 Spezial-Skills.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -802,7 +802,7 @@
       "name": "grundbuchamt-praxis",
       "source": "./grundbuchamt-praxis",
       "description": "Praxisplugin für Grundbuchamt, Grundbuchauszug und grundbuchtaugliche Nachweise: Abteilung I/II/III lesen, Bewilligung, Antrag, Auflassung, Rang, Zwischenverfügung, Beschwerde, Grundschuldbrief, Aufgebot, Dienstbarkeiten, Vormerkung, Vorkaufsrecht, Teilung und Vollzug.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -811,7 +811,7 @@
       "name": "handelsrecht-hgb",
       "source": "./handelsrecht-hgb",
       "description": "Reines HGB-Plugin für Handelsrecht: Kaufmann, Handelsregister, Firma, Prokura, Handlungsvollmacht, Handelsgeschäfte, Handelskauf, Handelsvertreter, Makler, Kommission, Fracht, Spedition, Lager, Handelsbücher sowie OHG/KG einschließlich MoPeG-Statuswechsel von GbR zu OHG.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -820,7 +820,7 @@
       "name": "handelsregister-praxis",
       "source": "./handelsregister-praxis",
       "description": "Praxisplugin für den Umgang mit dem Handelsregister: Anmeldung, Registergericht, Rechtspfleger, Registerrichter, Beanstandung, Zwischenverfügung, Beschwerde, Gesellschafterliste, Kapitalmaßnahmen, Firma, Vertretung, Prokura, Löschung, Insolvenzvermerk und registerfeste Nachweise.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -829,7 +829,7 @@
       "name": "handelsvertreterrecht",
       "source": "./handelsvertreterrecht",
       "description": "Handelsvertreterrecht nach HGB: Status, Provision, Buchauszug, Kündigung, Ausgleich § 89b, Wettbewerbsverbot § 90a und Vertriebsmodelle.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -838,7 +838,7 @@
       "name": "hausarbeitenmacher",
       "source": "./hausarbeitenmacher",
       "description": "Didaktisches Plugin für juristische Hausarbeiten und Seminararbeiten. Führt sokratisch durch Zivilrecht öffentliches Recht Strafrecht mit Ausfluegen in Europarecht und Rechtstheorie. Adressaten-Strategie ohne Schleimerei. Liefert keine fertigen Lösungen sondern führt zur eigenen Subsumtion.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -847,7 +847,7 @@
       "name": "haushaltsrecht-bho-bund-laender",
       "source": "./haushaltsrecht-bho-bund-laender",
       "description": "Großes Haushaltsrecht-Plugin für BHO, HGrG, Bundeshaushalt, Länderhaushalte, Titelanalyse, Umschichtung, Sondervermögen, Szenarien und Dashboard.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -856,7 +856,7 @@
       "name": "hinweisgeberschutz-compliance",
       "source": "./hinweisgeberschutz-compliance",
       "description": "Hinweisgeberschutzgesetz in der Praxis: interne/externe Meldestelle, NDA-Konflikte, Repressalien, Untersuchungen, Datenschutz und Governance.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -865,7 +865,7 @@
       "name": "hoai-leistungsphasen-praxis",
       "source": "./hoai-leistungsphasen-praxis",
       "description": "Großplugin für HOAI-Leistungsphasen 1 bis 9: Grundlagenermittlung, Vorplanung, Entwurf, Genehmigung, Ausführungsplanung, Vergabe, Bauüberwachung, Objektbetreuung, Honorar, Vertrag, Haftung, Nachträge und Bauprojektsteuerung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -874,7 +874,7 @@
       "name": "hochschulrecht-laender",
       "source": "./hochschulrecht-laender",
       "description": "Hochschulrecht der Länder: Hochschulgesetze, Satzungen, Gremien, Zulassung, Exmatrikulation, Berufung, Drittmittel, Promotion und Aufsicht.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -883,7 +883,7 @@
       "name": "immobilienrechtspraxis",
       "source": "./immobilienrechtspraxis",
       "description": "Werkzeuge fuer immobilienrechtliche Rechtsabteilungen: musterbasierte Vertragserstellung mit Klauselschutz, Vertragspruefung gegen Playbook, Grundbuchanalyse, Sachverhaltsermittlung, Mieteranfragen, Case Management und AVV-Pruefung. Rechtsprechung nur nach Live-Verifikation.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -892,7 +892,7 @@
       "name": "influencer-recht",
       "source": "./influencer-recht",
       "description": "Plugin für Influencer, Creator, Agenturen und Unternehmen: Werbekennzeichnung, Steuer, Umsatzsteuer, Sachleistungen, Plattformrecht, Medienrecht, Marken, Urheberrecht, Datenschutz und Verträge.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -901,7 +901,7 @@
       "name": "informationsfreiheit-presseauskunft",
       "source": "./informationsfreiheit-presseauskunft",
       "description": "IFG-, Transparenz-, UIG-, VIG- und Presseauskunfts-Plugin für Bund, Länder und Behörden: Antrag, Kosten, Fristen, Widerspruch, Klage und Tracking.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -910,7 +910,7 @@
       "name": "insiderrecht-compliance",
       "source": "./insiderrecht-compliance",
       "description": "Insiderrecht- und Marktmissbrauchs-Compliance nach MAR, WpHG und BaFin-Praxis: Insiderinformationen, Ad-hoc, Insiderlisten, Handelsverbote, Aufschub, Directors Dealings, Aufklärung und Verteidigung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -919,7 +919,7 @@
       "name": "insolvenzforderungsanmeldungspruefung",
       "source": "./insolvenzforderungsanmeldungspruefung",
       "description": "Freistehendes Plugin für die Insolvenzforderungsanmeldungsprüfung: Intake, § 174 InsO, Belege, Grund, Betrag, Rang, vbuH, Nachforderungen, Tabellenimport, Prüfungstermin, Bestreiten, Feststellung, Tabellenauszug und Verteilung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -928,7 +928,7 @@
       "name": "insolvenzplan-starug-planwerkstatt",
       "source": "./insolvenzplan-starug-planwerkstatt",
       "description": "Freistehendes Plugin für Insolvenzplan und StaRUG-Restrukturierungsplan: Intake, Sanierungskonzept, Vergleichsrechnung, Gruppen, Klassen, darstellender und gestaltender Teil, Anlagen, Abstimmung, Cram-down, Minderheitenschutz, Gericht und Planvollzug.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -937,7 +937,7 @@
       "name": "insolvenzrecht",
       "source": "./insolvenzrecht",
       "description": "Insolvenzrechtliche Skills zu Zahlungsunfähigkeit, Überschuldung, Antragspflicht und Gläubigerantrag.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -946,7 +946,7 @@
       "name": "insolvenzverwaltung",
       "source": "./insolvenzverwaltung",
       "description": "Freistehendes Insolvenzverwaltungs-Plugin aus Sicht von Insolvenzverwalter, Sachwalter und vorläufiger Verwaltung: Regelverfahren, Eigenverwaltung, Schutzschirm, Anfechtung, § 15b InsO, Masse, Forderungsprüfung, Insolvenzplan, StaRUG-Planwerkstatt, Gutachten, Berichte und Schlussrechnung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -955,7 +955,7 @@
       "name": "internal-investigations-praxis",
       "source": "./internal-investigations-praxis",
       "description": "Internal-Investigations-Praxisplugin fuer Kanzleien und Unternehmen: Untersuchungsauftrag, Scope, Interviews, Arbeitsrecht, Datenschutz, Privilege-Risiko, StPO-Beschlagnahme, HinSchG, Dokumentation und Verteidigung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -964,7 +964,7 @@
       "name": "internationales-handelsrecht-lex-mercatoria",
       "source": "./internationales-handelsrecht-lex-mercatoria",
       "description": "Mega-Plugin für internationales Handelsrecht, CISG, Incoterms, UNIDROIT Principles, Lex Mercatoria, Schiedsverfahren, Trade Finance und Lieferkettenverträge.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -973,7 +973,7 @@
       "name": "jurastudium",
       "source": "./jurastudium",
       "description": "Studium und Referendariat – Prüfungsgespräch nach AG-Tradition, Subsumtionslehre, Methodenlehre (Zivilrecht, Strafrecht, Öffentliches Recht), Rechtsgeschichte, Lernstrategien, Lösungsschemata, Gutachtenstil, Klausurkorrektur, Lernplanung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -982,7 +982,7 @@
       "name": "juristische-sprache-deutsch-als-zweitsprache",
       "source": "./juristische-sprache-deutsch-als-zweitsprache",
       "description": "Plugin fuer Menschen im deutschen Recht mit anderer Herkunftssprache: einfache Erklaerungen, Juristendeutsch, Bescheide, Schriftsaetze, Grammatik, Fristen und Verfahrenslogik.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -991,7 +991,7 @@
       "name": "jveg-kostenpruefer",
       "source": "./jveg-kostenpruefer",
       "description": "Freistehender JVEG-Kostenprüfer für Zeugenentschädigung, Vorschuss, Fahrtkosten, Übernachtung, Verdienstausfall, Sachverständigen- und Dolmetscherkosten, Fristen, Festsetzung, Beschwerde und belegfeste Rechenprotokolle.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1000,7 +1000,7 @@
       "name": "kanzlei-allgemein",
       "source": "./kanzlei-allgemein",
       "description": "Kanzlei-Allgemein-Plugin (fusioniert mit Cowork): edles Kommandocenter Mandatsannahme/GwG Klage/Replik Vertrag Rechtsprechung Handelsregister beA-Journal Rechnung UStVA Fristenbuch Timesheet RVG Versand-Vor-Check Posteingang Mandantenakte Mahnwesen Tagesbrief Geburtstage Weihnachtskarten.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1009,7 +1009,7 @@
       "name": "kanzlei-builder-hub",
       "source": "./kanzlei-builder-hub",
       "description": "Findet, prüft und installiert Community-Skills mit Security-Review-Gate vor dem Deployment in die Kanzleiumgebung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1018,7 +1018,7 @@
       "name": "kanzlei-management",
       "source": "./kanzlei-management",
       "description": "Mega-Plugin für Kanzlei-Management: Managing Partner, Management Committee, Cashflow, Pricing, UBT, FTE, Utilization, WIP, Associates, Partnerkreis und Dashboards.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1027,7 +1027,7 @@
       "name": "kanzlei-mandant-lifecycle",
       "source": "./kanzlei-mandant-lifecycle",
       "description": "Lifecycle-Plugin für Kanzlei, Mandant und Rechtsabteilung: Mandatsstart, OCG, Budget, Dashboard, Rechnung, Litigation, Erwartungsmanagement und Relationship-Governance.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1036,7 +1036,7 @@
       "name": "kartellrecht-marktabgrenzung-pruefung",
       "source": "./kartellrecht-marktabgrenzung-pruefung",
       "description": "Globales Kartellrecht/Competition Law: GWB, Art 101/102 AEUV, Fusionskontrolle, BKartA, DG Competition, FTC/DOJ, ICN-Jurisdiktionen, Dawn Raids, Marktabgrenzung, Missbrauch, Private Enforcement.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1045,7 +1045,7 @@
       "name": "ki-governance",
       "source": "./ki-governance",
       "description": "EU-KI-VO + DSGVO – Use-Case-Triage, KI-Inventar, AIA/DPIA, Vendor-Review, Drift-Monitoring der KI-Richtlinie.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1054,7 +1054,7 @@
       "name": "ki-richtlinie-kanzleien",
       "source": "./ki-richtlinie-kanzleien",
       "description": "Erstellt und pflegt eine berufsrechtskonforme KI-Nutzungsrichtlinie für Kanzleien und Rechtsabteilungen mit Anwaelten und Syndikus-Anwaelten. Beruht auf BRAO, BORA, DSGVO, KI-Verordnung sowie BRAK- und DAV-Hinweisen.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1063,7 +1063,7 @@
       "name": "ki-vo-ai-act-pruefer",
       "source": "./ki-vo-ai-act-pruefer",
       "description": "Mechanik-Workflow zur KI-VO (EU 2024/1689): KI-System-Definition, Rollen, Risikoklassen, Hochrisiko-Diagnose, GPAI, Art. 43-Konformitätsbewertung, CE/EU-DB, Marktbeobachtung, Konformitäts-Evidence-Pack, KI-Kompetenz, Shadow-AI, Berufsrecht, Hochschul- und Behördenpraxis.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1072,7 +1072,7 @@
       "name": "kommunalrecht-laender",
       "source": "./kommunalrecht-laender",
       "description": "Großes Kommunalrecht-Plugin für Gemeinden, Städte, Landkreise, Satzungen, Räte, Bürgerbegehren, Kommunalfinanzen, Aufsicht und Landesrecht.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1081,7 +1081,7 @@
       "name": "krankenhausrecht",
       "source": "./krankenhausrecht",
       "description": "Super-Plugin für deutsches Krankenhausrecht: Planung, Finanzierung, Entgelte, Reform, Qualität, MD-Prüfung, Klinikbetrieb und Rechtsstreit.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1090,7 +1090,7 @@
       "name": "krankenkassenrecht-krankenversicherung",
       "source": "./krankenkassenrecht-krankenversicherung",
       "description": "Plugin für GKV, PKV, Beihilfe-Schnittstellen und Krankenversicherungsrecht: Leistungen, Beiträge, Krankengeld, Hilfsmittel, Widerspruch, MD, Versicherungsvertrag und Kostenerstattung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1099,7 +1099,7 @@
       "name": "kriegsdienstverweigerung-wehrdienst",
       "source": "./kriegsdienstverweigerung-wehrdienst",
       "description": "Praxisplugin für Kriegsdienstverweigerung und Wehrdienst aus Gewissensgründen: Art. 4 Abs. 3 GG, KDVG n. F. 2026, Antrag über BAPersBw, BAFzA-Entscheidung, Gewissensbegründung, Soldaten, Reservisten, Rechtsschutz und saubere Abgrenzung zur Totalverweigerung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1108,7 +1108,7 @@
       "name": "krisenfrueherkennung-starug",
       "source": "./krisenfrueherkennung-starug",
       "description": "Krisenfrüherkennung und Krisenmanagement nach StaRUG: Pflicht zum 24-Monats-Frühwarnsystem nach § 1 StaRUG, § 102 StaRUG Warnpflicht der Berater, Geschäftsführerhaftung, drohende Zahlungsunfähigkeit, integrierte Planung, Restrukturierungsplan und Stabilisierungsanordnung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1117,7 +1117,7 @@
       "name": "leasingrecht-praxis",
       "source": "./leasingrecht-praxis",
       "description": "Wirtschaftsrechtliches Praxisplugin für Leasing, Sale-and-lease-back, Equipment Finance, Fahrzeugflotten, IT-Leasing, Insolvenz, Restwert, Sicherheiten und Vertragsgestaltung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1126,7 +1126,7 @@
       "name": "legistik-werkstatt",
       "source": "./legistik-werkstatt",
       "description": "Legistik-Werkstatt für Ministerien, Bundestag, Fraktionen/Opposition, Länder, Landtage und Normgeber. Baut Referenten- und Kabinettsentwürfe, Vorlagen aus der Mitte, Änderungs-/Entschließungsanträge, Rechtsverordnungen und Satzungen mit Begründung, Synopse, XML und Prüfpfaden.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1135,7 +1135,7 @@
       "name": "liquiditaetsplanung",
       "source": "./liquiditaetsplanung",
       "description": "Liquiditaetsplanung nach deutschem Recht: 3-Wochen-Vorschau, 13/26/52-Wochen-Forecast, Excel-Export, Quote/Luecken-Ampel, Dokumentationspaket und Schnittstellen zu Fortbestehensprognose und Insolvenzrecht. Rechtsprechung nur nach Live-Verifikation.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1144,7 +1144,7 @@
       "name": "lizenzvertragsersteller",
       "source": "./lizenzvertragsersteller",
       "description": "Baukastensystem fuer IP-Lizenzvertraege deutsches und internationales Recht. 32 Skills: Urheber Patent Marken Design Gebrauchsmuster Geschaeftsgeheimnis Know-how; Klausel-Bausteine, Quellcode-Escrow, Insolvenz-Klausel, Sicherungslizenz, TT-GVO, DSGVO, Quellensteuer, Output DE EN bilingual.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1153,7 +1153,7 @@
       "name": "lobbyregister-bundestag",
       "source": "./lobbyregister-bundestag",
       "description": "Lobbyregister-Bundestag-Superplugin mit 50 geführten Skills für Registrierungspflicht, Ausnahmen, Registereintrag, Regelungsvorhaben, Stellungnahmen, Finanzdaten, Aktualisierung, Verhaltenskodex, Meldung von Verstoessen und Fristen nach LobbyRG.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1162,7 +1162,7 @@
       "name": "luftrecht-flughafenrecht",
       "source": "./luftrecht-flughafenrecht",
       "description": "Luftrecht-Plugin für LuftVG, LuftSiG, LBA, Flughäfen, Airlines, Slots, Flugzeugpfandrechte, Beschlagnahme, Insolvenz, Drohnen und Aviation-Compliance.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1171,7 +1171,7 @@
       "name": "mandantenanfragen-assistent",
       "source": "./mandantenanfragen-assistent",
       "description": "Assistent für Anwaltskanzleien zur Erstantwort auf Mandantenanfragen per E-Mail: dankt foermlich übernimmt die Anrede aus der eingehenden E-Mail nennt die telefonische Terminvergabe bittet um Sachverhalt per E-Mail oder bietet eine Telefon-Transkription mit DSGVO-Einwilligungshinweis an.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1180,7 +1180,7 @@
       "name": "markenrecht-fashion-luxus",
       "source": "./markenrecht-fashion-luxus",
       "description": "Großes Markenrechts-Plugin für DE/EU/US und internationale Portfolios: DPMA, EUIPO, WIPO/Madrid, USPTO, Markenarten, Schutzhindernisse, Benutzung, Widerspruch, Verfall/Nichtigkeit, Enforcement, Plattformen, Zoll, Lizenzen und Luxus-Fashion-Spezialfälle.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1189,7 +1189,7 @@
       "name": "meinungspruefer",
       "source": "./meinungspruefer",
       "description": "Meinungsprüfer für Äußerungsrecht: Meinung oder Tatsache, Beleidigung, üble Nachrede, Verleumdung, § 188 StGB, Art. 5 GG, Art. 10 EMRK, Art. 11 GRCh, EGMR/EuGH, OLG-Praxis, US-Supreme-Court-Vergleich, Zivilrecht, Plattformen, Social Media, Arbeitsplatz, Schule und kommunale Machtkritik.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1198,7 +1198,7 @@
       "name": "memorandums-ersteller",
       "source": "./memorandums-ersteller",
       "description": "Wandelt Mandantenunterlagen in ein juristisches Memorandum mit Vier-Teile-Gliederung — Sachverhalt mit Quellenreferenz; Ein-Satz-Fragen; Ein-Satz-Antworten; rechtliche Ausführungen mit Pinpoint-Zitierung. Optional Piercing-Questions. Rechtsgebietsneutral. Alias Memorandumsmacher.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1207,7 +1207,7 @@
       "name": "methodenlehre-buergerliches-recht",
       "source": "./methodenlehre-buergerliches-recht",
       "description": "Methodenlehre und Rechtsanwendung im deutschen buergerlichen Recht aus Anwaltsperspektive: Anspruchsaufbau, Auslegung, Abwaegung, Praezedenzarbeit, Rechtsfortbildung, Methodenwahl, EU-Methodik und methodenehrliche Begruendungskontrolle.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1216,7 +1216,7 @@
       "name": "mietrecht",
       "source": "./mietrecht",
       "description": "Mietrecht für Mieter und Vermieter mit ausschließlich amtlichen Mietspiegel-Quellen pro Bundesland und für Top- und Universitaetsstaedte. Datenerhebung Mieterhoehungs-Widerspruch Mietsenkungsverlangen Nebenkostenprüfung und Erstellung Mieteranfragen Klageentwurf zum Amtsgericht.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1225,7 +1225,7 @@
       "name": "mittelstand-corporate-ma",
       "source": "./mittelstand-corporate-ma",
       "description": "Freistehendes Mittelstandsmandat-Corporate/M&A-Plugin: Deal-Kommandocenter, Aktenanlage, Datenraum, Legal DD, Tabellenreview, Liquiditätsvorschau, SPA/APA, W&I, Public M&A, Umwandlung, StaRUG/Insolvenzplan, CP-Kalender, E-Rechnung/GoBD, PMI.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1234,7 +1234,7 @@
       "name": "nachbarschaftsstreit-pruefer",
       "source": "./nachbarschaftsstreit-pruefer",
       "description": "Nachbarrecht und Nachbarschaftsstreit: Überbau, Überhang, Äste/Wurzeln, Grenzbaum, Zaun/Mauer/Hecke, Immissionen, Vertiefung, Notweg, Hammerschlagsrecht, Beweise, Aufforderung, Klage und Vergleich.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1243,7 +1243,7 @@
       "name": "nda-abgleich",
       "source": "./nda-abgleich",
       "description": "Gleicht NDA-Entwurf der Gegenseite gegen eigenen Standard ab und setzt Haltelinien chirurgisch im Word-Aenderungsmodus durch. Ampelmatrix ROT/GELB/GRUEN. Ausgabe .docx mit echten Tracked Changes. Keine Absatzlöschungen, keine Klausel-Neufassungen.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1252,7 +1252,7 @@
       "name": "nda-verschwiegenheit-generator-checker",
       "source": "./nda-verschwiegenheit-generator-checker",
       "description": "Allgemeiner NDA-Ersteller und NDA-Prüfer für deutsche und internationale Verschwiegenheitsvereinbarungen: Entwurf, Redline, GeschGehG, HinSchG, AGB, Arbeitsrecht, M&A, Forschung, Software, Datenraum und Verletzungsreaktion.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1261,7 +1261,7 @@
       "name": "nis2-cybersecurity-compliance",
       "source": "./nis2-cybersecurity-compliance",
       "description": "NIS-2, BSIG 2025, BSI, IT-Grundschutz, Cloud, Incident Response und technische Security-Compliance für Geschäftsleitung, CISO und Legal.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1270,7 +1270,7 @@
       "name": "normenkontrolle-bauleitplanung",
       "source": "./normenkontrolle-bauleitplanung",
       "description": "Freistehendes Plugin für die Prüfung und Anfechtung von Bebauungsplänen, Flächennutzungsplänen und örtlichen Bauvorschriften nach § 47 VwGO vor BayVGH und OVG. Mandatsperspektive Antragstellervertretung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1279,7 +1279,7 @@
       "name": "normenkontrollrat-nkr",
       "source": "./normenkontrollrat-nkr",
       "description": "Plugin fuer den Nationalen Normenkontrollrat (NKR): Pruefung von Referentenentwuerfen Formulierungshilfen und Gesetzentwuerfen auf Erfuellungsaufwand Erforderlichkeit Verhaeltnismaessigkeit One-in-one-out Digitalcheck Mittelstandsfreundlichkeit und Praktikabilitaet im Vollzug.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1288,7 +1288,7 @@
       "name": "notariat-alltag",
       "source": "./notariat-alltag",
       "description": "Alltagsplugin für Notariat, Notariatsmitarbeitende und Notarinnen/Notare: Beurkundung, Vollzug, Register, Grundbuch, Geldwäsche, Kosten, Fristen und Mandantenkommunikation.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1297,7 +1297,7 @@
       "name": "oeffentliches-wirtschaftsrecht",
       "source": "./oeffentliches-wirtschaftsrecht",
       "description": "Öffentliches-Wirtschaftsrecht-Plugin für Scheinprivatisierung, ÖPP, Projektfinanzierung, kommunale Unternehmen, Beihilfen, Vergabe und Regulierung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1306,7 +1306,7 @@
       "name": "ordnungswidrigkeitenrecht",
       "source": "./ordnungswidrigkeitenrecht",
       "description": "Allgemeines OWiG-Plugin für Bußgeldverfahren: Anhörung, Bescheid, Einspruch, Behörde, Akteneinsicht, Gericht, Verjährung, Einziehung und Nebenfolgen.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1315,7 +1315,7 @@
       "name": "parteienrecht-parteiorganisation",
       "source": "./parteienrecht-parteiorganisation",
       "description": "Parteienrechts- und Parteiorganisations-Plugin für formale Parteiarbeit: Parteiengesetz, Satzung, Mitgliederrechte, Parteitage, Kreis- und Bezirksversammlungen, Kandidatenaufstellung, Wahlvorschläge, Parteigerichte, Spenden, Rechenschaft, Abgeordnetenrecht und Wahlleiterkommunikation.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1324,7 +1324,7 @@
       "name": "patentrecherche",
       "source": "./patentrecherche",
       "description": "Patentrecherche für Patentanwaelte agentisch in Espacenet Google Patents DPMAregister DEPATISnet EPO Register WIPO USPTO. Stand der Technik Neuheit § 3 PatG Art. 54 EPUe erfinderische Tätigkeit § 4 PatG Art. 56 EPUe Problem-Solution-Approach FTO CPC IPC INPADOC Recherchebericht.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1333,7 +1333,7 @@
       "name": "patentrecht",
       "source": "./patentrecht",
       "description": "Großes Patentrechts-Plugin für Erfindungsaufnahme, Patentanmeldung, Anspruchsentwurf, Recherche, Neuheit, erfinderische Tätigkeit, FTO, Abmahnung, Claim Chart, Vorbenutzungsrecht, Lizenz, Erfinderbenennung, Einspruch, Nichtigkeit, Register und Fristen.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1342,7 +1342,7 @@
       "name": "phishing-vorfall-pruefer",
       "source": "./phishing-vorfall-pruefer",
       "description": "Freistehender Phishing-Vorfall-Prüfer für Online-Banking: BGB § 675u, § 675v, § 675w, pushTAN, Call-ID-Spoofing, grobe Fahrlässigkeit, Beweislast, Bankpflichten, Schlichtung und Klage.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1351,7 +1351,7 @@
       "name": "preussisches-allgemeines-landrecht-pralr",
       "source": "./preussisches-allgemeines-landrecht-pralr",
       "description": "PrALR-Plugin zum Allgemeinen Landrecht für die Preußischen Staaten: Quellenkritik, Textzeugen, Zivilrecht, Staats-/Polizeirecht, Strafrecht, Ständerecht, Aufopferung und Rezeptionsgeschichte.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1360,7 +1360,7 @@
       "name": "private-equity-praxis",
       "source": "./private-equity-praxis",
       "description": "Private-Equity-Praxis-Plugin für deutsche Kanzleien, Investoren, Fonds, Family Offices und Unternehmen: Fund Formation, KAGB/AIF, ELTIF, Deal Execution, Private Credit, Schuldschein, LMA, NPL, Portfolio, Exit und Distressed.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1369,7 +1369,7 @@
       "name": "produktrecht",
       "source": "./produktrecht",
       "description": "Produkthaftung und Produktrecht: Produktsicherheit, GPSR, ProdHaftG, deliktische Produzentenhaftung, Right to Repair, Software-/OTA-Updates, digitale Produktlebenszyklen, Rückruf, Marktüberwachung und Launch-Review.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1378,7 +1378,7 @@
       "name": "prozessrecht",
       "source": "./prozessrecht",
       "description": "Prozessrechtliche Skills für Mandate, Fristen, Mahnbescheid, Eilverfahren, Vollstreckung und Schriftsätze.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1387,7 +1387,7 @@
       "name": "pruefungsrecht-hochschule",
       "source": "./pruefungsrecht-hochschule",
       "description": "Hochschulprüfungsrecht: Prüfungsordnung, Bewertungsspielraum, Akteneinsicht, Krankheit, Nachteilsausgleich, Täuschung, KI, Drittversuch und Eilrechtsschutz.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1396,7 +1396,7 @@
       "name": "rechtsberatungsstelle",
       "source": "./rechtsberatungsstelle",
       "description": "Pro-Bono- und Rechtsberatungsstellen (RDG-konform): Mandantenintake, Fristenkontrolle, Übergabe am Semesterende, mandantenfreundliche Briefe.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1405,7 +1405,7 @@
       "name": "rechtstheorie-rechtsphilosophie",
       "source": "./rechtstheorie-rechtsphilosophie",
       "description": "Rechtstheorie- und Rechtsphilosophie-Plugin fuer juristische Praxis: Rechtsbegriff, Kelsen-orientierte Normgeltung, Demokratie, Rechtsrealismus, Systemdenken, Besitzdogmatik, Law-and-Economics, Hayek-Wissensproblem, spontane Ordnung, Machtkritik und anti-dezisionistische Red-Team-Pruefung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1414,7 +1414,7 @@
       "name": "regulatorisches-recht",
       "source": "./regulatorisches-recht",
       "description": "Aufsichtsrecht – KWG, ZAG, WpHG, GwG, EnWG, TKG, HeilMWerbG, Umsatzsteuer-Voranmeldung, Inkasso/RDG, Regulator-Feeds, Wochendigest.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1423,7 +1423,7 @@
       "name": "rentenpruefer",
       "source": "./rentenpruefer",
       "description": "Rentenprüfer für gesetzliche Rente, Versorgungswerk und internationale Versicherungszeiten: Kontenklärung, Rentenantrag, Nachversicherung, Auslandszeiten, Bescheide, Widerspruch und verständliche Dokumentation.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1432,7 +1432,7 @@
       "name": "robotik-recht",
       "source": "./robotik-recht",
       "description": "Robotik-Recht Deutschland/EU: Maschinenverordnung, KI-VO, Produkthaftung, ProdSG, Datenschutz, CRA, Data Act, CE, Marktüberwachung, Unfälle, Rückruf, Verträge und Robotik-Testakte.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1441,7 +1441,7 @@
       "name": "roemisch-katholisches-kirchenrecht",
       "source": "./roemisch-katholisches-kirchenrecht",
       "description": "Großes, lehramts- und papsttreues Arbeitsplugin zum Recht der römisch-katholischen Kirche: CIC, Katechismus, Sakramente, Ehe, Kirchenaustritt, Verfahren, Disziplin, Pfarrei, Diözese, Kurie und mehrsprachige Kommunikation.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1450,7 +1450,7 @@
       "name": "roemisches-recht",
       "source": "./roemisches-recht",
       "description": "Mega-Plugin zum römischen Recht: Zwölftafelgesetz, Institutionensystem, Sachenrecht, Obligationen, Aktionenrecht, Erbrecht, Juristenrecht, Justinian, byzantinisches Recht und Rezeption.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1459,7 +1459,7 @@
       "name": "schoeffen-handelsrichter-praxis",
       "source": "./schoeffen-handelsrichter-praxis",
       "description": "Plugin für Schöffen, Jugendschöffen, ehrenamtliche Richter und Handelsrichter: Rolle, Rechte, Pflichten, Sitzung, Beratung, Befangenheit, Beweiswürdigung, Handelskammer, Verwaltungsgericht und sichere praktische Orientierung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1468,7 +1468,7 @@
       "name": "schriftform-und-textform-bgb",
       "source": "./schriftform-und-textform-bgb",
       "description": "Formerfordernisse im deutschen Zivilrecht: Schriftform, Textform, qES, Zugang, beA/ERV und Prozessordnungen. Mit Checklisten, Dokumentation und Rechtsprechung nur nach Live-Verifikation.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1477,7 +1477,7 @@
       "name": "schulrecht-laender",
       "source": "./schulrecht-laender",
       "description": "Schulrecht der Länder: Schulpflicht, Aufnahme, Inklusion, Noten, Versetzung, Ordnungsmaßnahmen, Datenschutz, Elternrechte und Eilrechtsschutz.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1486,7 +1486,7 @@
       "name": "seerecht-schifffahrtsrecht",
       "source": "./seerecht-schifffahrtsrecht",
       "description": "See- und Schifffahrtsrecht-Plugin für Schiffskauf, Schiffbau, Werften, Schiffshypothek, Schiffsregister, Arrest, Wrack, Bergung, Charter und ITLOS.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1495,7 +1495,7 @@
       "name": "selbstvertreter-amtsgericht",
       "source": "./selbstvertreter-amtsgericht",
       "description": "Selbstvertretung vor dem Amtsgericht ohne Anwalt: Anfänger-Workflow, Fristen, Zuständigkeit, §23 GVG/§511 ZPO-Grenzen, Klage/Erwiderung/Replik, Beweise, PKH, Termin, Sanity-Check, Rechtsprechungschat, Berufung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1504,7 +1504,7 @@
       "name": "selbstvertreter-sozialgericht",
       "source": "./selbstvertreter-sozialgericht",
       "description": "Selbstvertretung vor Sozialbehörden Krankenkassen Pflegekassen BG Versorgungsamt Jobcenter Rente Familienkasse und Sozialgericht: Anhörung Akteneinsicht Mitwirkung Widerspruch Klage Eilantrag Pflegegrad Hilfsmittel Krankengeld EM-Rente GdB Bürgergeld Wohngeld Eingliederungshilfe.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1513,7 +1513,7 @@
       "name": "softwarerecht-de-eu-us",
       "source": "./softwarerecht-de-eu-us",
       "description": "Softwarerecht Deutschland/EU/International/USA: Entwicklung, Lizenzen, SaaS, Open Source, Arbeitnehmer/Freelancer, Softwarepatente, AI-Code und Streit.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1522,7 +1522,7 @@
       "name": "solo-selbststaendige-praxis",
       "source": "./solo-selbststaendige-praxis",
       "description": "Praxisplugin für Solo-Selbstständige in Deutschland: Start, Anmeldung, Steuern, Verträge, Rechnungen, Datenschutz, Statusfeststellung, KSK, Versicherungen, Zahlungsausfall, Krise, Wachstum und Alltag ohne juristische Überforderung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1531,7 +1531,7 @@
       "name": "sozialversicherungsstatus-pruefer",
       "source": "./sozialversicherungsstatus-pruefer",
       "description": "Sozialversicherungsstatus und DRV-Statusfeststellung: Geschäftsführer, Freelancer, Anwälte, Lehrkräfte, Musikschulen, Plattformarbeit und Scheinselbständigkeit.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1540,7 +1540,7 @@
       "name": "staatsanwaltschaft-praxis-einstieg",
       "source": "./staatsanwaltschaft-praxis-einstieg",
       "description": "Praxisplugin für neue Staatsanwältinnen, Staatsanwälte und Sitzungsdienst: Ermittlungen, RiStBV, Anklage, Strafbefehl, Hauptverhandlung, Rechtsmittel und OWiG-Bußgeldverfahren.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1549,7 +1549,7 @@
       "name": "startup-hr-personalabteilung-berlin",
       "source": "./startup-hr-personalabteilung-berlin",
       "description": "Personalabteilungs- und HR-Operations-Plugin für ein Berliner Start-up mit ca. 100 Beschäftigten: Arbeitsverträge, Payroll/DATEV-Schnittstelle, Personalakten, Datenschutz, AGG-Vorfälle, Betriebsrat, Benefits, Fehlzeiten, Kündigungen, Happiness-Management und Chef-Briefings.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1558,7 +1558,7 @@
       "name": "status-navigator-step-plan",
       "source": "./status-navigator-step-plan",
       "description": "Status-Navigator und Step-Plan-Macher. Reine Dokumentenverarbeitung mit 35 Skills. Strukturiert disparate Dokumentenlagen in eine mehrseitige Excel-Arbeitsmappe und optional ein Padlet-Shelf mit Reitern Ueberblick, Vorhanden, Fehlend und Workflow. Keine rechtliche Bewertung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1567,7 +1567,7 @@
       "name": "steuerrecht-anwalt-und-berater",
       "source": "./steuerrecht-anwalt-und-berater",
       "description": "Steuerrecht für Anwalt (anw- FAO § 9) und Steuerberater (stb-): Einspruch Klage FG Aussenprüfung Selbstanzeige, Grundsteuer, Grunderwerbsteuer, Share Deals, Signing Closing, BWA SuSa Lohnbuchhaltung Jahresabschluss.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1576,7 +1576,7 @@
       "name": "strafanzeige-vorbereiter",
       "source": "./strafanzeige-vorbereiter",
       "description": "Vorsichtiger Strafanzeigen-Vorbereiter: prüft Anfangsverdacht, Beweise, Strafantrag, Risiken falscher Verdächtigung, Alternativen und erstellt nur bei tragfähiger Tatsachengrundlage eine nüchterne Strafanzeige.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1585,7 +1585,7 @@
       "name": "strafbefehl-verteidiger",
       "source": "./strafbefehl-verteidiger",
       "description": "Freistehendes Strafbefehls-Plugin für Verteidigung gegen Strafbefehl, Einspruch, Akteneinsicht, Tagessätze, Nebenfolgen, Pflichtverteidigung, Wiedereinsetzung, Einstellung, Zeugenstrategie und Hauptverhandlung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1594,7 +1594,7 @@
       "name": "strafzumessung",
       "source": "./strafzumessung",
       "description": "Strafzumessung nach deutschem Strafrecht vom Strafbefehl bis zur grossen Strafkammer. § 46 StGB Strafzumessungstatsachen Tagessatz Geldstrafe Freiheitsstrafe Bewaehrung § 56 § 49 Regelbeispiele besonders schwerer Fall Verstaendigung § 257c StPO TOA § 46a Gesamtstrafe § 55 JGG.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1603,7 +1603,7 @@
       "name": "strassenrecht-infrastruktur",
       "source": "./strassenrecht-infrastruktur",
       "description": "Straßenrecht-Plugin für Bundesfernstraßen, Landesstraßen, Gemeindestraßen, Widmung, Planfeststellung, Sondernutzung, Baulast und Erhaltung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1612,7 +1612,7 @@
       "name": "strassenverkehrsrecht-stvo",
       "source": "./strassenverkehrsrecht-stvo",
       "description": "StVO-/Straßenverkehrsrecht-Plugin für Verkehrsregeln, Zeichen, Anordnungen, Ausnahmegenehmigungen, Fahrerlaubnis, Bußgeld-Schnittstellen und Behördenpraxis.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1621,7 +1621,7 @@
       "name": "subsumtions-pruefer",
       "source": "./subsumtions-pruefer",
       "description": "Interaktiver Subsumtions-Workflow für deutsches Recht und Europarecht: Tatbestandsmerkmale zerlegen, Vier-Schritt-Schema anwenden, Rechtsfolgen und Einreden prüfen. Keine Rechtsberatung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1630,7 +1630,7 @@
       "name": "tabellenreview-3d",
       "source": "./tabellenreview-3d",
       "description": "3D-Tabellenreview als Wuerfel: Spaltenprompts pro Datenpunkt x Zeilenprompts pro Dokument x Arbeitsblatt-Perspektiven (Recht / Steuer / Wirtschaft) gestapelt. Massenprüfung Vertragsstapel M&A-DD Immobilien Vendor-Onboarding mit Excel-Mehrblatt Kreuzblatt-Konsistenz Audit-Trail Belegkette.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1639,7 +1639,7 @@
       "name": "telekommunikationsrecht",
       "source": "./telekommunikationsrecht",
       "description": "Großes Telekommunikationsrecht-Plugin für TKG, Bundesnetzagentur, Internetanschlüsse, Anbieterwechsel, Kundenschutz, Netzregulierung, Frequenzen, Nummerierung, Sonderkartellrecht, Datenschutz und Sicherheitsanforderungen.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1648,7 +1648,7 @@
       "name": "tierschutzrecht",
       "source": "./tierschutzrecht",
       "description": "Tierschutzrecht-Plugin für TierSchG, BGB § 90a, Haltung, Zucht, Transport, Tierversuche, Behördenverfahren, Strafrecht, Bußgeld und zivilrechtliche Tierfälle.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1657,7 +1657,7 @@
       "name": "umweltrecht",
       "source": "./umweltrecht",
       "description": "Freistehendes Umweltrecht-Plugin für BImSchG, TEHG, Abfall, Wasser, Boden, Naturschutz, UIG, Verfahren, Bußgeld, Umwelt-Due-Diligence, Klimaklagen UmwRG, Lieferkettensorgfalt LkSG/CSDDD und ESG-Greenwashing/CSRD.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1666,7 +1666,7 @@
       "name": "umweltschutzverband-verbandsklage",
       "source": "./umweltschutzverband-verbandsklage",
       "description": "Plugin für Umweltverbände: UmwRG, Aarhus, UIG, UVP, BImSchG, Planfeststellung, § 47 VwGO, Naturschutz, Klima, Verbandsklage und Eilrechtsschutz.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1675,7 +1675,7 @@
       "name": "urheberrecht-de-eu",
       "source": "./urheberrecht-de-eu",
       "description": "Deutsches und EU-Urheberrecht fuer Werkhoehe, Musik, KI, TDM, Software, Lizenzen, Abmahnung, Schranken, Leistungsschutz und Rechteclearing.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1684,7 +1684,7 @@
       "name": "urteilsbauer-relationsmacher",
       "source": "./urteilsbauer-relationsmacher",
       "description": "Urteils- und Beschluss-Werkstatt für Amts- Land- und Familienrichter sowie Rechtspfleger. Aktenintake Relation Beweiswürdigung mit Richter-Input Tatbestandsmerkmale Tenor Tatbestand Entscheidungsgründe Rechtsmittelbelehrung. Erzeugt DOCX nach Paragraf 313 ZPO.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1693,7 +1693,7 @@
       "name": "us-bankruptcy-code",
       "source": "./us-bankruptcy-code",
       "description": "US Bankruptcy Code Title 11: Chapters 7/9/11/12/13/15, Automatic Stay, Claims, DIP, 363 Sales, Plans und Cross-Border.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1702,7 +1702,7 @@
       "name": "us-copyright-registrierung-verlag",
       "source": "./us-copyright-registrierung-verlag",
       "description": "US Copyright Act fuer deutsche Verlage und Rechteinhaber: Title 17, Registrierung, Rechte, Fair Use, DMCA, Musik, AI, Litigation und Deals.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1711,7 +1711,7 @@
       "name": "venture-capital-geber",
       "source": "./venture-capital-geber",
       "description": "VC-Geber-Plugin für deutsche Venture-Capital-Investoren, Family Offices, Angels und junge VCs: Sourcing, Deal-Tracking, Wandeldarlehen, SAFE, Pre-Seed, Series A/B, Cap Table, Follow-on, Portfolio-Updates, KAGB/BaFin-Grenzen, EU/CH/UK/US-Brücken und legitime Deal-Taktik.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1720,7 +1720,7 @@
       "name": "verbraucher-rechtsstaat-alltag",
       "source": "./verbraucher-rechtsstaat-alltag",
       "description": "Kleines, hilfreiches Plugin für Verbraucher: E-Commerce, Kaufrecht, Reparaturen, kleine Dienstleistungen, Rechnungen, Inkasso, Plattformen, Behördenbriefe und Gerichtspost verständlich einordnen und vorsichtig reagieren.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1729,7 +1729,7 @@
       "name": "verbraucherinsolvenz-schuldenbereinigung",
       "source": "./verbraucherinsolvenz-schuldenbereinigung",
       "description": "Verbraucherinsolvenz und Schuldenbereinigung nach InsO: außergerichtlicher Einigungsversuch, Schuldenbereinigungsplan, Antrag, Restschuldbefreiung, P-Konto, ehemalige Selbstständige und lebensnahe Verfahrensführung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1738,7 +1738,7 @@
       "name": "verbraucherschutzrecht-pruefer",
       "source": "./verbraucherschutzrecht-pruefer",
       "description": "Großer Verbraucherschutz-Prüfer für BGB, EGBGB, UWG, UKlaG, VSBG, E-Commerce, digitale Produkte, Reise, Finanzen, Energie, Gesundheit und Alltag.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1747,7 +1747,7 @@
       "name": "verbraucherschutzverband-durchsetzung",
       "source": "./verbraucherschutzverband-durchsetzung",
       "description": "Plugin für Verbraucherverbände: VDuG, UKlaG, UWG, Abhilfeklage, Musterfeststellung, Unterlassung, Register, Finanzierung, Vergleich und Kampagnenakte.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1756,7 +1756,7 @@
       "name": "vereinsrecht-vereinsmanager",
       "source": "./vereinsrecht-vereinsmanager",
       "description": "Vereinsrechts- und Vereinsmanagement-Plugin für eingetragene und nicht eingetragene Vereine: Gründung, Satzung, Mitgliederversammlung, Vorstand, Protokolle, Beschlüsse, Gemeinnützigkeit, Register, Haftung, Datenschutz, Finanzen, Veranstaltungen und Spezialvereine.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1765,7 +1765,7 @@
       "name": "verfassungsrecht",
       "source": "./verfassungsrecht",
       "description": "Deutsches Verfassungsrecht unter dem Grundgesetz aus Sicht einer Spezialkanzlei. Rechtsprechungsgetrieben mit Live-Recherche auf bundesverfassungsgericht.de. Acht Skills für Gesetzgebungskompetenz formelle und materielle Verfassungsmäßigkeit Grundrechte und Verfassungsbeschwerde.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1774,7 +1774,7 @@
       "name": "verhaeltnismaessigkeitspruefer",
       "source": "./verhaeltnismaessigkeitspruefer",
       "description": "75 Skills zur Schranken-Schranke: BVerfG-Leitentscheidungen, Rechtsvergleich Suedafrika/Kanada/EGMR/EuGH/USA und 12 europaeische Ordnungen, plus Theorie Alexy, Rechtsgeschichte-Linie, Schnellpruefung 5 Minuten, Klausurschema, Streitstellen-Katalog, Subsumtionshelfer mit 10 Pattern-Faellen.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1783,7 +1783,7 @@
       "name": "verkehr-infrastrukturrecht",
       "source": "./verkehr-infrastrukturrecht",
       "description": "Freistehendes Verkehrs- und Infrastrukturrecht-Plugin für Verkehrsplanung, Planfeststellung, Straßenbahn, Ladeinfrastruktur, Parkraum und Verkehrswende.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1792,7 +1792,7 @@
       "name": "verkehrsowi-verteidiger",
       "source": "./verkehrsowi-verteidiger",
       "description": "Freistehendes VerkehrsOWi-Plugin für Bußgeldbescheid, Anhörung, Einspruch, Punkte, Fahrverbot, Rotlicht, Geschwindigkeit, Abstand, Handy, Alkohol, Drogen, Akteneinsicht, Messakte, Zeugenstrategie und Amtsgericht.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1801,7 +1801,7 @@
       "name": "verlagsrecht-buchpreisbindung",
       "source": "./verlagsrecht-buchpreisbindung",
       "description": "Plugin für Verlagsrecht, Verlagsgesetz, Autoren- und Herausgeberverträge, Buchpreisbindung, Titelschutz, Vertrieb, E-Book, Hörbuch und verlagsnahe Compliance.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1810,7 +1810,7 @@
       "name": "verlagsredaktion",
       "source": "./verlagsredaktion",
       "description": "Verlagsdesk fuer juristische und fachliche Verlage: Eingangskorb, Manuskript, Redaktion, Rechtecheck, Zitate, Bildrechte, Autorenkommunikation, Heftplanung, Buchprojekte, Satzfahnen, Metadaten, Marketing und Produktionsuebergabe.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1819,7 +1819,7 @@
       "name": "versammlungsrecht",
       "source": "./versammlungsrecht",
       "description": "Praxisplugin für Versammlungsrecht und Versammlungsfreiheit: Anzeige unter freiem Himmel, Landesrecht, Behörde, Fristen, Spontan- und Eilversammlung, Ordner, Kooperationsgespräch, Auflagen, Verbot, Eilrechtsschutz und Durchführung ohne vorauseilende Selbstzensur.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1828,7 +1828,7 @@
       "name": "versicherungsrecht",
       "source": "./versicherungsrecht",
       "description": "Großes Versicherungsrecht-Plugin für VVG, VAG, europäische Versicherungsaufsicht, Lebensversicherung, BU, PKV, Rechtsschutz, Kreditversicherung, D&O, Cyber, Sach- und Haftpflichtdeckung.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1837,7 +1837,7 @@
       "name": "vertragsausfueller",
       "source": "./vertragsausfueller",
       "description": "Freistehendes Vertragsausfüller-Plugin: DOCX-Vorlagen und Altverträge strippen, Felder erkennen, Term Sheets mappen, Rückfragen führen, neue Verträge erzeugen und Track-Changes-Fassungen nur nach ausdrücklicher Nachfrage vorbereiten.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1846,7 +1846,7 @@
       "name": "vertragsrecht",
       "source": "./vertragsrecht",
       "description": "Vertragsrecht – Lieferanten- und Vertriebsverträge, AGB §§ 305 ff. BGB, NDA, SaaS-/MSA-Review, Renewal-Tracking, Eskalations-Routing, Business-Zusammenfassungen.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1855,7 +1855,7 @@
       "name": "wahlkampfrecht-praxis",
       "source": "./wahlkampfrecht-praxis",
       "description": "Wahlkampfrecht und Wahlkampfpraxis fuer Parteien, Kandidierende und Kampagnenteams: Strategie, Plakatierung, Social Media, Datenschutz, politische Werbung, Parteienfinanzierung, Desinformation, Veranstaltungen, Schulen, Podien, Wahltag und Compliance.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1864,7 +1864,7 @@
       "name": "wandeldarlehen-lebenszyklus",
       "source": "./wandeldarlehen-lebenszyklus",
       "description": "Begleitet den vollständigen Lebenszyklus eines Wandeldarlehens für GmbH und UG: Vertragserstellung (bilingual/einsprachig), Beurkundungsprüfung, Wandelereignisse, Wandlungsberechnung, Cap-Table-Update, Gesellschafterbeschluss und Notar-Paket.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1873,7 +1873,7 @@
       "name": "weg-hausverwaltung",
       "source": "./weg-hausverwaltung",
       "description": "Operatives WEG- und Hausverwaltungs-Plugin fuer Beschluesse, Eigentuemerversammlung, Protokoll, Beschlusssammlung, Wirtschaftsplan, Jahresabrechnung, Hausgeld, Sonderumlage, Betriebskosten, Handwerker, bauliche Veraenderungen, Steckersolar, Wallbox, Verwalter, Beirat und Anwalt-Eskalation.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1882,7 +1882,7 @@
       "name": "weltraumrecht",
       "source": "./weltraumrecht",
       "description": "Großes Plugin für deutsches, europäisches und internationales Weltraumrecht: Raumfahrtverträge, Satelliten, Haftung, Weltraumbahnhof, Raketen, Raumstationen, Frequenzen, Exportkontrolle und Space Property.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1891,7 +1891,7 @@
       "name": "word-legal-ai-plugin-and-skill-for-german-lawyers",
       "source": "./word-legal-ai-plugin-and-skill-for-german-lawyers",
       "description": "Word Legal AI for German Lawyers: Kaltstart, Kanzleistil, makrofreies Word-Finish, Verträge, Schriftsätze, Memos, Redlines, Klauselbibliothek, Defensive Drafting, Term Sheet, DE-EN Bilingual, US/UK Legal Writing und englische Verträge nach deutschem Recht.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1900,7 +1900,7 @@
       "name": "zitierweise-deutsches-recht",
       "source": "./zitierweise-deutsches-recht",
       "description": "Deutsche juristische Hauszitierweise v4.0: Rechtsprechung nur mit Gericht, Entscheidungsform, Datum, Aktenzeichen und verifizierbarer Quelle; keine BeckRS-, Kommentar- oder Aufsatz-Blindzitate. Literatur nur mit Nutzerquelle oder lizenziertem Live-Zugriff.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1909,7 +1909,7 @@
       "name": "zwangsverwaltung-zvg",
       "source": "./zwangsverwaltung-zvg",
       "description": "Freistehendes ZVG-Plugin für Zwangsverwaltung und Versteigerung: Beschlagnahme, Besitz, Mieten, Treuhandkonto, Berichte, Verteilung, ZVG-Portal-Recherche, Bieterangebote und Versteigerungsteilnahme.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
@@ -1918,11 +1918,11 @@
       "name": "zwangsvollstreckung",
       "source": "./zwangsvollstreckung",
       "description": "Plugin Zwangsvollstreckung §§ 704 ff. ZPO: Mahn-/Vollstreckungsbescheid, PfÜB Bank/Arbeit, § 802l Kontensuche, Vermögensauskunft, Räumung, § 800 ZPO Notar, § 201 InsO, ZVG, EU-Kontenpfändung VO 655/2014, § 765a Härtefall, Schuldnerschutz.",
-      "version": "300.0.0",
+      "version": "301.0.0",
       "author": {
         "name": "Klotzkette"
       }
     }
   ],
-  "version": "300.0.0"
+  "version": "301.0.0"
 }

--- a/ASSET_INDEX.md
+++ b/ASSET_INDEX.md
@@ -1,5 +1,5 @@
 # Release-Asset-Index
-**Stand:** v300.0.0 — automatisch aktualisierte Asset-Übersicht
+**Stand:** v301.0.0 — automatisch aktualisierte Asset-Übersicht
 
 ## Sammel-Assets
 | Asset | Verwendung |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+# v301.0.0 — Eval-Harness-Vollausbau + Portable-Bundle
+
+## Vollausbau Eval-Harness
+
+- **204/204 Testakten** haben jetzt eine `rubric.yaml` (vorher 5).
+- Neuer `scripts/generate-default-rubrics.py` — erzeugt fuer jede Testakte ohne bestehende Rubric eine Baseline (file_exists README, file_exists gesamt-pdf, file_count >= 1 MD-Aktenstueck, plus human_review-Platzhalter zur sukzessiven Verfeinerung).
+- 5 hand-gepflegte Rubrics mit fachspezifischen Pass/Fail-Checks bleiben (ChainCortex, MedTech-Volkenrath, Meinhardt, Koerber, Sauer).
+- Baseline-Eval-Run: **204/204 All-Pass, 0 Failures**.
+
+## Portable Eval-Harness fuer Fremd-Repos
+
+- Neues Verzeichnis `docs/portable-eval-harness/` mit Drop-In-Anleitung fuer beliebige Legal-AI-Repos.
+- Kopierfertige `rubric.yaml`-Beispiele fuer:
+  - **arbeitszeugnispruefer-skill** — Pruefkorpus als Testakten, mit BAG-Az.-Pattern und Ampel-Symbol-Check.
+  - **vorlagen-fuer-recht** — Vertragsentwurf als Testakte mit Klausel-Checks ($ 613a, Rechtswahl, anwaltliche Endpruefung).
+
+## Versions-Bump
+
+- 213 plugin.json + marketplace.json + README + ASSET_INDEX + CHANGELOG auf v301.0.0.
+
+## Validatoren
+
+- `validate-plugin-structure.mjs` OK
+- `run-eval.py` 204/204 All-Pass
+
+---
+
 # v300.0.0 — Eval-Harness nach Harvey-LAB-Vorbild
 
 ## Neue Werkzeuge

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Für diesen Anwendungsfall gibt es eine kuratierte, nach Fachanwaltschaften sort
 | **Skills (SKILL.md)** | 20859 — [Gesamtübersicht](./SKILLS.md) |
 | **Testakten** | 203 |
 | **Fachanwalts-/-anwältinnen-Profile** | 24 |
-| **Plugin-Version / Arbeitsstand** | `v300.0.0` — [latest Release auf GitHub](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest) |
+| **Plugin-Version / Arbeitsstand** | `v301.0.0` — [latest Release auf GitHub](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest) |
 | **Marketplace-Definition** | [`.claude-plugin/marketplace.json`](./.claude-plugin/marketplace.json) |
 
 ### Sammel-Downloads

--- a/agb-recht-pruefer/.claude-plugin/plugin.json
+++ b/agb-recht-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agb-recht-pruefer",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Gigantischer AGB-Rechtsprüfer und Klausel-Entwerfer für deutsches Recht: §§ 305 bis 310 BGB, UKlaG, B2C/B2B, Branchen-AGB, Redlining, Klauselrisiko und rechtssichere Entwurfsworkflows.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/aktenaufbereiter-strafrecht/.claude-plugin/plugin.json
+++ b/aktenaufbereiter-strafrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aktenaufbereiter-strafrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Aktenaufbereiter für die Strafverteidigung. Sechs Excel-fähige Übersichten — Aktenvorblatt; Personenverzeichnis; Tatkomplexe; Beziehungen; Chronologie; Fristen. Fortlaufend ergaenzbar. Erkennt Luecken und Widersprueche. Kein Ersatz für Aktenlektuere.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/aktenauszug-gerichtsverfahren/.claude-plugin/plugin.json
+++ b/aktenauszug-gerichtsverfahren/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aktenauszug-gerichtsverfahren",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Strukturierter Aktenauszug für deutsche Gerichtsverfahren: Verfahrensidentifikation Einleitungssatz Verfahrenszusammenfassung Sachverhaltschronologie Verfahrensgeschichte tabellarische Gegenüberstellung der Parteivortraege Beweismittel und Rechtsargumente für schnelle Einarbeitung in Akten.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/aktienrecht-hauptversammlung-ag-se/.claude-plugin/plugin.json
+++ b/aktienrecht-hauptversammlung-ag-se/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aktienrecht-hauptversammlung-ag-se",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Hauptversammlungs-Vorbereiter, Leitfaden-Ersteller und Durchführungsplugin für kleine AG, normale AG, börsennotierte AG und SE: Einberufung, Tagesordnung, virtuelle HV, Q&A, Abstimmung, Niederschrift, Anfechtungsrisiko und Post-HV.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/anlagen-zu-schriftsaetzen/.claude-plugin/plugin.json
+++ b/anlagen-zu-schriftsaetzen/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anlagen-zu-schriftsaetzen",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Anlagenmanagement fuer gerichtliche Schriftsaetze: sortiert chaotische Mandantenordner, E-Mails, Scans, Tabellen und Vorversionen zu beA-tauglichen K/B/AST/AG-Anlagen mit Verzeichnis, Konvolutdeckblaettern, Stempel-/Dateinamenregeln, Hashlog, Lueckenliste und Qualitygate.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/apothekenrecht/.claude-plugin/plugin.json
+++ b/apothekenrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apothekenrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Super-Plugin für Apothekenrecht: Betriebserlaubnis, ApBetrO, Versand, E-Rezept, BtM, Retaxation, Aufsicht und Compliance.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/arbeitsrecht/.claude-plugin/plugin.json
+++ b/arbeitsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "arbeitsrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Arbeitsrechtliche Workflows fuer Kuendigung, Befristung, Urlaub, AGG, Aufhebungsvertrag, Betriebsrat, Arbeitszeit, Lohn und Expansion. Rechtsprechung wird nur mit Gericht, Datum, Aktenzeichen und verifizierbarer Quelle verwendet.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/arbeitszeugnis-analyse/.claude-plugin/plugin.json
+++ b/arbeitszeugnis-analyse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "arbeitszeugnis-analyse",
   "displayName": "Arbeitszeugnis-Analyse (Ampelsystem)",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Analyse deutscher Arbeitszeugnisse nach Ampelsystem (Rot/Orange/Grün). Geheimcodes, Schaufenster-Drift, negative Codeworte, Steigerungsadverbien. Satzweise Notenmatrix, begründete Gesamtnotenspanne. Vollständiger Mandatsablauf: Erstgespräch, Mandantenbericht, Aufforderungsschreiben, Klagestrategie.",
   "author": {
     "name": "Klotzkette"

--- a/aufsichtsrat-ag-se-praxis/.claude-plugin/plugin.json
+++ b/aufsichtsrat-ag-se-praxis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aufsichtsrat-ag-se-praxis",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Praxisplugin für Aufsichtsräte in AG und SE: Überwachung, Informationsrechte, Vorstand bestellen/abberufen, Vergütung, Ausschüsse, Protokoll, Business Judgment, Haftungsvermeidung, Börse, SE und Mitbestimmung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/aussenwirtschaft-zoll-sanktionen/.claude-plugin/plugin.json
+++ b/aussenwirtschaft-zoll-sanktionen/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aussenwirtschaft-zoll-sanktionen",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Freistehendes Plugin für Außenwirtschaft, Sanktionen, Zoll, Exportkontrolle, BAFA, TARIC, CBAM, Verbrauchsteuer, AWV, AML/KYC und Ermittlungen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/bank-rechtsabteilung/.claude-plugin/plugin.json
+++ b/bank-rechtsabteilung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bank-rechtsabteilung",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Rechtsabteilung einer mittelgroßen deutschen Bank: Aufsicht, Kredit, Avale, Bürgschaft, Garantien, Trade Finance, ZAG/PSD2, PSD3/PSR-Vorschau, eWpG, MiCAR, Tokenisierung, BaFin, Vorstand, HV und Kanzleisteuerung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/barrierefreiheit-web-checker/.claude-plugin/plugin.json
+++ b/barrierefreiheit-web-checker/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "barrierefreiheit-web-checker",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Web-Barrierefreiheits-Checker für BFSG, BFSGV, BITV 2.0, EN 301 549 und WCAG: Scope, Audit, Tastatur, Screenreader, Formulare, PDFs, Erklärung, Roadmap und Abnahme.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/bav-strategie-konzern/.claude-plugin/plugin.json
+++ b/bav-strategie-konzern/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bav-strategie-konzern",
   "displayName": "Betriebliche Altersversorgung Strategie Konzern",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Strategische Beratung zur betrieblichen Altersversorgung in Konzernen: Pensionsmodelle alle fuenf Durchführungswege CTA Pension Buyouts Drei-Stufen-Theorie Versorgungssystem-Harmonisierung internationale Benefits Restrukturierung DB-zu-DC im Duesseldorfer Boutique-Stil.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/beamtenrecht/.claude-plugin/plugin.json
+++ b/beamtenrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "beamtenrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Beamtenrecht für Bund, Länder und Richterdienst: Status, Laufbahn, Besoldung, Versorgung, Konkurrentenstreit, Disziplinarrecht, Dienstunfähigkeit, Richterlaufbahn, Landesrecht und verständliche Mandatsführung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/bereicherungs-und-anfechtungsrecht-pruefer/.claude-plugin/plugin.json
+++ b/bereicherungs-und-anfechtungsrecht-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bereicherungs-und-anfechtungsrecht-pruefer",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Mechanisches Durchprüfen von Bereicherungsrecht §§ 812 ff. BGB, AnfG und Insolvenzanfechtung §§ 129-147 InsO. Mit KI-Screening von Schuldnerakten, § 135 Gesellschafterdarlehen, Bargeschäft § 142 und Verteidigung des Anfechtungsgegners. Keine Rechtsberatung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/berichtspflichten-erlediger/.claude-plugin/plugin.json
+++ b/berichtspflichten-erlediger/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "berichtspflichten-erlediger",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Berichtspflichten-Erlediger für mittelständische Unternehmen: amtliche Statistik, Portale, Umwelt-, Produkt-, Steuer-, Sozial-, Lieferketten-, Datenschutz- und Aufsichtsmeldungen mit Fristenboard, Datenquellen, Plausibilitätscheck und Behördenkommunikation.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/berufsgerichtliche-verfahren-freie-berufe/.claude-plugin/plugin.json
+++ b/berufsgerichtliche-verfahren-freie-berufe/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "berufsgerichtliche-verfahren-freie-berufe",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin für anwaltsgerichtliche und berufsgerichtliche Verfahren gegen Anwälte, Patentanwälte, Steuerberater, Wirtschaftsprüfer und Notare: Kammeraufsicht, Rüge, Disziplinarverfahren, Zulassung, Vermögensverfall, beA, Werbung, Sachlichkeit und Rechtsmittel.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/berufsrecht-anwaelte/.claude-plugin/plugin.json
+++ b/berufsrecht-anwaelte/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "berufsrecht-anwaelte",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin für anwaltliches Berufsrecht: BRAO, BORA, FAO, beA, Kanzleisitz, Werbung, Interessenkollision, Verschwiegenheit, KI-/Cloud-Outsourcing, Schatten-KI, Berufsausübungsgesellschaft, Gebühren, Kammeraufsicht und anwaltsgerichtliche Risiken.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/berufsrecht-ki-vertragspruefung/.claude-plugin/plugin.json
+++ b/berufsrecht-ki-vertragspruefung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "berufsrecht-ki-vertragspruefung",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Berufsrechtliche und strafrechtliche Vorprüfung von Verträgen mit Legal-AI-Anbietern: § 43e BRAO, § 203 StGB, Consumer-Tool-Abgrenzung, No-Training, Telemetrie, Drittstaat, KI-VO-Rollen, Art.-50-Transparenz, Schatten-KI und Klauselvorschläge.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/berufsrecht-notare/.claude-plugin/plugin.json
+++ b/berufsrecht-notare/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "berufsrecht-notare",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin für Notarrecht: BNotO, BeurkG, DONot, Dienstaufsicht, Urkundspflichten, Neutralität, Verwahrung, Amtspflichten, Vertreter/Verwalter, Disziplinarverfahren und notarielle Berufspraxis.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/berufsrecht-patentanwaelte/.claude-plugin/plugin.json
+++ b/berufsrecht-patentanwaelte/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "berufsrecht-patentanwaelte",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin für Patentanwaltsrecht: PAO, Patentanwaltskammer, Vertretungsbefugnis, Schutzrechtsmandate, Verschwiegenheit, Interessenkollision, Werbung, Berufsausübungsgesellschaft und berufsgerichtliche Risiken.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/berufsrecht-steuerberater/.claude-plugin/plugin.json
+++ b/berufsrecht-steuerberater/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "berufsrecht-steuerberater",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin für Steuerberaterrecht: StBerG, BOStB, Steuerberaterkammer, Vorbehaltsaufgaben, Werbung, Verschwiegenheit, Gebühren, Geldwäsche, Berufsgericht, Berufsausübungsgesellschaft und Haftungsprävention.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/berufsrecht-wirtschaftspruefer/.claude-plugin/plugin.json
+++ b/berufsrecht-wirtschaftspruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "berufsrecht-wirtschaftspruefer",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin für Wirtschaftsprüferrecht: WPO, Berufssatzung, WPK, APAS, Unabhängigkeit, Qualitätskontrolle, Abschlussprüfung, Bestätigungsvermerk, PIE, Berufsaufsicht und berufsgerichtliche Risiken.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/betaeubungsmittelrecht/.claude-plugin/plugin.json
+++ b/betaeubungsmittelrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "betaeubungsmittelrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Betäubungsmittelrecht-Plugin für BtMG, BtMVV, KCanG/MedCanG-Schnittstellen, Strafverfahren, Therapie, ärztliche Praxis, Apotheken und Compliance.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/betreuungsrecht/.claude-plugin/plugin.json
+++ b/betreuungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "betreuungsrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Betreuungsrechtliche Skills für ehrenamtliche Familienbetreuer, Berufs- und Vereinsbetreuer: Kaltstart, Scan-Akte, Kalender, Gerichtskommunikation, Jahresbericht, Vermögensverzeichnis, Genehmigungspflichten, Wunschermittlung, Kontoanalyse und Schutzplan nach BtOG und BGB.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/bgb-at-pruefer/.claude-plugin/plugin.json
+++ b/bgb-at-pruefer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bgb-at-pruefer",
   "displayName": "BGB AT Prüfer",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Großes Prüfplugin zum BGB Allgemeiner Teil: Vertragsschluss, Willenserklärung, Zugang, Geschäftsfähigkeit, Form, qES, beA, Anfechtung, Stellvertretung, Fristen, Verjährung und Routing für digitale Elemente, Update- und Reparaturrecht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/bgb-bt-pruefer/.claude-plugin/plugin.json
+++ b/bgb-bt-pruefer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bgb-bt-pruefer",
   "displayName": "BGB BT Prüfer",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Großer BGB-BT-Prüfer für Schuldrecht Besonderer Teil: Kauf einschließlich Verbrauchsgüterkauf, Waren mit digitalen Elementen, Updatepflichten und Right-to-Repair-Schnittstellen, außerdem Miete, Werk, Bürgschaft, GoA, Bereicherung, Delikt und Rückabwicklung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/buerokratieversteher-entbuerokratisierer/.claude-plugin/plugin.json
+++ b/buerokratieversteher-entbuerokratisierer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "buerokratieversteher-entbuerokratisierer",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Allgemeiner Bürokratieversteher und Entbürokratisierer für Laien, Menschen mit Deutsch als Zweitsprache und alle, die Bescheide, Anträge, Vorladungen, Behördenbriefe, Jugendamt-, Schul-, Bau-, Sozial-, Familien- oder Kommunalverfahren verstehen und vorsichtig bearbeiten wollen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/bundesnetzagentur-verfahren/.claude-plugin/plugin.json
+++ b/bundesnetzagentur-verfahren/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bundesnetzagentur-verfahren",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Großes Regulierungs-Plugin für anwaltliche Arbeit mit der Bundesnetzagentur in Energie, Telekommunikation, Post, Eisenbahn und Digital Services.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/bundeswehrrecht-wehrrecht/.claude-plugin/plugin.json
+++ b/bundeswehrrecht-wehrrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bundeswehrrecht-wehrrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Super-Plugin für Soldatenrecht, Wehrbeschwerde, Disziplinarrecht, Wehrpflicht, Reservisten, Versorgung und Bundeswehrverwaltung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/commercial-courts-deutschland/.claude-plugin/plugin.json
+++ b/commercial-courts-deutschland/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commercial-courts-deutschland",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Commercial-Courts-Plugin für englischsprachige Wirtschaftsverfahren in Deutschland: Zuständigkeit, Wahlklauseln, Klage, Case Management, Beweis, Geheimnisschutz, Wortprotokoll/Transcript, Rechtsmittel, BGH, Kosten, Vollstreckung und bilingualer Schriftsatz-/Hearing-Workflow.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/common-law-kompass/.claude-plugin/plugin.json
+++ b/common-law-kompass/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "common-law-kompass",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Freistehendes Common-Law-Plugin für deutsche Wirtschaftsjuristen: UK/US-False-Friends, Vertragsbegriffe, Consideration, Suretyship, Indemnity, UCC, Precedent, Discovery und bilinguale Drafting-Reviews.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/corporate-kanzlei/.claude-plugin/plugin.json
+++ b/corporate-kanzlei/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corporate-kanzlei",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Corporate-Kanzlei-Plugin: Deal-Kommandocenter, Datenraum, Due Diligence, SPA/APA, Umwandlung, StaRUG, Insolvenzplan, W&I, Signing/Closing, PMI.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/datenbankrecht/.claude-plugin/plugin.json
+++ b/datenbankrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "datenbankrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Großes Plugin zum deutschen und europäischen Datenbankrecht: UrhG §§ 87a ff., Datenbankrichtlinie, Investitionsschutz, Scraping, API, KI-Training, Vertrags- und Plattformkonflikte.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/datenschutz-sanktionsverfahren-verteidigung/.claude-plugin/plugin.json
+++ b/datenschutz-sanktionsverfahren-verteidigung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "datenschutz-sanktionsverfahren-verteidigung",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Spezialplugin für Vertretung und Verteidigung in datenschutzrechtlichen Sanktionsverfahren: DSGVO-Bußgeld, OWiG/StPO, Art.-58-Anordnung, Verwaltungsgericht, Aufsichtsbehördenkommunikation, EuGH/EDPB und Behördenstrategie.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/datenschutzrecht/.claude-plugin/plugin.json
+++ b/datenschutzrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "datenschutzrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "DSGVO/BDSG/TDDDG – PIA/DPIA, AVV-Review, Auskunft Art. 15, Datenpanne Art. 33/34, Drittlandstransfer Art. 44 ff. inkl. US-Transfer, DPF, SCC, TIA, Behördenpaket und Brückenskills zur Sanktionsverteidigung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/designrecht-geschmacksmusterrecht/.claude-plugin/plugin.json
+++ b/designrecht-geschmacksmusterrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "designrecht-geschmacksmusterrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Eigenständiges Plugin für deutsches und europäisches Designrecht: DesignG, EU-Design, DPMA, EUIPO, WIPO-Hague, Neuheit, Eigenart, Anmeldung, Nichtigkeit, Verletzung, Eilrechtsschutz, Zoll, Plattformen und Designverträge.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/deutsche-rechtsgeschichte/.claude-plugin/plugin.json
+++ b/deutsche-rechtsgeschichte/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deutsche-rechtsgeschichte",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Mega-Plugin zur deutschen Rechtsgeschichte: Epochen, Quellenkritik, Rezeption, Reichsrecht, BGB, Weimar, NS-Unrecht, DDR/BRD und rechtsgeschichtliche Argumentation.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/dfg-foerderantrag/.claude-plugin/plugin.json
+++ b/dfg-foerderantrag/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dfg-foerderantrag",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "DFG-Förderantragssteller für Sachbeihilfe, adaptive Anfänger-/Profi-Führung, kleine schnelle Anträge, große Koselleck-Strategien, elan-Formalia, Finanzplan, Reviewer-Red-Team, Forschungsdaten, KI-/Ethik-Check und Wiedereinreichung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/dsa-dma-digitalregulierung/.claude-plugin/plugin.json
+++ b/dsa-dma-digitalregulierung/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dsa-dma-digitalregulierung",
   "displayName": "DSA DMA und Digitalregulierung EU",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Digitalregulierung der EU: DSA (VO 2022/2065) und DMA (VO 2022/1925) plus Data Act DGA AI Act NIS-2 DORA CRA eIDAS 2.0 DDG P2B-VO und § 19a GWB. Gatekeeper-Schwellen VLOP-Einordnung Risikobewertung Art. 34 Forschungsdatenzugang Art. 40 Account-Sperre Art. 20-23 Zustellung Art. 13 DSA Klagewege.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/ecommerce-recht/.claude-plugin/plugin.json
+++ b/ecommerce-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ecommerce-recht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Super-Plugin für Online-Shops, Plattformen, Marktplätze und digitale Verbraucherprozesse.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/einfache-leichte-sprache-jura/.claude-plugin/plugin.json
+++ b/einfache-leichte-sprache-jura/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "einfache-leichte-sprache-jura",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Juristische Texte in Einfache Sprache oder Leichte Sprache übertragen: experimentelle Standard-Annäherung, Zielgruppe klären, Rechtsinhalt sichern und Qualitätsgate nutzen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/einigungsvertrag-vermoegensrecht/.claude-plugin/plugin.json
+++ b/einigungsvertrag-vermoegensrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "einigungsvertrag-vermoegensrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Einigungsvertrag-Plugin für DDR/BRD-Übergangsrecht, Volksvermögen, Parteivermögen, Treuhand, Bodenreform, Mauergrundstücke, VermG und Restitution.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/email-umformulierer-berufsrecht/.claude-plugin/plugin.json
+++ b/email-umformulierer-berufsrecht/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "email-umformulierer-berufsrecht",
   "displayName": "E-Mail-Umformulierer (Berufsrechtskonform)",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Formuliert unfreundliche, emotionale oder unsachliche E-Mails in hoefliche, sachliche und berufsrechtskonform formulierte Texte um. Fokus auf BRAO/BORA-Konformität, mit Varianten für Steuerberater, Notare und allgemeine berufliche Korrespondenz.",
   "author": {
     "name": "Klotzkette"

--- a/energierecht/.claude-plugin/plugin.json
+++ b/energierecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "energierecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Freistehendes Energierecht-Plugin für Stadtwerke, Versorger, Wärme, Netze, Vertrieb, Industrie, EEG, KWKG, Verfahren, Transaktionen und Projektfinanzierung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/erbbaurecht-praxis/.claude-plugin/plugin.json
+++ b/erbbaurecht-praxis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "erbbaurecht-praxis",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Praxisplugin für Erbbaurecht und Erbbaugrundbuch: Erbbaurechtsvertrag, Erbbauzins, Wertsicherung, Heimfall, Zustimmung, Belastung, Finanzierung, Veräußerung, Laufzeit, Entschädigung, Zwangsversteigerung, Rang und Grundbuchvollzug.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/europarecht-kompass/.claude-plugin/plugin.json
+++ b/europarecht-kompass/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "europarecht-kompass",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Freistehendes Europarecht-Plugin gegen deutsche Denkfehler: Vorrang, unmittelbare Wirkung, Richtlinien, Verordnungen, Charta, Grundfreiheiten, Beihilfen, Vorlageverfahren und EU-Drafting.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-agrarrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-agrarrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-agrarrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin Fachanwalt für Agrarrecht. Höferecht (HöfeO Anerbenrecht Länder) Landpachtrecht BGB §§ 581 ff. GAP EU-Direktzahlungen Cross-Compliance Düngeverordnung Pflanzenschutz Tierschutz Forstrecht. Schnittstelle Plugin fachanwalt-erbrecht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-arbeitsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-arbeitsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-arbeitsrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Fachanwalt-Arbeitsrecht nach FAO Paragraf 10: KSchG, BetrVG, TzBfG, AGG, EntgTranspG, Urlaub, Betriebsrat, Befristung und Vergleichspraxis. Rechtsprechung nur mit Datum, Aktenzeichen und verifizierter Quelle.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-bank-kapitalmarktrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-bank-kapitalmarktrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-bank-kapitalmarktrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin Fachanwalt für Bank- und Kapitalmarktrecht. KWG ZAG WpHG WpIG MiFID-II MAR MiCAR Verbraucherkredit Bürgschaft Aval Bankgarantie Vermögensanlage Beratungshaftung. Schnittstellen Plugin gesellschaftsrecht regulatorisches-recht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-bau-architektenrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-bau-architektenrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-bau-architektenrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin Fachanwalt für Bau- und Architektenrecht. BGB Werkvertrag VOB-A VOB-B VOB-C HOAI Bauordnungsrecht. Bauvertrag Maengelhaftung Abnahme Vergaberecht. Schnittstellen Plugin fachanwalt-vergaberecht kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-erbrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-erbrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-erbrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin Fachanwalt für Erbrecht. BGB Erbrecht §§ 1922 ff. Pflichtteil Testament Erbschein Erbauseinandersetzung Erbschaftsteuer EU-ErbVO. Schnittstellen Plugin steuerrecht-anwalt-und-berater kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-familienrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-familienrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-familienrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin Fachanwalt für Familienrecht. Orientierung Normen Mandate Fristen Literatur. Familiengericht FamFG Scheidung Sorge Umgang Unterhalt Zugewinn Ehevertrag eingetragene Lebenspartnerschaft. Ergaenzend zum Plugin kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-gewerblicher-rechtsschutz/.claude-plugin/plugin.json
+++ b/fachanwalt-gewerblicher-rechtsschutz/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-gewerblicher-rechtsschutz",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin Fachanwalt für gewerblichen Rechtsschutz nach FAO § 14k. MarkenG. DesignG. UWG. PatG GebrMG. UrhG-Bezuege. Markenanmeldung DPMA EUIPO. UWG-Abmahnung §§ 8 ff. UWG. Designverletzung. Einstweilige Verfuegung Verletzungsklage Lizenzanaloger Schadensersatz.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-handels-gesellschaftsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-handels-gesellschaftsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-handels-gesellschaftsrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin Fachanwalt für Handels- und Gesellschaftsrecht nach FAO § 14i. HGB. AktG. GmbHG. PartGG. UmwG. Geschäftsführerhaftung §§ 43 GmbHG 93 AktG. Gesellschafterstreit Beschlussanfechtung. Handelsvertreterausgleich § 89b HGB. MoPeG GbR seit 2024. Schnittstellen kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-insolvenz-sanierungsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-insolvenz-sanierungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-insolvenz-sanierungsrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin Fachanwalt für Insolvenz- und Sanierungsrecht nach FAO § 14. InsO Eroeffnung Antragspflicht § 15a Gläubigerantrag § 14 InsO. StaRUG Restrukturierungsplan. Insolvenzanfechtung §§ 129 ff. InsO. Schnittstellen insolvenzrecht und steuerrecht-anwalt-und-berater.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-internationales-wirtschaftsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-internationales-wirtschaftsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-internationales-wirtschaftsrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin Fachanwalt für Internationales Wirtschaftsrecht. CISG Bruessel Ia Rom I Rom II Schiedsverfahren ICC UNCITRAL Investitionsschutz ICSID WTO EU-Aussenhandel LkSG. Schnittstelle Plugin kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-it-recht/.claude-plugin/plugin.json
+++ b/fachanwalt-it-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-it-recht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin Fachanwalt für Informationstechnologierecht. SaaS Software-Lizenz DSGVO BDSG TTDSG TKG NIS2 DDG DSA DMA EU-KI-VO Open-Source. Schnittstellen Plugin datenschutzrecht ki-governance kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-medizinrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-medizinrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-medizinrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin Fachanwalt für Medizinrecht. Arzthaftung §§ 630a ff. BGB Patientenrechte Vertragsarztrecht Berufsrecht Aerzte SGB V Krankenversicherung MPDG Apothekenrecht. Schnittstellen Plugin fachanwalt-sozialrecht und kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-miet-wohnungseigentumsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-miet-wohnungseigentumsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-miet-wohnungseigentumsrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Großer Fachanwalt-Kompass Miet- und Wohnungseigentumsrecht mit über 200 Skills für Wohnraum, Gewerberaum, Betriebskosten, WEG, Hausverwaltung, Beschlüsse, GEG, Beweise, Fristen und Workflows.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-migrationsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-migrationsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-migrationsrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Großer Fachanwalt-Kompass Migrationsrecht mit über 200 Skills für Aufenthalt, Blaue Karte EU, Fachkräfte, Asyl, Dublin/GEAS, Einbürgerung, Staaten-/Gebietschecks und spanische/einfache Erklärung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-sozialrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-sozialrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-sozialrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin Fachanwalt für Sozialrecht nach FAO § 11. SGB I-XII und Sozialgerichtsbarkeit SGG. Widerspruch § 84 SGG Klage § 87 SGG Eilantrag § 86b SGG. Buergergeld Erwerbsminderung GdB Pflegegrad Hilfsmittel Eingliederungshilfe. Bescheidanalyse Akteneinsicht PKH Fristenbuch.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-sportrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-sportrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-sportrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin Fachanwalt für Sportrecht. Verbandsrecht (DFB FIFA UEFA IOC DOSB) CAS Schiedsverfahren Spielerverträge Doping WADA-Code NADA Sponsoring Persönlichkeitsrechte Veranstalterhaftung. Schnittstelle Plugin gesellschaftsrecht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-strafrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-strafrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-strafrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin Fachanwalt Strafrecht: StPO/StGB, Nebenstrafrecht, Verteidigung, Ermittlungsverfahren, HV, Revision, Nebenklage und Zeugenbeistand plus Strafprozess-Cockpit fuer Fristen, Aktenlog, U-Haft, Akteneinsicht, HV-Tagesmappe, Antragslog und Mandanteninstruktionen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-transport-speditionsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-transport-speditionsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-transport-speditionsrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin Fachanwalt für Transport- und Speditionsrecht. HGB §§ 407 ff. Frachtvertrag §§ 453 ff. Spedition CMR COTIF Montrealer Übereinkommen Haager Visby Regeln ADSp. Schnittstelle Plugin kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-urheber-medienrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-urheber-medienrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-urheber-medienrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin Fachanwalt für Urheber- und Medienrecht. UrhG UWG KUG Recht am eigenen Bild Presserecht Persoenlichkeitsrecht Medienstaatsvertrag. Schnittstellen Plugin gewerblicher-rechtsschutz verlagsredaktion kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-vergaberecht/.claude-plugin/plugin.json
+++ b/fachanwalt-vergaberecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-vergaberecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin Fachanwalt fuer Vergaberecht als Vergabe-Workbench: GWB 97 ff., VgV, UVgO, SektVO, KonzVgV, VOB/A, Schwellenwerte 2026/2027, Vergabeakte, Ruge, Nachpruefung, TED/eForms, Wettbewerbsregister und Foerdermittel.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-verkehrsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-verkehrsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-verkehrsrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin Fachanwalt für Verkehrsrecht. StVG StVO PflVG VVG-Bezuege. Verkehrsunfall Personen- und Sachschaden Bußgeld Fahrerlaubnis Verkehrsstrafrecht (§§ 315c 316 StGB). Schnittstelle Plugin kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-versicherungsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-versicherungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-versicherungsrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin Fachanwalt für Versicherungsrecht. VVG VAG Berufsunfähigkeit private Krankenversicherung Lebens- und Rentenversicherung Sachversicherung Haftpflicht D-und-O. Schnittstelle Plugin kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fachanwalt-verwaltungsrecht/.claude-plugin/plugin.json
+++ b/fachanwalt-verwaltungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fachanwalt-verwaltungsrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin Fachanwalt für Verwaltungsrecht. VwGO VwVfG. Anfechtungs- und Verpflichtungsklage Eilrechtsschutz § 80 Abs 5 VwGO einstweilige Anordnung Normenkontrolle Polizei- und Ordnungsrecht. Schnittstelle Plugin kanzlei-allgemein.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/factoring-recht/.claude-plugin/plugin.json
+++ b/factoring-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "factoring-recht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Super-Plugin für Factoring, Forderungskauf, Aufsichtsrecht, Vertragsgestaltung, Debitorenkommunikation, Insolvenz- und Sanierungsfragen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fahrgastrechte/.claude-plugin/plugin.json
+++ b/fahrgastrechte/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fahrgastrechte",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Fahrgastrechte im Eisenbahnverkehr nach VO (EU) 2021/782 und EVO 2023: Verspaetung/Ausfall einordnen, Entschaedigung berechnen (25/50 Prozent), Forderung an die DB, Widerspruch, Schlichtung und Klage zum AG. Katalog DB-Ablehnungsgruende.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fashion-law-moderecht/.claude-plugin/plugin.json
+++ b/fashion-law-moderecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fashion-law-moderecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Praxisplugin Fashion Law/Moderecht für Modeunternehmen, Designer, Händler und Kanzleien: IP, Designs, Marken, Textilkennzeichnung, Produktsicherheit, Nachhaltigkeit, Lieferkette, Plattformen, E-Commerce, Vertrieb, Influencer und Krisen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/festlandchina-wirtschaftsverkehr/.claude-plugin/plugin.json
+++ b/festlandchina-wirtschaftsverkehr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "festlandchina-wirtschaftsverkehr",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Mega-Plugin für wirtschaftlichen Umgang mit Festlandchina: Fabrik, Import, Export, Investition, De-Risking, Lieferkette, IP, Daten, Exportkontrolle und politisches Risiko.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fluggastrechte/.claude-plugin/plugin.json
+++ b/fluggastrechte/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fluggastrechte",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Fluggastrechte selber geltend machen nach VO (EG) Nr. 261/2004. Tickets erfassen, Annullierung oder Verspaetung pruefen, aussergewoehnliche Umstaende, Distanz, Ausgleich, Forderungsschreiben, Mahnung und Klage. Rechtsprechung nur nach Live-Verifikation.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/forderungsmanagement-klagewerkstatt/.claude-plugin/plugin.json
+++ b/forderungsmanagement-klagewerkstatt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forderungsmanagement-klagewerkstatt",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Klagewerkstatt für Forderungsmanagement mit Zuständigkeitsprüfung, Mahnvorlauf, Inkasso-Zahlungsklage und Anspruchs-Gatekeeper: Nur klare, fällige und belegte Forderungen werden zur Klage freigegeben.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/forschungszulage-antragstellung/.claude-plugin/plugin.json
+++ b/forschungszulage-antragstellung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forschungszulage-antragstellung",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Forschungszulage-Antragstellung nach FZulG: adaptiver Fördercheck, BSFZ-Portaltexte mit Zeichenbudgets, Finanzamt-Antrag, FuE-Abgrenzung, Bemessungsgrundlage 2026, Auszahlung, Verlust-/Insolvenzlage, Dokumentation, Beihilfen, Einspruch und Mehrjahresroadmap.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/fortbestehensprognose/.claude-plugin/plugin.json
+++ b/fortbestehensprognose/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fortbestehensprognose",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Fortbestehensprognose § 19 Abs. 2 InsO als Geschäftsführer-Selbstdokumentation. Bilanzstatus Annahmen Plausibilisierung Zwoelf-Monats-Liquiditaet. Sanierungsbausteine Patronatserklärung Comfortletter Rangrücktritt Stundung Forderungsverzicht. IDW S 11 StaRUG. Eskalation bei negativer Prognose.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/franchiserecht-praxis/.claude-plugin/plugin.json
+++ b/franchiserecht-praxis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "franchiserecht-praxis",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Wirtschaftsrechtliches Plugin für Franchise-Systeme: vorvertragliche Aufklärung, Handbuch, Gebühren, Gebietsschutz, Kartellrecht, Kündigung, Expansion, Streit und Insolvenz.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gebrauchsmusterrecht/.claude-plugin/plugin.json
+++ b/gebrauchsmusterrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gebrauchsmusterrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Eigenständiges Plugin für deutsches Gebrauchsmusterrecht: GebrMG, DPMA-Anmeldung, Recherche nach § 7 GebrMG, Abzweigung, Neuheitsschonfrist, Verletzung, Löschung, BPatG-Beschwerde, Lizenz, FTO und Schnellschutz für technische Produkte.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/geldwaeschepraevention-aml-kyc/.claude-plugin/plugin.json
+++ b/geldwaeschepraevention-aml-kyc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "geldwaeschepraevention-aml-kyc",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Freistehendes Plugin für Geldwäscheprävention, AML, KYC, GwG-Risikoanalyse, UBO, PEP, Sanktionen, FIU/goAML, Transparenzregister und Behördenverfahren.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gesellschaftsgruender/.claude-plugin/plugin.json
+++ b/gesellschaftsgruender/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gesellschaftsgruender",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Anfängerfreundlicher Gründungsassistent für deutsche Gesellschaften: Rechtsformwahl, Satzung, SHA, Cap Table, Notar, Handelsregister, Bank/KYC, Behörden, Steuerstart, IP, Datenschutz, erste 100 Tage und Streitprävention.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gesellschaftsrecht-legal-english/.claude-plugin/plugin.json
+++ b/gesellschaftsrecht-legal-english/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gesellschaftsrecht-legal-english",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Didaktisches Gesellschaftsrecht — English Business Terms: Corporate Legal English fuer Big-Law-Anfaenger. Dealroom: Cap Table vs Gesellschafterliste; Term Sheet; SHA; Vesting; Drag/Tag; Liquidation Preference; Anti-Dilution; SPA; DD; Notar/HR; Multi-Format-Auswertung; Frankfurt-Startup-Akte.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gesellschaftsrecht/.claude-plugin/plugin.json
+++ b/gesellschaftsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gesellschaftsrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Gesellschaftsrecht – GmbH/AG/Personengesellschaften, M&A-Due-Diligence ohne Discovery (Q&A + Datenraum), Gesellschafterbeschlüsse, HRB/HRA-Anmeldungen, Closing Checklists, Compliance-Fristen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gesellschaftsrechtliche-treuepflicht/.claude-plugin/plugin.json
+++ b/gesellschaftsrechtliche-treuepflicht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gesellschaftsrechtliche-treuepflicht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Großes Prüfplugin zur gesellschaftsrechtlichen Treuepflicht in GmbH, AG, SE, Personengesellschaft, Familiengesellschaft und Konzern: Stimmrecht, Minderheitenschutz, Gesellschafterliste, Einziehung, Ausschluss, Konkurrenz, Sanierung, Treuepflichtverletzung und Rechtsfolgen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/gewerblicher-rechtsschutz/.claude-plugin/plugin.json
+++ b/gewerblicher-rechtsschutz/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gewerblicher-rechtsschutz",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Gewerblicher Rechtsschutz – DPMA/EUIPO-Markenrecherche und -anmeldung, Freedom-to-Operate, Patentscreening, UWG- und Urheberrechts-Abmahnung (Versand und Reaktion), Open-Source-Compliance, IP-Klausel-Review, Schutzrechts-Fristen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/goae-gebuehrenordnung-aerzte/.claude-plugin/plugin.json
+++ b/goae-gebuehrenordnung-aerzte/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "goae-gebuehrenordnung-aerzte",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Super-Plugin zur GOÄ: private Arztrechnungen prüfen, erstellen, begründen, beanstanden und prozessual verwerten.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/grosskanzlei-corporate-ma/.claude-plugin/plugin.json
+++ b/grosskanzlei-corporate-ma/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "grosskanzlei-corporate-ma",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Freistehendes Big-Law-Corporate/M&A-Plugin: Deal-OS, Padlet-Canvas, Anfänger-/First-Year-Coach, Aktenanlage, Datenraum, Legal DD, Tabellenreview, SPA/APA, W&I, Public M&A, UmwG/UmwStG, StaRUG, Fusionskontrolle, FDI, FSR, Signing/Closing, PMI und 125 Spezial-Skills.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/grundbuchamt-praxis/.claude-plugin/plugin.json
+++ b/grundbuchamt-praxis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "grundbuchamt-praxis",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Praxisplugin für Grundbuchamt, Grundbuchauszug und grundbuchtaugliche Nachweise: Abteilung I/II/III lesen, Bewilligung, Antrag, Auflassung, Rang, Zwischenverfügung, Beschwerde, Grundschuldbrief, Aufgebot, Dienstbarkeiten, Vormerkung, Vorkaufsrecht, Teilung und Vollzug.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/handelsrecht-hgb/.claude-plugin/plugin.json
+++ b/handelsrecht-hgb/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "handelsrecht-hgb",
   "displayName": "Handelsrecht HGB",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Reines HGB-Plugin für Handelsrecht: Kaufmann, Handelsregister, Firma, Prokura, Handlungsvollmacht, Handelsgeschäfte, Handelskauf, Handelsvertreter, Makler, Kommission, Fracht, Spedition, Lager, Handelsbücher sowie OHG/KG einschließlich MoPeG-Statuswechsel von GbR zu OHG.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/handelsregister-praxis/.claude-plugin/plugin.json
+++ b/handelsregister-praxis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "handelsregister-praxis",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Praxisplugin für den Umgang mit dem Handelsregister: Anmeldung, Registergericht, Rechtspfleger, Registerrichter, Beanstandung, Zwischenverfügung, Beschwerde, Gesellschafterliste, Kapitalmaßnahmen, Firma, Vertretung, Prokura, Löschung, Insolvenzvermerk und registerfeste Nachweise.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/handelsvertreterrecht/.claude-plugin/plugin.json
+++ b/handelsvertreterrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "handelsvertreterrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Handelsvertreterrecht nach HGB: Status, Provision, Buchauszug, Kündigung, Ausgleich § 89b, Wettbewerbsverbot § 90a und Vertriebsmodelle.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/hausarbeitenmacher/.claude-plugin/plugin.json
+++ b/hausarbeitenmacher/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hausarbeitenmacher",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Didaktisches Plugin für juristische Hausarbeiten und Seminararbeiten. Führt sokratisch durch Zivilrecht öffentliches Recht Strafrecht mit Ausfluegen in Europarecht und Rechtstheorie. Adressaten-Strategie ohne Schleimerei. Liefert keine fertigen Lösungen sondern führt zur eigenen Subsumtion.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/haushaltsrecht-bho-bund-laender/.claude-plugin/plugin.json
+++ b/haushaltsrecht-bho-bund-laender/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "haushaltsrecht-bho-bund-laender",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Großes Haushaltsrecht-Plugin für BHO, HGrG, Bundeshaushalt, Länderhaushalte, Titelanalyse, Umschichtung, Sondervermögen, Szenarien und Dashboard.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/hinweisgeberschutz-compliance/.claude-plugin/plugin.json
+++ b/hinweisgeberschutz-compliance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hinweisgeberschutz-compliance",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Hinweisgeberschutzgesetz in der Praxis: interne/externe Meldestelle, NDA-Konflikte, Repressalien, Untersuchungen, Datenschutz und Governance.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/hoai-leistungsphasen-praxis/.claude-plugin/plugin.json
+++ b/hoai-leistungsphasen-praxis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hoai-leistungsphasen-praxis",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Großplugin für HOAI-Leistungsphasen 1 bis 9: Grundlagenermittlung, Vorplanung, Entwurf, Genehmigung, Ausführungsplanung, Vergabe, Bauüberwachung, Objektbetreuung, Honorar, Vertrag, Haftung, Nachträge und Bauprojektsteuerung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/hochschulrecht-laender/.claude-plugin/plugin.json
+++ b/hochschulrecht-laender/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hochschulrecht-laender",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Hochschulrecht der Länder: Hochschulgesetze, Satzungen, Gremien, Zulassung, Exmatrikulation, Berufung, Drittmittel, Promotion und Aufsicht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/immobilienrechtspraxis/.claude-plugin/plugin.json
+++ b/immobilienrechtspraxis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "immobilienrechtspraxis",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Werkzeuge fuer immobilienrechtliche Rechtsabteilungen: musterbasierte Vertragserstellung mit Klauselschutz, Vertragspruefung gegen Playbook, Grundbuchanalyse, Sachverhaltsermittlung, Mieteranfragen, Case Management und AVV-Pruefung. Rechtsprechung nur nach Live-Verifikation.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/influencer-recht/.claude-plugin/plugin.json
+++ b/influencer-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "influencer-recht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin für Influencer, Creator, Agenturen und Unternehmen: Werbekennzeichnung, Steuer, Umsatzsteuer, Sachleistungen, Plattformrecht, Medienrecht, Marken, Urheberrecht, Datenschutz und Verträge.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/informationsfreiheit-presseauskunft/.claude-plugin/plugin.json
+++ b/informationsfreiheit-presseauskunft/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "informationsfreiheit-presseauskunft",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "IFG-, Transparenz-, UIG-, VIG- und Presseauskunfts-Plugin für Bund, Länder und Behörden: Antrag, Kosten, Fristen, Widerspruch, Klage und Tracking.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/insiderrecht-compliance/.claude-plugin/plugin.json
+++ b/insiderrecht-compliance/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "insiderrecht-compliance",
   "displayName": "Insiderrecht Compliance",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Insiderrecht- und Marktmissbrauchs-Compliance nach MAR, WpHG und BaFin-Praxis: Insiderinformationen, Ad-hoc, Insiderlisten, Handelsverbote, Aufschub, Directors Dealings, Aufklärung und Verteidigung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/insolvenzforderungsanmeldungspruefung/.claude-plugin/plugin.json
+++ b/insolvenzforderungsanmeldungspruefung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insolvenzforderungsanmeldungspruefung",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Freistehendes Plugin für die Insolvenzforderungsanmeldungsprüfung: Intake, § 174 InsO, Belege, Grund, Betrag, Rang, vbuH, Nachforderungen, Tabellenimport, Prüfungstermin, Bestreiten, Feststellung, Tabellenauszug und Verteilung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/insolvenzplan-starug-planwerkstatt/.claude-plugin/plugin.json
+++ b/insolvenzplan-starug-planwerkstatt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insolvenzplan-starug-planwerkstatt",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Freistehendes Plugin für Insolvenzplan und StaRUG-Restrukturierungsplan: Intake, Sanierungskonzept, Vergleichsrechnung, Gruppen, Klassen, darstellender und gestaltender Teil, Anlagen, Abstimmung, Cram-down, Minderheitenschutz, Gericht und Planvollzug.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/insolvenzrecht/.claude-plugin/plugin.json
+++ b/insolvenzrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insolvenzrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Insolvenzrechtliche Skills zu Zahlungsunfähigkeit, Überschuldung, Antragspflicht und Gläubigerantrag.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/insolvenzverwaltung/.claude-plugin/plugin.json
+++ b/insolvenzverwaltung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insolvenzverwaltung",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Freistehendes Insolvenzverwaltungs-Plugin aus Sicht von Insolvenzverwalter, Sachwalter und vorläufiger Verwaltung: Regelverfahren, Eigenverwaltung, Schutzschirm, Anfechtung, § 15b InsO, Masse, Forderungsprüfung, Insolvenzplan, StaRUG-Planwerkstatt, Gutachten, Berichte und Schlussrechnung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/internal-investigations-praxis/.claude-plugin/plugin.json
+++ b/internal-investigations-praxis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "internal-investigations-praxis",
   "displayName": "Internal Investigations Praxis",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Internal-Investigations-Praxisplugin fuer Kanzleien und Unternehmen: Untersuchungsauftrag, Scope, Interviews, Arbeitsrecht, Datenschutz, Privilege-Risiko, StPO-Beschlagnahme, HinSchG, Dokumentation und Verteidigung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/internationales-handelsrecht-lex-mercatoria/.claude-plugin/plugin.json
+++ b/internationales-handelsrecht-lex-mercatoria/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "internationales-handelsrecht-lex-mercatoria",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Mega-Plugin für internationales Handelsrecht, CISG, Incoterms, UNIDROIT Principles, Lex Mercatoria, Schiedsverfahren, Trade Finance und Lieferkettenverträge.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/jurastudium/.claude-plugin/plugin.json
+++ b/jurastudium/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jurastudium",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Studium und Referendariat – Prüfungsgespräch nach AG-Tradition, Subsumtionslehre, Methodenlehre (Zivilrecht, Strafrecht, Öffentliches Recht), Rechtsgeschichte, Lernstrategien, Lösungsschemata, Gutachtenstil, Klausurkorrektur, Lernplanung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/juristische-sprache-deutsch-als-zweitsprache/.claude-plugin/plugin.json
+++ b/juristische-sprache-deutsch-als-zweitsprache/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "juristische-sprache-deutsch-als-zweitsprache",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin fuer Menschen im deutschen Recht mit anderer Herkunftssprache: einfache Erklaerungen, Juristendeutsch, Bescheide, Schriftsaetze, Grammatik, Fristen und Verfahrenslogik.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/jveg-kostenpruefer/.claude-plugin/plugin.json
+++ b/jveg-kostenpruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jveg-kostenpruefer",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Freistehender JVEG-Kostenprüfer für Zeugenentschädigung, Vorschuss, Fahrtkosten, Übernachtung, Verdienstausfall, Sachverständigen- und Dolmetscherkosten, Fristen, Festsetzung, Beschwerde und belegfeste Rechenprotokolle.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kanzlei-allgemein/.claude-plugin/plugin.json
+++ b/kanzlei-allgemein/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanzlei-allgemein",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Kanzlei-Allgemein-Plugin (fusioniert mit Cowork): edles Kommandocenter Mandatsannahme/GwG Klage/Replik Vertrag Rechtsprechung Handelsregister beA-Journal Rechnung UStVA Fristenbuch Timesheet RVG Versand-Vor-Check Posteingang Mandantenakte Mahnwesen Tagesbrief Geburtstage Weihnachtskarten.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kanzlei-builder-hub/.claude-plugin/plugin.json
+++ b/kanzlei-builder-hub/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanzlei-builder-hub",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Findet, prüft und installiert Community-Skills mit Security-Review-Gate vor dem Deployment in die Kanzleiumgebung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kanzlei-management/.claude-plugin/plugin.json
+++ b/kanzlei-management/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanzlei-management",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Mega-Plugin für Kanzlei-Management: Managing Partner, Management Committee, Cashflow, Pricing, UBT, FTE, Utilization, WIP, Associates, Partnerkreis und Dashboards.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kanzlei-mandant-lifecycle/.claude-plugin/plugin.json
+++ b/kanzlei-mandant-lifecycle/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanzlei-mandant-lifecycle",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Lifecycle-Plugin für Kanzlei, Mandant und Rechtsabteilung: Mandatsstart, OCG, Budget, Dashboard, Rechnung, Litigation, Erwartungsmanagement und Relationship-Governance.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kartellrecht-marktabgrenzung-pruefung/.claude-plugin/plugin.json
+++ b/kartellrecht-marktabgrenzung-pruefung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kartellrecht-marktabgrenzung-pruefung",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Globales Kartellrecht/Competition Law: GWB, Art 101/102 AEUV, Fusionskontrolle, BKartA, DG Competition, FTC/DOJ, ICN-Jurisdiktionen, Dawn Raids, Marktabgrenzung, Missbrauch, Private Enforcement.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/ki-governance/.claude-plugin/plugin.json
+++ b/ki-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ki-governance",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "EU-KI-VO + DSGVO – Use-Case-Triage, KI-Inventar, AIA/DPIA, Vendor-Review, Drift-Monitoring der KI-Richtlinie.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/ki-richtlinie-kanzleien/.claude-plugin/plugin.json
+++ b/ki-richtlinie-kanzleien/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ki-richtlinie-kanzleien",
   "displayName": "KI-Richtlinie fuer Kanzleien und Rechtsabteilungen",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Erstellt und pflegt eine berufsrechtskonforme KI-Nutzungsrichtlinie für Kanzleien und Rechtsabteilungen mit Anwaelten und Syndikus-Anwaelten. Beruht auf BRAO, BORA, DSGVO, KI-Verordnung sowie BRAK- und DAV-Hinweisen.",
   "author": {
     "name": "Klotzkette"

--- a/ki-vo-ai-act-pruefer/.claude-plugin/plugin.json
+++ b/ki-vo-ai-act-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ki-vo-ai-act-pruefer",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Mechanik-Workflow zur KI-VO (EU 2024/1689): KI-System-Definition, Rollen, Risikoklassen, Hochrisiko-Diagnose, GPAI, Art. 43-Konformitätsbewertung, CE/EU-DB, Marktbeobachtung, Konformitäts-Evidence-Pack, KI-Kompetenz, Shadow-AI, Berufsrecht, Hochschul- und Behördenpraxis.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kommunalrecht-laender/.claude-plugin/plugin.json
+++ b/kommunalrecht-laender/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kommunalrecht-laender",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Großes Kommunalrecht-Plugin für Gemeinden, Städte, Landkreise, Satzungen, Räte, Bürgerbegehren, Kommunalfinanzen, Aufsicht und Landesrecht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/krankenhausrecht/.claude-plugin/plugin.json
+++ b/krankenhausrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "krankenhausrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Super-Plugin für deutsches Krankenhausrecht: Planung, Finanzierung, Entgelte, Reform, Qualität, MD-Prüfung, Klinikbetrieb und Rechtsstreit.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/krankenkassenrecht-krankenversicherung/.claude-plugin/plugin.json
+++ b/krankenkassenrecht-krankenversicherung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "krankenkassenrecht-krankenversicherung",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin für GKV, PKV, Beihilfe-Schnittstellen und Krankenversicherungsrecht: Leistungen, Beiträge, Krankengeld, Hilfsmittel, Widerspruch, MD, Versicherungsvertrag und Kostenerstattung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/kriegsdienstverweigerung-wehrdienst/.claude-plugin/plugin.json
+++ b/kriegsdienstverweigerung-wehrdienst/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kriegsdienstverweigerung-wehrdienst",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Praxisplugin für Kriegsdienstverweigerung und Wehrdienst aus Gewissensgründen: Art. 4 Abs. 3 GG, KDVG n. F. 2026, Antrag über BAPersBw, BAFzA-Entscheidung, Gewissensbegründung, Soldaten, Reservisten, Rechtsschutz und saubere Abgrenzung zur Totalverweigerung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/krisenfrueherkennung-starug/.claude-plugin/plugin.json
+++ b/krisenfrueherkennung-starug/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "krisenfrueherkennung-starug",
   "displayName": "Krisenfrüherkennung und StaRUG-Management",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Krisenfrüherkennung und Krisenmanagement nach StaRUG: Pflicht zum 24-Monats-Frühwarnsystem nach § 1 StaRUG, § 102 StaRUG Warnpflicht der Berater, Geschäftsführerhaftung, drohende Zahlungsunfähigkeit, integrierte Planung, Restrukturierungsplan und Stabilisierungsanordnung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/leasingrecht-praxis/.claude-plugin/plugin.json
+++ b/leasingrecht-praxis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "leasingrecht-praxis",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Wirtschaftsrechtliches Praxisplugin für Leasing, Sale-and-lease-back, Equipment Finance, Fahrzeugflotten, IT-Leasing, Insolvenz, Restwert, Sicherheiten und Vertragsgestaltung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/legistik-werkstatt/.claude-plugin/plugin.json
+++ b/legistik-werkstatt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legistik-werkstatt",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Legistik-Werkstatt für Ministerien, Bundestag, Fraktionen/Opposition, Länder, Landtage und Normgeber. Baut Referenten- und Kabinettsentwürfe, Vorlagen aus der Mitte, Änderungs-/Entschließungsanträge, Rechtsverordnungen und Satzungen mit Begründung, Synopse, XML und Prüfpfaden.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/liquiditaetsplanung/.claude-plugin/plugin.json
+++ b/liquiditaetsplanung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "liquiditaetsplanung",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Liquiditaetsplanung nach deutschem Recht: 3-Wochen-Vorschau, 13/26/52-Wochen-Forecast, Excel-Export, Quote/Luecken-Ampel, Dokumentationspaket und Schnittstellen zu Fortbestehensprognose und Insolvenzrecht. Rechtsprechung nur nach Live-Verifikation.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/lizenzvertragsersteller/.claude-plugin/plugin.json
+++ b/lizenzvertragsersteller/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lizenzvertragsersteller",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Baukastensystem fuer IP-Lizenzvertraege deutsches und internationales Recht. 32 Skills: Urheber Patent Marken Design Gebrauchsmuster Geschaeftsgeheimnis Know-how; Klausel-Bausteine, Quellcode-Escrow, Insolvenz-Klausel, Sicherungslizenz, TT-GVO, DSGVO, Quellensteuer, Output DE EN bilingual.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/lobbyregister-bundestag/.claude-plugin/plugin.json
+++ b/lobbyregister-bundestag/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lobbyregister-bundestag",
   "displayName": "Lobbyregister Bundestag",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Lobbyregister-Bundestag-Superplugin mit 50 geführten Skills für Registrierungspflicht, Ausnahmen, Registereintrag, Regelungsvorhaben, Stellungnahmen, Finanzdaten, Aktualisierung, Verhaltenskodex, Meldung von Verstoessen und Fristen nach LobbyRG.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/luftrecht-flughafenrecht/.claude-plugin/plugin.json
+++ b/luftrecht-flughafenrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "luftrecht-flughafenrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Luftrecht-Plugin für LuftVG, LuftSiG, LBA, Flughäfen, Airlines, Slots, Flugzeugpfandrechte, Beschlagnahme, Insolvenz, Drohnen und Aviation-Compliance.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/mandantenanfragen-assistent/.claude-plugin/plugin.json
+++ b/mandantenanfragen-assistent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mandantenanfragen-assistent",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Assistent für Anwaltskanzleien zur Erstantwort auf Mandantenanfragen per E-Mail: dankt foermlich übernimmt die Anrede aus der eingehenden E-Mail nennt die telefonische Terminvergabe bittet um Sachverhalt per E-Mail oder bietet eine Telefon-Transkription mit DSGVO-Einwilligungshinweis an.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/markenrecht-fashion-luxus/.claude-plugin/plugin.json
+++ b/markenrecht-fashion-luxus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markenrecht-fashion-luxus",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Großes Markenrechts-Plugin für DE/EU/US und internationale Portfolios: DPMA, EUIPO, WIPO/Madrid, USPTO, Markenarten, Schutzhindernisse, Benutzung, Widerspruch, Verfall/Nichtigkeit, Enforcement, Plattformen, Zoll, Lizenzen und Luxus-Fashion-Spezialfälle.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/meinungspruefer/.claude-plugin/plugin.json
+++ b/meinungspruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meinungspruefer",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Meinungsprüfer für Äußerungsrecht: Meinung oder Tatsache, Beleidigung, üble Nachrede, Verleumdung, § 188 StGB, Art. 5 GG, Art. 10 EMRK, Art. 11 GRCh, EGMR/EuGH, OLG-Praxis, US-Supreme-Court-Vergleich, Zivilrecht, Plattformen, Social Media, Arbeitsplatz, Schule und kommunale Machtkritik.",
   "author": {
     "name": "Klotzkette"

--- a/memorandums-ersteller/.claude-plugin/plugin.json
+++ b/memorandums-ersteller/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorandums-ersteller",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Wandelt Mandantenunterlagen in ein juristisches Memorandum mit Vier-Teile-Gliederung — Sachverhalt mit Quellenreferenz; Ein-Satz-Fragen; Ein-Satz-Antworten; rechtliche Ausführungen mit Pinpoint-Zitierung. Optional Piercing-Questions. Rechtsgebietsneutral. Alias Memorandumsmacher.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/methodenlehre-buergerliches-recht/.claude-plugin/plugin.json
+++ b/methodenlehre-buergerliches-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "methodenlehre-buergerliches-recht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Methodenlehre und Rechtsanwendung im deutschen buergerlichen Recht aus Anwaltsperspektive: Anspruchsaufbau, Auslegung, Abwaegung, Praezedenzarbeit, Rechtsfortbildung, Methodenwahl, EU-Methodik und methodenehrliche Begruendungskontrolle.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/mietrecht/.claude-plugin/plugin.json
+++ b/mietrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mietrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Mietrecht für Mieter und Vermieter mit ausschließlich amtlichen Mietspiegel-Quellen pro Bundesland und für Top- und Universitaetsstaedte. Datenerhebung Mieterhoehungs-Widerspruch Mietsenkungsverlangen Nebenkostenprüfung und Erstellung Mieteranfragen Klageentwurf zum Amtsgericht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/mittelstand-corporate-ma/.claude-plugin/plugin.json
+++ b/mittelstand-corporate-ma/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mittelstand-corporate-ma",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Freistehendes Mittelstandsmandat-Corporate/M&A-Plugin: Deal-Kommandocenter, Aktenanlage, Datenraum, Legal DD, Tabellenreview, Liquiditätsvorschau, SPA/APA, W&I, Public M&A, Umwandlung, StaRUG/Insolvenzplan, CP-Kalender, E-Rechnung/GoBD, PMI.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/nachbarschaftsstreit-pruefer/.claude-plugin/plugin.json
+++ b/nachbarschaftsstreit-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nachbarschaftsstreit-pruefer",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Nachbarrecht und Nachbarschaftsstreit: Überbau, Überhang, Äste/Wurzeln, Grenzbaum, Zaun/Mauer/Hecke, Immissionen, Vertiefung, Notweg, Hammerschlagsrecht, Beweise, Aufforderung, Klage und Vergleich.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/nda-abgleich/.claude-plugin/plugin.json
+++ b/nda-abgleich/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nda-abgleich",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Gleicht NDA-Entwurf der Gegenseite gegen eigenen Standard ab und setzt Haltelinien chirurgisch im Word-Aenderungsmodus durch. Ampelmatrix ROT/GELB/GRUEN. Ausgabe .docx mit echten Tracked Changes. Keine Absatzlöschungen, keine Klausel-Neufassungen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/nda-verschwiegenheit-generator-checker/.claude-plugin/plugin.json
+++ b/nda-verschwiegenheit-generator-checker/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nda-verschwiegenheit-generator-checker",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Allgemeiner NDA-Ersteller und NDA-Prüfer für deutsche und internationale Verschwiegenheitsvereinbarungen: Entwurf, Redline, GeschGehG, HinSchG, AGB, Arbeitsrecht, M&A, Forschung, Software, Datenraum und Verletzungsreaktion.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/nis2-cybersecurity-compliance/.claude-plugin/plugin.json
+++ b/nis2-cybersecurity-compliance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nis2-cybersecurity-compliance",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "NIS-2, BSIG 2025, BSI, IT-Grundschutz, Cloud, Incident Response und technische Security-Compliance für Geschäftsleitung, CISO und Legal.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/normenkontrolle-bauleitplanung/.claude-plugin/plugin.json
+++ b/normenkontrolle-bauleitplanung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "normenkontrolle-bauleitplanung",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Freistehendes Plugin für die Prüfung und Anfechtung von Bebauungsplänen, Flächennutzungsplänen und örtlichen Bauvorschriften nach § 47 VwGO vor BayVGH und OVG. Mandatsperspektive Antragstellervertretung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/normenkontrollrat-nkr/.claude-plugin/plugin.json
+++ b/normenkontrollrat-nkr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "normenkontrollrat-nkr",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin fuer den Nationalen Normenkontrollrat (NKR): Pruefung von Referentenentwuerfen Formulierungshilfen und Gesetzentwuerfen auf Erfuellungsaufwand Erforderlichkeit Verhaeltnismaessigkeit One-in-one-out Digitalcheck Mittelstandsfreundlichkeit und Praktikabilitaet im Vollzug.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/notariat-alltag/.claude-plugin/plugin.json
+++ b/notariat-alltag/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "notariat-alltag",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Alltagsplugin für Notariat, Notariatsmitarbeitende und Notarinnen/Notare: Beurkundung, Vollzug, Register, Grundbuch, Geldwäsche, Kosten, Fristen und Mandantenkommunikation.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/oeffentliches-wirtschaftsrecht/.claude-plugin/plugin.json
+++ b/oeffentliches-wirtschaftsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oeffentliches-wirtschaftsrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Öffentliches-Wirtschaftsrecht-Plugin für Scheinprivatisierung, ÖPP, Projektfinanzierung, kommunale Unternehmen, Beihilfen, Vergabe und Regulierung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/ordnungswidrigkeitenrecht/.claude-plugin/plugin.json
+++ b/ordnungswidrigkeitenrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ordnungswidrigkeitenrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Allgemeines OWiG-Plugin für Bußgeldverfahren: Anhörung, Bescheid, Einspruch, Behörde, Akteneinsicht, Gericht, Verjährung, Einziehung und Nebenfolgen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/parteienrecht-parteiorganisation/.claude-plugin/plugin.json
+++ b/parteienrecht-parteiorganisation/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parteienrecht-parteiorganisation",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Parteienrechts- und Parteiorganisations-Plugin für formale Parteiarbeit: Parteiengesetz, Satzung, Mitgliederrechte, Parteitage, Kreis- und Bezirksversammlungen, Kandidatenaufstellung, Wahlvorschläge, Parteigerichte, Spenden, Rechenschaft, Abgeordnetenrecht und Wahlleiterkommunikation.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/patentrecherche/.claude-plugin/plugin.json
+++ b/patentrecherche/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "patentrecherche",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Patentrecherche für Patentanwaelte agentisch in Espacenet Google Patents DPMAregister DEPATISnet EPO Register WIPO USPTO. Stand der Technik Neuheit § 3 PatG Art. 54 EPUe erfinderische Tätigkeit § 4 PatG Art. 56 EPUe Problem-Solution-Approach FTO CPC IPC INPADOC Recherchebericht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/patentrecht/.claude-plugin/plugin.json
+++ b/patentrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "patentrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Großes Patentrechts-Plugin für Erfindungsaufnahme, Patentanmeldung, Anspruchsentwurf, Recherche, Neuheit, erfinderische Tätigkeit, FTO, Abmahnung, Claim Chart, Vorbenutzungsrecht, Lizenz, Erfinderbenennung, Einspruch, Nichtigkeit, Register und Fristen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/phishing-vorfall-pruefer/.claude-plugin/plugin.json
+++ b/phishing-vorfall-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "phishing-vorfall-pruefer",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Freistehender Phishing-Vorfall-Prüfer für Online-Banking: BGB § 675u, § 675v, § 675w, pushTAN, Call-ID-Spoofing, grobe Fahrlässigkeit, Beweislast, Bankpflichten, Schlichtung und Klage.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/preussisches-allgemeines-landrecht-pralr/.claude-plugin/plugin.json
+++ b/preussisches-allgemeines-landrecht-pralr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "preussisches-allgemeines-landrecht-pralr",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "PrALR-Plugin zum Allgemeinen Landrecht für die Preußischen Staaten: Quellenkritik, Textzeugen, Zivilrecht, Staats-/Polizeirecht, Strafrecht, Ständerecht, Aufopferung und Rezeptionsgeschichte.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/private-equity-praxis/.claude-plugin/plugin.json
+++ b/private-equity-praxis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "private-equity-praxis",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Private-Equity-Praxis-Plugin für deutsche Kanzleien, Investoren, Fonds, Family Offices und Unternehmen: Fund Formation, KAGB/AIF, ELTIF, Deal Execution, Private Credit, Schuldschein, LMA, NPL, Portfolio, Exit und Distressed.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/produktrecht/.claude-plugin/plugin.json
+++ b/produktrecht/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "produktrecht",
   "displayName": "Produkthaftung und Produktrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Produkthaftung und Produktrecht: Produktsicherheit, GPSR, ProdHaftG, deliktische Produzentenhaftung, Right to Repair, Software-/OTA-Updates, digitale Produktlebenszyklen, Rückruf, Marktüberwachung und Launch-Review.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/prozessrecht/.claude-plugin/plugin.json
+++ b/prozessrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prozessrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Prozessrechtliche Skills für Mandate, Fristen, Mahnbescheid, Eilverfahren, Vollstreckung und Schriftsätze.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/pruefungsrecht-hochschule/.claude-plugin/plugin.json
+++ b/pruefungsrecht-hochschule/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pruefungsrecht-hochschule",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Hochschulprüfungsrecht: Prüfungsordnung, Bewertungsspielraum, Akteneinsicht, Krankheit, Nachteilsausgleich, Täuschung, KI, Drittversuch und Eilrechtsschutz.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/rechtsberatungsstelle/.claude-plugin/plugin.json
+++ b/rechtsberatungsstelle/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rechtsberatungsstelle",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Pro-Bono- und Rechtsberatungsstellen (RDG-konform): Mandantenintake, Fristenkontrolle, Übergabe am Semesterende, mandantenfreundliche Briefe.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/rechtstheorie-rechtsphilosophie/.claude-plugin/plugin.json
+++ b/rechtstheorie-rechtsphilosophie/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rechtstheorie-rechtsphilosophie",
   "displayName": "Rechtstheorie und Rechtsphilosophie",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Rechtstheorie- und Rechtsphilosophie-Plugin fuer juristische Praxis: Rechtsbegriff, Kelsen-orientierte Normgeltung, Demokratie, Rechtsrealismus, Systemdenken, Besitzdogmatik, Law-and-Economics, Hayek-Wissensproblem, spontane Ordnung, Machtkritik und anti-dezisionistische Red-Team-Pruefung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/regulatorisches-recht/.claude-plugin/plugin.json
+++ b/regulatorisches-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "regulatorisches-recht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Aufsichtsrecht – KWG, ZAG, WpHG, GwG, EnWG, TKG, HeilMWerbG, Umsatzsteuer-Voranmeldung, Inkasso/RDG, Regulator-Feeds, Wochendigest.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/rentenpruefer/.claude-plugin/plugin.json
+++ b/rentenpruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rentenpruefer",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Rentenprüfer für gesetzliche Rente, Versorgungswerk und internationale Versicherungszeiten: Kontenklärung, Rentenantrag, Nachversicherung, Auslandszeiten, Bescheide, Widerspruch und verständliche Dokumentation.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/robotik-recht/.claude-plugin/plugin.json
+++ b/robotik-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "robotik-recht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Robotik-Recht Deutschland/EU: Maschinenverordnung, KI-VO, Produkthaftung, ProdSG, Datenschutz, CRA, Data Act, CE, Marktüberwachung, Unfälle, Rückruf, Verträge und Robotik-Testakte.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/roemisch-katholisches-kirchenrecht/.claude-plugin/plugin.json
+++ b/roemisch-katholisches-kirchenrecht/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "roemisch-katholisches-kirchenrecht",
   "displayName": "Römisch-katholisches Kirchenrecht CIC und Katechismus",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Großes, lehramts- und papsttreues Arbeitsplugin zum Recht der römisch-katholischen Kirche: CIC, Katechismus, Sakramente, Ehe, Kirchenaustritt, Verfahren, Disziplin, Pfarrei, Diözese, Kurie und mehrsprachige Kommunikation.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/roemisches-recht/.claude-plugin/plugin.json
+++ b/roemisches-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roemisches-recht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Mega-Plugin zum römischen Recht: Zwölftafelgesetz, Institutionensystem, Sachenrecht, Obligationen, Aktionenrecht, Erbrecht, Juristenrecht, Justinian, byzantinisches Recht und Rezeption.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/schoeffen-handelsrichter-praxis/.claude-plugin/plugin.json
+++ b/schoeffen-handelsrichter-praxis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schoeffen-handelsrichter-praxis",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin für Schöffen, Jugendschöffen, ehrenamtliche Richter und Handelsrichter: Rolle, Rechte, Pflichten, Sitzung, Beratung, Befangenheit, Beweiswürdigung, Handelskammer, Verwaltungsgericht und sichere praktische Orientierung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/schriftform-und-textform-bgb/.claude-plugin/plugin.json
+++ b/schriftform-und-textform-bgb/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "schriftform-und-textform-bgb",
   "displayName": "Schriftform und Textform im BGB",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Formerfordernisse im deutschen Zivilrecht: Schriftform, Textform, qES, Zugang, beA/ERV und Prozessordnungen. Mit Checklisten, Dokumentation und Rechtsprechung nur nach Live-Verifikation.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/schulrecht-laender/.claude-plugin/plugin.json
+++ b/schulrecht-laender/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schulrecht-laender",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Schulrecht der Länder: Schulpflicht, Aufnahme, Inklusion, Noten, Versetzung, Ordnungsmaßnahmen, Datenschutz, Elternrechte und Eilrechtsschutz.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/seerecht-schifffahrtsrecht/.claude-plugin/plugin.json
+++ b/seerecht-schifffahrtsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "seerecht-schifffahrtsrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "See- und Schifffahrtsrecht-Plugin für Schiffskauf, Schiffbau, Werften, Schiffshypothek, Schiffsregister, Arrest, Wrack, Bergung, Charter und ITLOS.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/selbstvertreter-amtsgericht/.claude-plugin/plugin.json
+++ b/selbstvertreter-amtsgericht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "selbstvertreter-amtsgericht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Selbstvertretung vor dem Amtsgericht ohne Anwalt: Anfänger-Workflow, Fristen, Zuständigkeit, §23 GVG/§511 ZPO-Grenzen, Klage/Erwiderung/Replik, Beweise, PKH, Termin, Sanity-Check, Rechtsprechungschat, Berufung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/selbstvertreter-sozialgericht/.claude-plugin/plugin.json
+++ b/selbstvertreter-sozialgericht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "selbstvertreter-sozialgericht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Selbstvertretung vor Sozialbehörden Krankenkassen Pflegekassen BG Versorgungsamt Jobcenter Rente Familienkasse und Sozialgericht: Anhörung Akteneinsicht Mitwirkung Widerspruch Klage Eilantrag Pflegegrad Hilfsmittel Krankengeld EM-Rente GdB Bürgergeld Wohngeld Eingliederungshilfe.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/softwarerecht-de-eu-us/.claude-plugin/plugin.json
+++ b/softwarerecht-de-eu-us/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "softwarerecht-de-eu-us",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Softwarerecht Deutschland/EU/International/USA: Entwicklung, Lizenzen, SaaS, Open Source, Arbeitnehmer/Freelancer, Softwarepatente, AI-Code und Streit.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/solo-selbststaendige-praxis/.claude-plugin/plugin.json
+++ b/solo-selbststaendige-praxis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "solo-selbststaendige-praxis",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Praxisplugin für Solo-Selbstständige in Deutschland: Start, Anmeldung, Steuern, Verträge, Rechnungen, Datenschutz, Statusfeststellung, KSK, Versicherungen, Zahlungsausfall, Krise, Wachstum und Alltag ohne juristische Überforderung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/sozialversicherungsstatus-pruefer/.claude-plugin/plugin.json
+++ b/sozialversicherungsstatus-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sozialversicherungsstatus-pruefer",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Sozialversicherungsstatus und DRV-Statusfeststellung: Geschäftsführer, Freelancer, Anwälte, Lehrkräfte, Musikschulen, Plattformarbeit und Scheinselbständigkeit.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/staatsanwaltschaft-praxis-einstieg/.claude-plugin/plugin.json
+++ b/staatsanwaltschaft-praxis-einstieg/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "staatsanwaltschaft-praxis-einstieg",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Praxisplugin für neue Staatsanwältinnen, Staatsanwälte und Sitzungsdienst: Ermittlungen, RiStBV, Anklage, Strafbefehl, Hauptverhandlung, Rechtsmittel und OWiG-Bußgeldverfahren.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/startup-hr-personalabteilung-berlin/.claude-plugin/plugin.json
+++ b/startup-hr-personalabteilung-berlin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "startup-hr-personalabteilung-berlin",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Personalabteilungs- und HR-Operations-Plugin für ein Berliner Start-up mit ca. 100 Beschäftigten: Arbeitsverträge, Payroll/DATEV-Schnittstelle, Personalakten, Datenschutz, AGG-Vorfälle, Betriebsrat, Benefits, Fehlzeiten, Kündigungen, Happiness-Management und Chef-Briefings.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/status-navigator-step-plan/.claude-plugin/plugin.json
+++ b/status-navigator-step-plan/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "status-navigator-step-plan",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Status-Navigator und Step-Plan-Macher. Reine Dokumentenverarbeitung mit 35 Skills. Strukturiert disparate Dokumentenlagen in eine mehrseitige Excel-Arbeitsmappe und optional ein Padlet-Shelf mit Reitern Ueberblick, Vorhanden, Fehlend und Workflow. Keine rechtliche Bewertung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/steuerrecht-anwalt-und-berater/.claude-plugin/plugin.json
+++ b/steuerrecht-anwalt-und-berater/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "steuerrecht-anwalt-und-berater",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Steuerrecht für Anwalt (anw- FAO § 9) und Steuerberater (stb-): Einspruch Klage FG Aussenprüfung Selbstanzeige, Grundsteuer, Grunderwerbsteuer, Share Deals, Signing Closing, BWA SuSa Lohnbuchhaltung Jahresabschluss.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/strafanzeige-vorbereiter/.claude-plugin/plugin.json
+++ b/strafanzeige-vorbereiter/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "strafanzeige-vorbereiter",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Vorsichtiger Strafanzeigen-Vorbereiter: prüft Anfangsverdacht, Beweise, Strafantrag, Risiken falscher Verdächtigung, Alternativen und erstellt nur bei tragfähiger Tatsachengrundlage eine nüchterne Strafanzeige.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/strafbefehl-verteidiger/.claude-plugin/plugin.json
+++ b/strafbefehl-verteidiger/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "strafbefehl-verteidiger",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Freistehendes Strafbefehls-Plugin für Verteidigung gegen Strafbefehl, Einspruch, Akteneinsicht, Tagessätze, Nebenfolgen, Pflichtverteidigung, Wiedereinsetzung, Einstellung, Zeugenstrategie und Hauptverhandlung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/strafzumessung/.claude-plugin/plugin.json
+++ b/strafzumessung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "strafzumessung",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Strafzumessung nach deutschem Strafrecht vom Strafbefehl bis zur grossen Strafkammer. § 46 StGB Strafzumessungstatsachen Tagessatz Geldstrafe Freiheitsstrafe Bewaehrung § 56 § 49 Regelbeispiele besonders schwerer Fall Verstaendigung § 257c StPO TOA § 46a Gesamtstrafe § 55 JGG.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/strassenrecht-infrastruktur/.claude-plugin/plugin.json
+++ b/strassenrecht-infrastruktur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "strassenrecht-infrastruktur",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Straßenrecht-Plugin für Bundesfernstraßen, Landesstraßen, Gemeindestraßen, Widmung, Planfeststellung, Sondernutzung, Baulast und Erhaltung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/strassenverkehrsrecht-stvo/.claude-plugin/plugin.json
+++ b/strassenverkehrsrecht-stvo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "strassenverkehrsrecht-stvo",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "StVO-/Straßenverkehrsrecht-Plugin für Verkehrsregeln, Zeichen, Anordnungen, Ausnahmegenehmigungen, Fahrerlaubnis, Bußgeld-Schnittstellen und Behördenpraxis.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/subsumtions-pruefer/.claude-plugin/plugin.json
+++ b/subsumtions-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "subsumtions-pruefer",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Interaktiver Subsumtions-Workflow für deutsches Recht und Europarecht: Tatbestandsmerkmale zerlegen, Vier-Schritt-Schema anwenden, Rechtsfolgen und Einreden prüfen. Keine Rechtsberatung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/tabellenreview-3d/.claude-plugin/plugin.json
+++ b/tabellenreview-3d/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tabellenreview-3d",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "3D-Tabellenreview als Wuerfel: Spaltenprompts pro Datenpunkt x Zeilenprompts pro Dokument x Arbeitsblatt-Perspektiven (Recht / Steuer / Wirtschaft) gestapelt. Massenprüfung Vertragsstapel M&A-DD Immobilien Vendor-Onboarding mit Excel-Mehrblatt Kreuzblatt-Konsistenz Audit-Trail Belegkette.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/telekommunikationsrecht/.claude-plugin/plugin.json
+++ b/telekommunikationsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "telekommunikationsrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Großes Telekommunikationsrecht-Plugin für TKG, Bundesnetzagentur, Internetanschlüsse, Anbieterwechsel, Kundenschutz, Netzregulierung, Frequenzen, Nummerierung, Sonderkartellrecht, Datenschutz und Sicherheitsanforderungen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/tierschutzrecht/.claude-plugin/plugin.json
+++ b/tierschutzrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tierschutzrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Tierschutzrecht-Plugin für TierSchG, BGB § 90a, Haltung, Zucht, Transport, Tierversuche, Behördenverfahren, Strafrecht, Bußgeld und zivilrechtliche Tierfälle.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/umweltrecht/.claude-plugin/plugin.json
+++ b/umweltrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "umweltrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Freistehendes Umweltrecht-Plugin für BImSchG, TEHG, Abfall, Wasser, Boden, Naturschutz, UIG, Verfahren, Bußgeld, Umwelt-Due-Diligence, Klimaklagen UmwRG, Lieferkettensorgfalt LkSG/CSDDD und ESG-Greenwashing/CSRD.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/umweltschutzverband-verbandsklage/.claude-plugin/plugin.json
+++ b/umweltschutzverband-verbandsklage/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "umweltschutzverband-verbandsklage",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin für Umweltverbände: UmwRG, Aarhus, UIG, UVP, BImSchG, Planfeststellung, § 47 VwGO, Naturschutz, Klima, Verbandsklage und Eilrechtsschutz.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/urheberrecht-de-eu/.claude-plugin/plugin.json
+++ b/urheberrecht-de-eu/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "urheberrecht-de-eu",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Deutsches und EU-Urheberrecht fuer Werkhoehe, Musik, KI, TDM, Software, Lizenzen, Abmahnung, Schranken, Leistungsschutz und Rechteclearing.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/urteilsbauer-relationsmacher/.claude-plugin/plugin.json
+++ b/urteilsbauer-relationsmacher/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "urteilsbauer-relationsmacher",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Urteils- und Beschluss-Werkstatt für Amts- Land- und Familienrichter sowie Rechtspfleger. Aktenintake Relation Beweiswürdigung mit Richter-Input Tatbestandsmerkmale Tenor Tatbestand Entscheidungsgründe Rechtsmittelbelehrung. Erzeugt DOCX nach Paragraf 313 ZPO.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/us-bankruptcy-code/.claude-plugin/plugin.json
+++ b/us-bankruptcy-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "us-bankruptcy-code",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "US Bankruptcy Code Title 11: Chapters 7/9/11/12/13/15, Automatic Stay, Claims, DIP, 363 Sales, Plans und Cross-Border.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/us-copyright-registrierung-verlag/.claude-plugin/plugin.json
+++ b/us-copyright-registrierung-verlag/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "us-copyright-registrierung-verlag",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "US Copyright Act fuer deutsche Verlage und Rechteinhaber: Title 17, Registrierung, Rechte, Fair Use, DMCA, Musik, AI, Litigation und Deals.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/venture-capital-geber/.claude-plugin/plugin.json
+++ b/venture-capital-geber/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "venture-capital-geber",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "VC-Geber-Plugin für deutsche Venture-Capital-Investoren, Family Offices, Angels und junge VCs: Sourcing, Deal-Tracking, Wandeldarlehen, SAFE, Pre-Seed, Series A/B, Cap Table, Follow-on, Portfolio-Updates, KAGB/BaFin-Grenzen, EU/CH/UK/US-Brücken und legitime Deal-Taktik.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verbraucher-rechtsstaat-alltag/.claude-plugin/plugin.json
+++ b/verbraucher-rechtsstaat-alltag/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verbraucher-rechtsstaat-alltag",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Kleines, hilfreiches Plugin für Verbraucher: E-Commerce, Kaufrecht, Reparaturen, kleine Dienstleistungen, Rechnungen, Inkasso, Plattformen, Behördenbriefe und Gerichtspost verständlich einordnen und vorsichtig reagieren.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verbraucherinsolvenz-schuldenbereinigung/.claude-plugin/plugin.json
+++ b/verbraucherinsolvenz-schuldenbereinigung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verbraucherinsolvenz-schuldenbereinigung",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Verbraucherinsolvenz und Schuldenbereinigung nach InsO: außergerichtlicher Einigungsversuch, Schuldenbereinigungsplan, Antrag, Restschuldbefreiung, P-Konto, ehemalige Selbstständige und lebensnahe Verfahrensführung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verbraucherschutzrecht-pruefer/.claude-plugin/plugin.json
+++ b/verbraucherschutzrecht-pruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verbraucherschutzrecht-pruefer",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Großer Verbraucherschutz-Prüfer für BGB, EGBGB, UWG, UKlaG, VSBG, E-Commerce, digitale Produkte, Reise, Finanzen, Energie, Gesundheit und Alltag.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verbraucherschutzverband-durchsetzung/.claude-plugin/plugin.json
+++ b/verbraucherschutzverband-durchsetzung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verbraucherschutzverband-durchsetzung",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin für Verbraucherverbände: VDuG, UKlaG, UWG, Abhilfeklage, Musterfeststellung, Unterlassung, Register, Finanzierung, Vergleich und Kampagnenakte.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/vereinsrecht-vereinsmanager/.claude-plugin/plugin.json
+++ b/vereinsrecht-vereinsmanager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vereinsrecht-vereinsmanager",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Vereinsrechts- und Vereinsmanagement-Plugin für eingetragene und nicht eingetragene Vereine: Gründung, Satzung, Mitgliederversammlung, Vorstand, Protokolle, Beschlüsse, Gemeinnützigkeit, Register, Haftung, Datenschutz, Finanzen, Veranstaltungen und Spezialvereine.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verfassungsrecht/.claude-plugin/plugin.json
+++ b/verfassungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verfassungsrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Deutsches Verfassungsrecht unter dem Grundgesetz aus Sicht einer Spezialkanzlei. Rechtsprechungsgetrieben mit Live-Recherche auf bundesverfassungsgericht.de. Acht Skills für Gesetzgebungskompetenz formelle und materielle Verfassungsmäßigkeit Grundrechte und Verfassungsbeschwerde.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verhaeltnismaessigkeitspruefer/.claude-plugin/plugin.json
+++ b/verhaeltnismaessigkeitspruefer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verhaeltnismaessigkeitspruefer",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "75 Skills zur Schranken-Schranke: BVerfG-Leitentscheidungen, Rechtsvergleich Suedafrika/Kanada/EGMR/EuGH/USA und 12 europaeische Ordnungen, plus Theorie Alexy, Rechtsgeschichte-Linie, Schnellpruefung 5 Minuten, Klausurschema, Streitstellen-Katalog, Subsumtionshelfer mit 10 Pattern-Faellen.",
   "author": {
     "name": "Klotzkette",

--- a/verkehr-infrastrukturrecht/.claude-plugin/plugin.json
+++ b/verkehr-infrastrukturrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verkehr-infrastrukturrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Freistehendes Verkehrs- und Infrastrukturrecht-Plugin für Verkehrsplanung, Planfeststellung, Straßenbahn, Ladeinfrastruktur, Parkraum und Verkehrswende.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verkehrsowi-verteidiger/.claude-plugin/plugin.json
+++ b/verkehrsowi-verteidiger/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verkehrsowi-verteidiger",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Freistehendes VerkehrsOWi-Plugin für Bußgeldbescheid, Anhörung, Einspruch, Punkte, Fahrverbot, Rotlicht, Geschwindigkeit, Abstand, Handy, Alkohol, Drogen, Akteneinsicht, Messakte, Zeugenstrategie und Amtsgericht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verlagsrecht-buchpreisbindung/.claude-plugin/plugin.json
+++ b/verlagsrecht-buchpreisbindung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verlagsrecht-buchpreisbindung",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin für Verlagsrecht, Verlagsgesetz, Autoren- und Herausgeberverträge, Buchpreisbindung, Titelschutz, Vertrieb, E-Book, Hörbuch und verlagsnahe Compliance.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/verlagsredaktion/.claude-plugin/plugin.json
+++ b/verlagsredaktion/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verlagsredaktion",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Verlagsdesk fuer juristische und fachliche Verlage: Eingangskorb, Manuskript, Redaktion, Rechtecheck, Zitate, Bildrechte, Autorenkommunikation, Heftplanung, Buchprojekte, Satzfahnen, Metadaten, Marketing und Produktionsuebergabe.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/versammlungsrecht/.claude-plugin/plugin.json
+++ b/versammlungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "versammlungsrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Praxisplugin für Versammlungsrecht und Versammlungsfreiheit: Anzeige unter freiem Himmel, Landesrecht, Behörde, Fristen, Spontan- und Eilversammlung, Ordner, Kooperationsgespräch, Auflagen, Verbot, Eilrechtsschutz und Durchführung ohne vorauseilende Selbstzensur.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/versicherungsrecht/.claude-plugin/plugin.json
+++ b/versicherungsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "versicherungsrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Großes Versicherungsrecht-Plugin für VVG, VAG, europäische Versicherungsaufsicht, Lebensversicherung, BU, PKV, Rechtsschutz, Kreditversicherung, D&O, Cyber, Sach- und Haftpflichtdeckung.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/vertragsausfueller/.claude-plugin/plugin.json
+++ b/vertragsausfueller/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vertragsausfueller",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Freistehendes Vertragsausfüller-Plugin: DOCX-Vorlagen und Altverträge strippen, Felder erkennen, Term Sheets mappen, Rückfragen führen, neue Verträge erzeugen und Track-Changes-Fassungen nur nach ausdrücklicher Nachfrage vorbereiten.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/vertragsrecht/.claude-plugin/plugin.json
+++ b/vertragsrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vertragsrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Vertragsrecht – Lieferanten- und Vertriebsverträge, AGB §§ 305 ff. BGB, NDA, SaaS-/MSA-Review, Renewal-Tracking, Eskalations-Routing, Business-Zusammenfassungen.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/wahlkampfrecht-praxis/.claude-plugin/plugin.json
+++ b/wahlkampfrecht-praxis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wahlkampfrecht-praxis",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Wahlkampfrecht und Wahlkampfpraxis fuer Parteien, Kandidierende und Kampagnenteams: Strategie, Plakatierung, Social Media, Datenschutz, politische Werbung, Parteienfinanzierung, Desinformation, Veranstaltungen, Schulen, Podien, Wahltag und Compliance.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/wandeldarlehen-lebenszyklus/.claude-plugin/plugin.json
+++ b/wandeldarlehen-lebenszyklus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wandeldarlehen-lebenszyklus",
   "displayName": "Wandeldarlehen-Lebenszyklus (Erstellung bis Cap-Table)",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Begleitet den vollständigen Lebenszyklus eines Wandeldarlehens für GmbH und UG: Vertragserstellung (bilingual/einsprachig), Beurkundungsprüfung, Wandelereignisse, Wandlungsberechnung, Cap-Table-Update, Gesellschafterbeschluss und Notar-Paket.",
   "author": {
     "name": "Klotzkette"

--- a/weg-hausverwaltung/.claude-plugin/plugin.json
+++ b/weg-hausverwaltung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "weg-hausverwaltung",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Operatives WEG- und Hausverwaltungs-Plugin fuer Beschluesse, Eigentuemerversammlung, Protokoll, Beschlusssammlung, Wirtschaftsplan, Jahresabrechnung, Hausgeld, Sonderumlage, Betriebskosten, Handwerker, bauliche Veraenderungen, Steckersolar, Wallbox, Verwalter, Beirat und Anwalt-Eskalation.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/weltraumrecht/.claude-plugin/plugin.json
+++ b/weltraumrecht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "weltraumrecht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Großes Plugin für deutsches, europäisches und internationales Weltraumrecht: Raumfahrtverträge, Satelliten, Haftung, Weltraumbahnhof, Raketen, Raumstationen, Frequenzen, Exportkontrolle und Space Property.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/word-legal-ai-plugin-and-skill-for-german-lawyers/.claude-plugin/plugin.json
+++ b/word-legal-ai-plugin-and-skill-for-german-lawyers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "word-legal-ai-plugin-and-skill-for-german-lawyers",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Word Legal AI for German Lawyers: Kaltstart, Kanzleistil, makrofreies Word-Finish, Verträge, Schriftsätze, Memos, Redlines, Klauselbibliothek, Defensive Drafting, Term Sheet, DE-EN Bilingual, US/UK Legal Writing und englische Verträge nach deutschem Recht.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/zitierweise-deutsches-recht/.claude-plugin/plugin.json
+++ b/zitierweise-deutsches-recht/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zitierweise-deutsches-recht",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Deutsche juristische Hauszitierweise v4.0: Rechtsprechung nur mit Gericht, Entscheidungsform, Datum, Aktenzeichen und verifizierbarer Quelle; keine BeckRS-, Kommentar- oder Aufsatz-Blindzitate. Literatur nur mit Nutzerquelle oder lizenziertem Live-Zugriff.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/zwangsverwaltung-zvg/.claude-plugin/plugin.json
+++ b/zwangsverwaltung-zvg/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zwangsverwaltung-zvg",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Freistehendes ZVG-Plugin für Zwangsverwaltung und Versteigerung: Beschlagnahme, Besitz, Mieten, Treuhandkonto, Berichte, Verteilung, ZVG-Portal-Recherche, Bieterangebote und Versteigerungsteilnahme.",
   "license": "Apache-2.0 OR MIT",
   "author": {

--- a/zwangsvollstreckung/.claude-plugin/plugin.json
+++ b/zwangsvollstreckung/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zwangsvollstreckung",
-  "version": "300.0.0",
+  "version": "301.0.0",
   "description": "Plugin Zwangsvollstreckung §§ 704 ff. ZPO: Mahn-/Vollstreckungsbescheid, PfÜB Bank/Arbeit, § 802l Kontensuche, Vermögensauskunft, Räumung, § 800 ZPO Notar, § 201 InsO, ZVG, EU-Kontenpfändung VO 655/2014, § 765a Härtefall, Schuldnerschutz.",
   "license": "Apache-2.0 OR MIT",
   "author": {


### PR DESCRIPTION
## Summary

Versions-Bump 300 → 301 für 213 plugin.json + marketplace.json + README + ASSET_INDEX + CHANGELOG.

### Was in v301 steckt

- Eval-Harness-Vollausbau: 204/204 Testakten mit Rubric, Baseline 204/204 All-Pass
- Portable-Bundle in `docs/portable-eval-harness/` für Fremd-Repos
- Vertiefte Rubric-Beispiele für `arbeitszeugnispruefer-skill` und Vorlagen-Repo

Nach Merge: Release-Workflow mit Tag `v301.0.0` triggern.

https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL


---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_