### PR TITLE
CLAUDE.md: Draft/Review-Pause-Ausnahme im Codex-Review-Workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,11 +89,11 @@ Diese Regel gilt **ausnahmslos und für alle Zeiten** für jede Vorlage, jeden V
 - Merges erfolgen per Merge-Commit (kein Squash, kein Rebase), damit die Entwicklungs-History pro Branch erhalten bleibt.
 - Force-Push auf `main` oder gemeinsame Branches ist verboten.
 - **Codex-Review verbindlich anstoßen — nicht blockierend.** Der Workflow je PR ist exakt:
-  1. PR erzeugen (`mcp__github__create_pull_request`, `draft: false`).
-  2. Direkt im Anschluss einen Kommentar mit dem Inhalt `@codex review` posten (`mcp__github__add_issue_comment`).
-  3. **Sofort** mergen (`mcp__github__merge_pull_request`, `merge_method: merge`) — **nicht** auf Codex' Antwort warten.
+  1. PR erzeugen (`mcp__github__create_pull_request`). Standard ist `draft: false`; wenn der Nutzer ausdrücklich einen Draft oder eine Review-Pause gefordert hat (siehe Ausnahme im ersten Punkt dieses Abschnitts), wird `draft: true` gesetzt und der PR bleibt offen.
+  2. Direkt im Anschluss einen Kommentar mit dem Inhalt `@codex review` posten (`mcp__github__add_issue_comment`). Dieser Schritt erfolgt **auch bei Draft-/Review-Pause-PRs**, damit Codex parallel im Hintergrund prüft.
+  3. **Sofort** mergen (`mcp__github__merge_pull_request`, `merge_method: merge`) — **nicht** auf Codex' Antwort warten. **Ausnahme:** Bei einem vom Nutzer ausdrücklich gewünschten Draft oder einer Review-Pause wird hier nicht gemerged, sondern auf die Freigabe des Nutzers gewartet.
 
-  Codex läuft im Hintergrund weiter und kommentiert später. Etwaige Findings werden — falls überhaupt nötig — in einem Folge-PR adressiert. Ziel ist eine durchgehende Audit-Spur ohne dass der Workflow blockiert wird. Diese Regel gilt **ausnahmslos für jeden PR**, unabhängig vom erzeugenden Werkzeug (Claude, Perplexity, Codex oder andere).
+  Codex läuft im Hintergrund weiter und kommentiert später. Etwaige Findings werden — falls überhaupt nötig — in einem Folge-PR adressiert. Ziel ist eine durchgehende Audit-Spur ohne dass der Workflow blockiert wird. Diese Regel gilt für jeden PR unabhängig vom erzeugenden Werkzeug (Claude, Perplexity, Codex oder andere); die Draft-/Review-Pause-Ausnahme aus dem ersten Punkt dieses Abschnitts bleibt unberührt.
 
 ## Konversationsstil – konzis starten, schnell zum Dokument
 


### PR DESCRIPTION
Behebt einen Widerspruch zwischen der bestehenden Draft/Review-Pause-Regel und dem neuen verbindlichen Codex-Review-Workflow. Ein Agent waere sonst bei einem vom Nutzer gewuenschten Draft trotzdem in den Auto-Merge gerannt.

Fix:
- Schritt 1 erlaubt draft:true bei expliziter Nutzer-Forderung
- Schritt 2 (Codex-Comment) gilt auch fuer Draft-PRs
- Schritt 3 (Auto-Merge) macht die Ausnahme explizit
- Schlusssatz haelt die Ausnahme aus Zeile 88 ausdruecklich aufrecht

Hintergrund: Hinweis von Codex im Review zu Commit 4abf4bf.