### PR TITLE
CLAUDE.md: Codex-Review-Workflow als nicht-blockierend präzisieren

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,12 @@ Diese Regel gilt **ausnahmslos und für alle Zeiten** für jede Vorlage, jeden V
 - Pull Requests in diesem Repo werden **nicht als Draft** erstellt, sondern direkt als „ready" und nach Push **sofort auf `main` gemerged** — es sei denn, der Nutzer fordert ausdrücklich einen Draft oder eine Review-Pause.
 - Merges erfolgen per Merge-Commit (kein Squash, kein Rebase), damit die Entwicklungs-History pro Branch erhalten bleibt.
 - Force-Push auf `main` oder gemeinsame Branches ist verboten.
-- **Codex-Review verbindlich anstoßen.** Direkt nach dem Erzeugen jedes Pull Requests — und vor dem Merge — muss auf dem PR ein Kommentar mit dem Inhalt `@codex review` gepostet werden. So bekommt jeder PR automatisch ein zweites Augenpaar von Codex, unabhängig davon, welches Werkzeug den PR erzeugt hat (Claude, Perplexity oder andere). Auch wenn der PR anschließend direkt gemerged wird, bleibt der Review-Kommentar als Audit-Spur stehen und Codex' spätere Anmerkungen können in einem Folge-PR adressiert werden. Diese Regel gilt **ausnahmslos für jeden PR**.
+- **Codex-Review verbindlich anstoßen — nicht blockierend.** Der Workflow je PR ist exakt:
+  1. PR erzeugen (`mcp__github__create_pull_request`, `draft: false`).
+  2. Direkt im Anschluss einen Kommentar mit dem Inhalt `@codex review` posten (`mcp__github__add_issue_comment`).
+  3. **Sofort** mergen (`mcp__github__merge_pull_request`, `merge_method: merge`) — **nicht** auf Codex' Antwort warten.
+
+  Codex läuft im Hintergrund weiter und kommentiert später. Etwaige Findings werden — falls überhaupt nötig — in einem Folge-PR adressiert. Ziel ist eine durchgehende Audit-Spur ohne dass der Workflow blockiert wird. Diese Regel gilt **ausnahmslos für jeden PR**, unabhängig vom erzeugenden Werkzeug (Claude, Perplexity, Codex oder andere).
 
 ## Konversationsstil – konzis starten, schnell zum Dokument
 


### PR DESCRIPTION
## CLAUDE.md — Codex-Review-Workflow präzisieren

Klarstellung der zuletzt aufgenommenen Codex-Review-Regel:

**Workflow je PR:**

1. PR erzeugen (ready, nicht Draft)
2. `@codex review` als Kommentar posten
3. **Sofort** mergen — nicht auf Codex' Antwort warten

Codex läuft im Hintergrund weiter; etwaige Findings werden in einem Folge-PR adressiert. Damit bleibt die Codex-Review-Spur erhalten, ohne den Workflow zu blockieren.

---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_