### PR TITLE
0_setup-cowork3p-eu-gateway: anbietername komplett entfernt

### DIFF
--- a/0_setup-cowork3p-eu-gateway/README.md
+++ b/0_setup-cowork3p-eu-gateway/README.md
@@ -1,7 +1,7 @@
-# Claude Cowork mit Langdock verbinden
+# Claude Cowork mit einem EU-Gateway verbinden
 
-Diese Anleitung zeigt Schritt für Schritt, wie man **Claude Cowork** so einrichtet, dass die Inferenz über den
-**EU-Gateway von Langdock** (deutsches Unternehmen, EU-Hosting, stellt Berufsverschwiegenheitsvereinbarung zur Verfügung (§ 43e Abs. 3 BRAO)) läuft. Das tatsächliche Backend auf Langdock-Seite muss dafür je nach Modell und Vereinbarung **AWS Bedrock oder Google Vertex** sein. Das ist mit Langdock zwingend vor der Nutzung abzustimmen.
+Diese Anleitung zeigt Schritt für Schritt, wie man **Claude Cowork** so einrichtet, dass die Inferenz über einen
+**EU-Gateway-Anbieter** läuft. Gemeint sind hier Anbieter mit EU-Hosting, die eine **Berufsverschwiegenheitsvereinbarung** nach § 43e Abs. 3 BRAO zur Verfügung stellen können. Das tatsächliche Backend ist je nach Anbieter und Vereinbarung in der Regel **AWS Bedrock oder Google Vertex**. Welches Backend in deinem konkreten Fall verwendet wird, ist mit dem Gateway-Anbieter zwingend vor der Nutzung abzustimmen.
 
 Die Anleitung richtet sich an **nicht-technische Nutzerinnen und Nutzer**. Alle Schritte lassen sich ohne
 Programmierkenntnisse durchführen.
@@ -18,8 +18,9 @@ Programmierkenntnisse durchführen.
 Sicherheitskonzept**. Je nach **Organisation und Einsatzzweck** sind ggf. **weitere sicherheitsrelevante
 Einstellungen** sinnvoll oder erforderlich (z. B. die Egress-Freigabeliste, Telemetrie-Optionen oder
 Arbeitsbereich-Einschränkungen). Den **API-Key nicht** in der Datei speichern, wenn diese weitergegeben wird. **Egress-Freigabeliste (`coworkEgressAllowedHosts`):** In der mitgelieferten Config steht sie bewusst auf `"*"` (alle Hosts erlaubt), damit agentisches Arbeiten mit Web-Zugriff uneingeschränkt funktioniert. Eine Einschränkung dieser Liste beschneidet den Web-Zugriff und damit das agentische Arbeiten und sollte daher **unbedingt vorab mit der IT abgestimmt** werden.
-- **AVV-Kette nach Art. 28 DSGVO beachten:** Mandant ↔ Anwalt (Verantwortlicher) ↔ Langdock (Auftragsverarbeiter) ↔ Backend-Anbieter (Bedrock / Vertex als Unter-Auftragsverarbeiter). Sub-Prozessor-Zustimmung nach Art. 28 Abs. 2 und 4 DSGVO erforderlich.
+- **AVV-Kette nach Art. 28 DSGVO beachten:** Mandant ↔ Anwalt (Verantwortlicher) ↔ Gateway-Anbieter (Auftragsverarbeiter) ↔ Backend-Anbieter (Bedrock / Vertex als Unter-Auftragsverarbeiter). Sub-Prozessor-Zustimmung nach Art. 28 Abs. 2 und 4 DSGVO erforderlich.
 - **DSFA-Erwägung nach Art. 35 DSGVO:** Bei systematischer Verarbeitung von Mandantendaten je nach Risiko erforderlich.
+- **Anbieterauswahl:** Diese Anleitung ist anbieterneutral. Geeignete EU-Gateways sind solche mit EU-Hosting, die einen **AVV nach Art. 28 DSGVO** und eine **Zusatzvereinbarung nach § 43e Abs. 3 BRAO i. V. m. § 203 Abs. 4 StGB** zur Verfügung stellen können. Die konkrete Anbieterauswahl, ihre vertragliche Bewertung und die Prüfung der jeweiligen Sub-Prozessor-Kette sind nicht Gegenstand dieser Anleitung.
 
 ---
 
@@ -27,26 +28,25 @@ Arbeitsbereich-Einschränkungen). Den **API-Key nicht** in der Datei speichern, 
 
 - **Claude Desktop** ist installiert.
 - Eine **passende Claude-Lizenz** für Cowork 3P (je nach Konstellation z. B. eine Team-Lizenz; ggf. ist die Einrichtung auch mit einem Free-Account möglich – bitte im eigenen Account prüfen).
-- Ein **Langdock-Account** mit **passender Lizenz** für den API-Zugang (in der Regel eine Business-Lizenz).
-- Mit Langdock muss – **zusätzlich** zu den Verträgen und dem **Auftragsverarbeitungsvertrag (AVV) einschließlich Begleitdokumenten** – eine **Zusatzvereinbarung zur Wahrung der anwaltlichen Verschwiegenheitspflicht** nach **§ 43e Abs. 3 BRAO i. V. m. § 203 Abs. 4 StGB** geschlossen werden.
-- Die Datei **`eu-gateway-cowork.config.json`** aus diesem Ordner. **Wichtig:** Vor Verwendung muss der Platzhalter `inferenceGatewayBaseUrl` durch die konkrete Gateway-URL des gewaehlten EU-Anbieters ersetzt werden — für Langdock z. B. `https://api.langdock.com/anthropic/eu`.
+- Ein **Account beim EU-Gateway-Anbieter deiner Wahl** mit einer **Lizenz, die API-Zugang erlaubt** (häufig eine Business- oder Enterprise-Lizenz – beim Anbieter prüfen).
+- Mit dem Gateway-Anbieter muss – **zusätzlich** zu den Verträgen und dem **Auftragsverarbeitungsvertrag (AVV) einschließlich Begleitdokumenten** – eine **Zusatzvereinbarung zur Wahrung der anwaltlichen Verschwiegenheitspflicht** nach **§ 43e Abs. 3 BRAO i. V. m. § 203 Abs. 4 StGB** geschlossen werden.
+- Die Datei **`eu-gateway-cowork.config.json`** aus diesem Ordner. **Wichtig:** Vor Verwendung muss der Platzhalter `inferenceGatewayBaseUrl` durch die konkrete Gateway-URL des gewaehlten EU-Anbieters ersetzt werden — siehe Doku des jeweiligen Anbieters für den korrekten Pfad zu den Anthropic-Modellen in der EU.
 
 ---
 
-## Teil 1 – In Langdock: API-Key erstellen
+## Teil 1 – Beim Gateway-Anbieter: API-Key erstellen
 
-1. Bei **Langdock** einloggen.
-2. In der Seitenleiste oben die **Workspace Settings** (Workspace-Einstellungen) öffnen.
-3. Dort (ebenfalls in der Seitenleiste) unter **„Products"** auf **„API"** klicken.
-4. Auf **„Create API Key"** klicken. Den erzeugten Key **kopieren** und **sicher aufbewahren**. Du brauchst ihn gleich in Teil 4.
+1. Bei deinem **Gateway-Anbieter** einloggen.
+2. In den **Workspace- oder Account-Einstellungen** den Bereich für **API-Zugang** öffnen (die Bezeichnung variiert pro Anbieter – häufig „API", „API-Keys" oder „Developer").
+3. Einen **neuen API-Key erzeugen** und ihn **kopieren** und **sicher aufbewahren**. Du brauchst ihn gleich in Teil 4.
 
 ---
 
-## Teil 2 – In Langdock: Modelle freischalten
+## Teil 2 – Beim Gateway-Anbieter: Anthropic-Modelle freischalten
 
-5. In der Seitenleiste oben die **Workspace Settings** (Workspace-Einstellungen) öffnen.
-6. Dort auf **„Workspace of Models"** gehen.
-7. Unter **„Hosted in the EU"** auf den Reiter **„Anthropic"** klicken und die **Anthropic-Modelle aktivieren**.
+4. In der **Modell- oder Provider-Verwaltung** des Gateway-Anbieters den Bereich für **EU-gehostete Modelle** öffnen.
+5. Die gewünschten **Anthropic-Modelle aktivieren** (Sonnet, Opus, Haiku in den jeweils benötigten Versionen).
+6. Sicherstellen, dass die **Base-URL** des Anbieters und der **erwartete Pfad für Anthropic-Modelle** (siehe Doku des Anbieters) bekannt sind – beides brauchst du gleich in der Config.
 
 ---
 
@@ -62,10 +62,11 @@ Arbeitsbereich-Einschränkungen). Den **API-Key nicht** in der Datei speichern, 
 10. In der Menüleiste den Reiter **„Entwickler"** öffnen und auf **„Drittanbieter-Inferenz konfigurieren…"** klicken.
 11. Im sich öffnenden Fenster oben rechts auf das **Konfigurations-Auswahlfeld** klicken und **„Konfiguration importieren…"** wählen.
     *Falls dieser Button in deiner App-Version nicht erscheint:* Du kannst die Werte stattdessen **von Hand in die Eingabemaske eintragen** – einfach Feld für Feld entlang der `eu-gateway-cowork.config.json`. Für nicht-technische Nutzer ist das der einfachere und sicherere Weg.
-12. Die Datei **`eu-gateway-cowork.config.json`** auswählen (Die Datei befindet sich hier im Repository und muss vorher auf Deinem Laptop heruntergeladen werden). **Zwischenschritt:** Den Platzhalter `inferenceGatewayBaseUrl` in der heruntergeladenen Datei durch die konkrete Gateway-URL deines EU-Anbieters ersetzen — bei Langdock z. B. `https://api.langdock.com/anthropic/eu`.
-13. Den **Langdock-API-Key** aus Teil 1 einfügen.
-14. Auf **„Verbindung testen"** klicken. Wenn alles stimmt, wird die Verbindung als erfolgreich bestätigt.
-15. Auf **„Änderungen übernehmen"** klicken.
+12. Die Datei **`eu-gateway-cowork.config.json`** auswählen (Die Datei befindet sich hier im Repository und muss vorher auf Deinem Laptop heruntergeladen werden).
+13. In der Datei die **`inferenceGatewayBaseUrl`** auf die **Base-URL deines Gateway-Anbieters** anpassen (siehe Doku des Anbieters für den korrekten Pfad zu den Anthropic-Modellen in der EU).
+14. Den **API-Key aus Teil 1** in das Feld **`inferenceGatewayApiKey`** eintragen.
+15. Auf **„Verbindung testen"** klicken. Wenn alles stimmt, wird die Verbindung als erfolgreich bestätigt.
+16. Auf **„Änderungen übernehmen"** klicken.
 
 **Fertig!** Du kannst in Claude Cowork jetzt oben das gewünschte Modell auswählen und loslegen.
 
@@ -73,9 +74,7 @@ Arbeitsbereich-Einschränkungen). Den **API-Key nicht** in der Datei speichern, 
 
 ## Gut zu wissen
 
-- **Geschwindigkeitslimit:** Die Standard-API von Langdock erlaubt **60.000 Tokens pro Minute**. Für intensives,
-  mehrschrittiges („agentisches") Arbeiten ist das zu wenig – dann erscheint eine Limit-Meldung. Höhere
-  Limits gibt es laut Langdock nur über **Enterprise-Konditionen auf Anfrage**.
+- **Geschwindigkeitslimit:** Gateway-Anbieter haben **eigene Token-Limits pro Minute** (typischerweise im fünf- bis sechsstelligen Bereich). Für intensives, mehrschrittiges („agentisches") Arbeiten kann das Standard-Limit zu knapp sein – dann erscheint eine Limit-Meldung. Höhere Limits sind in der Regel **nur über Enterprise-Konditionen auf Anfrage** erhältlich. Konkrete Limits bitte beim gewählten Anbieter erfragen.
 - **Kosten:** Die Nutzung über die API wird **nach Verbrauch** (pro Token) abgerechnet – anders als bei den
-  klassischen Anthropic-Lizenzen.
-- **Telemetrie:** Die mitgelieferte Config setzt `disableEssentialTelemetry`, `disableNonessentialTelemetry`, `disableNonessentialServices` und `disableAutoUpdates` auf `true`. Damit gehen keine routinemäßigen Telemetrie- und Update-Calls an Anthropic. Konversations-Inhalte selbst laufen über den Langdock-Gateway zum jeweiligen Backend (Bedrock / Vertex).
+  klassischen Anthropic-Lizenzen. Der konkrete Tarif ergibt sich aus dem Vertrag mit dem Gateway-Anbieter.
+- **Telemetrie:** Die mitgelieferte Config setzt `disableEssentialTelemetry`, `disableNonessentialTelemetry`, `disableNonessentialServices` und `disableAutoUpdates` auf `true`. Damit gehen keine routinemäßigen Telemetrie- und Update-Calls an Anthropic. Konversations-Inhalte selbst laufen über den Gateway zum jeweiligen Backend (Bedrock / Vertex).

--- a/0_setup-cowork3p-eu-gateway/eu-gateway-cowork.config.json
+++ b/0_setup-cowork3p-eu-gateway/eu-gateway-cowork.config.json
@@ -1,6 +1,6 @@
 {
-  "_comment_de": "ALLGEMEINE EU-Gateway-Konfiguration fuer Claude Cowork. Vor Verwendung die Platzhalter durch die konkreten Werte deines EU-Gateway-Anbieters ersetzen (z. B. Langdock mit https://api.langdock.com/anthropic/eu, oder andere EU-Hosted-Provider mit Anthropic-Routing). Die URL unten ist ein neutraler Platzhalter und muss zwingend ersetzt werden, sonst schlaegt die Verbindung fehl.",
-  "_comment_en": "Generic EU gateway configuration for Claude Cowork. Replace placeholders with your chosen EU gateway provider's actual values (e.g. Langdock with https://api.langdock.com/anthropic/eu, or another EU-hosted provider with Anthropic routing). The URL below is a neutral placeholder and MUST be replaced, otherwise the connection will fail.",
+  "_comment_de": "Allgemeine EU-Gateway-Konfiguration fuer Claude Cowork. Vor Verwendung die Platzhalter durch die konkreten Werte deines EU-Gateway-Anbieters ersetzen (EU-gehosteter Provider mit Anthropic-Routing in der EU). Die URL unten ist ein neutraler Platzhalter und muss zwingend ersetzt werden, sonst schlaegt die Verbindung fehl. Konkreten Pfad zu den Anthropic-Modellen siehe Doku des jeweiligen Anbieters.",
+  "_comment_en": "Generic EU gateway configuration for Claude Cowork. Replace placeholders with your chosen EU gateway provider's actual values (EU-hosted provider with Anthropic routing in the EU). The URL below is a neutral placeholder and MUST be replaced, otherwise the connection will fail. See your provider's documentation for the correct Anthropic-models path.",
   "inferenceProvider": "gateway",
   "inferenceGatewayBaseUrl": "https://REPLACE-WITH-YOUR-EU-GATEWAY-PROVIDER/anthropic/eu",
   "inferenceGatewayApiKey": "DEIN_EU_GATEWAY_API_KEY_HIER",


### PR DESCRIPTION
## Inhalt

Nach den Codex-P2-Fixes standen wieder mehrere Anbieternamen im EU-Gateway-README und in den Config-Kommentaren. Dieser PR neutralisiert sie komplett.

### Aenderungen

- README: Titel, Einleitung, AVV-Kette-Hinweis, Voraussetzungen, Teil 1 und Teil 2 sowie Teil 4 Schritte 12-16 anbieterneutral
- Schritt-Nummerierung in Teil 4 korrigiert (10-16 statt 10-15)
- Hinweisblock zur Anbieterauswahl ergaenzt
- Config-Kommentare `_comment_de` und `_comment_en` neutralisiert

### Validatoren

- `validate-plugin-structure.mjs` OK
- Config-JSON valide
- Repo-weiter Grep nach Anbieternamen: 0 Treffer