### PR TITLE
CLAUDE.md: Review-Pause-PRs bleiben ready (Codex-P2-Fix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,9 +89,9 @@ Diese Regel gilt **ausnahmslos und für alle Zeiten** für jede Vorlage, jeden V
 - Merges erfolgen per Merge-Commit (kein Squash, kein Rebase), damit die Entwicklungs-History pro Branch erhalten bleibt.
 - Force-Push auf `main` oder gemeinsame Branches ist verboten.
 - **Codex-Review verbindlich anstoßen — nicht blockierend.** Der Workflow je PR ist exakt:
-  1. PR erzeugen (`mcp__github__create_pull_request`). Standard ist `draft: false`; wenn der Nutzer ausdrücklich einen Draft oder eine Review-Pause gefordert hat (siehe Ausnahme im ersten Punkt dieses Abschnitts), wird `draft: true` gesetzt und der PR bleibt offen.
-  2. Direkt im Anschluss einen Kommentar mit dem Inhalt `@codex review` posten (`mcp__github__add_issue_comment`). Dieser Schritt erfolgt **auch bei Draft-/Review-Pause-PRs**, damit Codex parallel im Hintergrund prüft.
-  3. **Sofort** mergen (`mcp__github__merge_pull_request`, `merge_method: merge`) — **nicht** auf Codex' Antwort warten. **Ausnahme:** Bei einem vom Nutzer ausdrücklich gewünschten Draft oder einer Review-Pause wird hier nicht gemerged, sondern auf die Freigabe des Nutzers gewartet.
+  1. PR erzeugen (`mcp__github__create_pull_request`). Standard ist `draft: false`. Nur wenn der Nutzer ausdrücklich einen **Draft** angefordert hat, wird `draft: true` gesetzt. Eine bloße **Review-Pause ohne Draft-Wunsch** lässt den PR ready (`draft: false`) — Codex und menschliche Reviewer sollen ihn gerade in diesem Zustand inspizieren.
+  2. Direkt im Anschluss einen Kommentar mit dem Inhalt `@codex review` posten (`mcp__github__add_issue_comment`). Dieser Schritt erfolgt **sofort und bei jedem PR** — auch bei Draft-PRs und Review-Pause-PRs —, damit Codex parallel im Hintergrund prüft.
+  3. **Sofort** mergen (`mcp__github__merge_pull_request`, `merge_method: merge`) — **nicht** auf Codex' Antwort warten. **Ausnahme:** Bei einem vom Nutzer ausdrücklich gewünschten Draft **oder** einer Review-Pause wird hier nicht gemerged, sondern auf die Freigabe des Nutzers gewartet.
 
   Codex läuft im Hintergrund weiter und kommentiert später. Etwaige Findings werden — falls überhaupt nötig — in einem Folge-PR adressiert. Ziel ist eine durchgehende Audit-Spur ohne dass der Workflow blockiert wird. Diese Regel gilt für jeden PR unabhängig vom erzeugenden Werkzeug (Claude, Perplexity, Codex oder andere); die Draft-/Review-Pause-Ausnahme aus dem ersten Punkt dieses Abschnitts bleibt unberührt.
 


### PR DESCRIPTION
## Codex-P2-Fix: Review-Pause-PRs bleiben ready

Codex hat zu Recht angemerkt, dass Schritt 1 des aktuellen Workflows Draft- und Review-Pause-PRs gleichbehandelt — beide werden zu `draft: true`. Das ist falsch:

- **Draft** = der PR ist noch nicht fertig, bitte nicht reviewen
- **Review-Pause** = der PR ist fertig (`ready`), bitte aber noch nicht mergen, ich will erst draufschauen

Wenn der Nutzer nur eine Review-Pause möchte, soll der PR ready sein, damit Codex und ein Mensch ihn ordentlich inspizieren können.

### Fix

- `draft: true` **nur** bei ausdrücklichem Draft-Wunsch.
- Reine Review-Pause: `draft: false` (ready), aber nicht automatisch mergen.
- `@codex review`-Kommentar **sofort** bei jedem PR — auch bei Draft, auch bei Review-Pause (keine Verzögerung mehr auf "sobald der PR ready wird").
- Merge-Stopp bleibt bei Draft **oder** Review-Pause.

---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_