### PR TITLE
Megaprompts als Direkt-Download-Datei statt Browser-Anzeige

### DIFF
--- a/.github/workflows/release-plugin-zips.yml
+++ b/.github/workflows/release-plugin-zips.yml
@@ -78,6 +78,24 @@ jobs:
           ls dist/*-skills-markdown.zip | wc -l
           ls -lh dist/alle-skills-markdown.zip
 
+      - name: Megaprompts als Einzeldateien fuer Direkt-Download bereitstellen
+        run: |
+          # Jeden Megaprompt zusaetzlich als eigenstaendiges Release-Asset
+          # bereitstellen. Release-Assets liefert GitHub mit
+          # Content-Disposition: attachment, der Browser laedt sie also herunter
+          # statt sie als text/plain anzuzeigen. Dateiname-Schema:
+          #   <plugin>-megaprompt.md
+          for mp in testakten/megaprompts/*.md; do
+            name="$(basename "$mp")"
+            # README im Megaprompt-Ordner ist keine Megaprompt-Datei.
+            if [ "$name" = "README.md" ]; then
+              continue
+            fi
+            plugin="${name%.md}"
+            cp "$mp" "dist/${plugin}-megaprompt.md"
+          done
+          ls dist/*-megaprompt.md | wc -l
+
       - name: Sammel-ZIPs bauen
         run: |
           # alle-plugins-megazip.zip enthaelt die installierbaren Einzel-ZIPs
@@ -142,7 +160,7 @@ jobs:
           dist = Path("dist")
           assets = sorted(
               p for p in dist.iterdir()
-              if p.is_file() and (p.suffix == ".zip" or p.name == "marketplace.json")
+              if p.is_file() and (p.suffix == ".zip" or p.name == "marketplace.json" or p.name.endswith("-megaprompt.md"))
           )
           with (dist / "checksums-sha256.txt").open("w", encoding="utf-8") as fh:
               for path in assets:
@@ -198,7 +216,7 @@ jobs:
             else
               sleep 2
             fi
-          done < <(find dist -maxdepth 1 -type f \( -name '*.zip' -o -name 'marketplace.json' -o -name 'checksums-sha256.txt' \) | sort)
+          done < <(find dist -maxdepth 1 -type f \( -name '*.zip' -o -name '*-megaprompt.md' -o -name 'marketplace.json' -o -name 'checksums-sha256.txt' \) | sort)
 
       - name: Release-Assets remote verifizieren
         if: steps.tagref.outputs.tag != ''

--- a/agb-recht-pruefer/README.md
+++ b/agb-recht-pruefer/README.md
@@ -391,7 +391,8 @@ Automatisch generierte Komplett-Liste aller 303 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`agb-recht-pruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/agb-recht-pruefer.md) (24 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`agb-recht-pruefer-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/agb-recht-pruefer-megaprompt.md) (24 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`agb-recht-pruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/agb-recht-pruefer.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/agb-recht-pruefer.md`](../testakten/megaprompts/agb-recht-pruefer.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/aktenaufbereiter-strafrecht/README.md
+++ b/aktenaufbereiter-strafrecht/README.md
@@ -117,7 +117,8 @@ Automatisch generierte Komplett-Liste aller 59 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`aktenaufbereiter-strafrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/aktenaufbereiter-strafrecht.md) (70 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`aktenaufbereiter-strafrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/aktenaufbereiter-strafrecht-megaprompt.md) (73 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`aktenaufbereiter-strafrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/aktenaufbereiter-strafrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/aktenaufbereiter-strafrecht.md`](../testakten/megaprompts/aktenaufbereiter-strafrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/aktenauszug-gerichtsverfahren/README.md
+++ b/aktenauszug-gerichtsverfahren/README.md
@@ -170,7 +170,8 @@ Automatisch generierte Komplett-Liste aller 58 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`aktenauszug-gerichtsverfahren.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/aktenauszug-gerichtsverfahren.md) (100 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`aktenauszug-gerichtsverfahren-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/aktenauszug-gerichtsverfahren-megaprompt.md) (102 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`aktenauszug-gerichtsverfahren.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/aktenauszug-gerichtsverfahren.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/aktenauszug-gerichtsverfahren.md`](../testakten/megaprompts/aktenauszug-gerichtsverfahren.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/aktienrecht-hauptversammlung-ag-se/README.md
+++ b/aktienrecht-hauptversammlung-ag-se/README.md
@@ -158,7 +158,8 @@ Automatisch generierte Komplett-Liste aller 100 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`aktienrecht-hauptversammlung-ag-se.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/aktienrecht-hauptversammlung-ag-se.md) (38 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`aktienrecht-hauptversammlung-ag-se-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/aktienrecht-hauptversammlung-ag-se-megaprompt.md) (38 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`aktienrecht-hauptversammlung-ag-se.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/aktienrecht-hauptversammlung-ag-se.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/aktienrecht-hauptversammlung-ag-se.md`](../testakten/megaprompts/aktienrecht-hauptversammlung-ag-se.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/anlagen-zu-schriftsaetzen/README.md
+++ b/anlagen-zu-schriftsaetzen/README.md
@@ -224,7 +224,8 @@ Automatisch generierte Komplett-Liste aller 115 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`anlagen-zu-schriftsaetzen.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/anlagen-zu-schriftsaetzen.md) (39 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`anlagen-zu-schriftsaetzen-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/anlagen-zu-schriftsaetzen-megaprompt.md) (42 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`anlagen-zu-schriftsaetzen.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/anlagen-zu-schriftsaetzen.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/anlagen-zu-schriftsaetzen.md`](../testakten/megaprompts/anlagen-zu-schriftsaetzen.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/apothekenrecht/README.md
+++ b/apothekenrecht/README.md
@@ -134,7 +134,8 @@ Automatisch generierte Komplett-Liste aller 65 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`apothekenrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/apothekenrecht.md) (72 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`apothekenrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/apothekenrecht-megaprompt.md) (72 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`apothekenrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/apothekenrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/apothekenrecht.md`](../testakten/megaprompts/apothekenrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/arbeitsrecht/README.md
+++ b/arbeitsrecht/README.md
@@ -323,7 +323,8 @@ Automatisch generierte Komplett-Liste aller 98 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`arbeitsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/arbeitsrecht.md) (153 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`arbeitsrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/arbeitsrecht-megaprompt.md) (146 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`arbeitsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/arbeitsrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/arbeitsrecht.md`](../testakten/megaprompts/arbeitsrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/arbeitszeugnis-analyse/README.md
+++ b/arbeitszeugnis-analyse/README.md
@@ -186,7 +186,8 @@ Automatisch generierte Komplett-Liste aller 50 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`arbeitszeugnis-analyse.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/arbeitszeugnis-analyse.md) (84 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`arbeitszeugnis-analyse-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/arbeitszeugnis-analyse-megaprompt.md) (84 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`arbeitszeugnis-analyse.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/arbeitszeugnis-analyse.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/arbeitszeugnis-analyse.md`](../testakten/megaprompts/arbeitszeugnis-analyse.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/aufsichtsrat-ag-se-praxis/README.md
+++ b/aufsichtsrat-ag-se-praxis/README.md
@@ -154,7 +154,8 @@ Automatisch generierte Komplett-Liste aller 100 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`aufsichtsrat-ag-se-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/aufsichtsrat-ag-se-praxis.md) (37 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`aufsichtsrat-ag-se-praxis-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/aufsichtsrat-ag-se-praxis-megaprompt.md) (37 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`aufsichtsrat-ag-se-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/aufsichtsrat-ag-se-praxis.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/aufsichtsrat-ag-se-praxis.md`](../testakten/megaprompts/aufsichtsrat-ag-se-praxis.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/aussenwirtschaft-zoll-sanktionen/README.md
+++ b/aussenwirtschaft-zoll-sanktionen/README.md
@@ -244,7 +244,8 @@ Automatisch generierte Komplett-Liste aller 124 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`aussenwirtschaft-zoll-sanktionen.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/aussenwirtschaft-zoll-sanktionen.md) (68 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`aussenwirtschaft-zoll-sanktionen-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/aussenwirtschaft-zoll-sanktionen-megaprompt.md) (63 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`aussenwirtschaft-zoll-sanktionen.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/aussenwirtschaft-zoll-sanktionen.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/aussenwirtschaft-zoll-sanktionen.md`](../testakten/megaprompts/aussenwirtschaft-zoll-sanktionen.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/bank-rechtsabteilung/README.md
+++ b/bank-rechtsabteilung/README.md
@@ -247,7 +247,8 @@ Automatisch generierte Komplett-Liste aller 121 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`bank-rechtsabteilung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/bank-rechtsabteilung.md) (49 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`bank-rechtsabteilung-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/bank-rechtsabteilung-megaprompt.md) (50 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`bank-rechtsabteilung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/bank-rechtsabteilung.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/bank-rechtsabteilung.md`](../testakten/megaprompts/bank-rechtsabteilung.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/barrierefreiheit-web-checker/README.md
+++ b/barrierefreiheit-web-checker/README.md
@@ -132,7 +132,8 @@ Automatisch generierte Komplett-Liste aller 59 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`barrierefreiheit-web-checker.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/barrierefreiheit-web-checker.md) (54 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`barrierefreiheit-web-checker-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/barrierefreiheit-web-checker-megaprompt.md) (55 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`barrierefreiheit-web-checker.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/barrierefreiheit-web-checker.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/barrierefreiheit-web-checker.md`](../testakten/megaprompts/barrierefreiheit-web-checker.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/bav-strategie-konzern/README.md
+++ b/bav-strategie-konzern/README.md
@@ -166,7 +166,8 @@ Automatisch generierte Komplett-Liste aller 58 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`bav-strategie-konzern.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/bav-strategie-konzern.md) (168 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`bav-strategie-konzern-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/bav-strategie-konzern-megaprompt.md) (168 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`bav-strategie-konzern.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/bav-strategie-konzern.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/bav-strategie-konzern.md`](../testakten/megaprompts/bav-strategie-konzern.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/beamtenrecht/README.md
+++ b/beamtenrecht/README.md
@@ -281,7 +281,8 @@ Automatisch generierte Komplett-Liste aller 178 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`beamtenrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/beamtenrecht.md) (39 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`beamtenrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/beamtenrecht-megaprompt.md) (38 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`beamtenrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/beamtenrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/beamtenrecht.md`](../testakten/megaprompts/beamtenrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/bereicherungs-und-anfechtungsrecht-pruefer/README.md
+++ b/bereicherungs-und-anfechtungsrecht-pruefer/README.md
@@ -385,7 +385,8 @@ Automatisch generierte Komplett-Liste aller 138 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`bereicherungs-und-anfechtungsrecht-pruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/bereicherungs-und-anfechtungsrecht-pruefer.md) (64 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`bereicherungs-und-anfechtungsrecht-pruefer-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/bereicherungs-und-anfechtungsrecht-pruefer-megaprompt.md) (64 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`bereicherungs-und-anfechtungsrecht-pruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/bereicherungs-und-anfechtungsrecht-pruefer.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/bereicherungs-und-anfechtungsrecht-pruefer.md`](../testakten/megaprompts/bereicherungs-und-anfechtungsrecht-pruefer.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/berichtspflichten-erlediger/README.md
+++ b/berichtspflichten-erlediger/README.md
@@ -111,7 +111,8 @@ Automatisch generierte Komplett-Liste aller 57 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`berichtspflichten-erlediger.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/berichtspflichten-erlediger.md) (35 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`berichtspflichten-erlediger-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/berichtspflichten-erlediger-megaprompt.md) (35 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`berichtspflichten-erlediger.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/berichtspflichten-erlediger.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/berichtspflichten-erlediger.md`](../testakten/megaprompts/berichtspflichten-erlediger.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/berufsgerichtliche-verfahren-freie-berufe/README.md
+++ b/berufsgerichtliche-verfahren-freie-berufe/README.md
@@ -159,7 +159,8 @@ Automatisch generierte Komplett-Liste aller 99 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`berufsgerichtliche-verfahren-freie-berufe.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/berufsgerichtliche-verfahren-freie-berufe.md) (41 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`berufsgerichtliche-verfahren-freie-berufe-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/berufsgerichtliche-verfahren-freie-berufe-megaprompt.md) (41 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`berufsgerichtliche-verfahren-freie-berufe.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/berufsgerichtliche-verfahren-freie-berufe.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/berufsgerichtliche-verfahren-freie-berufe.md`](../testakten/megaprompts/berufsgerichtliche-verfahren-freie-berufe.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/berufsrecht-anwaelte/README.md
+++ b/berufsrecht-anwaelte/README.md
@@ -273,7 +273,8 @@ Automatisch generierte Komplett-Liste aller 208 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`berufsrecht-anwaelte.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/berufsrecht-anwaelte.md) (29 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`berufsrecht-anwaelte-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/berufsrecht-anwaelte-megaprompt.md) (29 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`berufsrecht-anwaelte.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/berufsrecht-anwaelte.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/berufsrecht-anwaelte.md`](../testakten/megaprompts/berufsrecht-anwaelte.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/berufsrecht-ki-vertragspruefung/README.md
+++ b/berufsrecht-ki-vertragspruefung/README.md
@@ -203,7 +203,8 @@ Automatisch generierte Komplett-Liste aller 94 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`berufsrecht-ki-vertragspruefung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/berufsrecht-ki-vertragspruefung.md) (82 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`berufsrecht-ki-vertragspruefung-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/berufsrecht-ki-vertragspruefung-megaprompt.md) (85 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`berufsrecht-ki-vertragspruefung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/berufsrecht-ki-vertragspruefung.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/berufsrecht-ki-vertragspruefung.md`](../testakten/megaprompts/berufsrecht-ki-vertragspruefung.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/berufsrecht-notare/README.md
+++ b/berufsrecht-notare/README.md
@@ -268,7 +268,8 @@ Automatisch generierte Komplett-Liste aller 204 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`berufsrecht-notare.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/berufsrecht-notare.md) (34 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`berufsrecht-notare-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/berufsrecht-notare-megaprompt.md) (34 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`berufsrecht-notare.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/berufsrecht-notare.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/berufsrecht-notare.md`](../testakten/megaprompts/berufsrecht-notare.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/berufsrecht-patentanwaelte/README.md
+++ b/berufsrecht-patentanwaelte/README.md
@@ -264,7 +264,8 @@ Automatisch generierte Komplett-Liste aller 204 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`berufsrecht-patentanwaelte.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/berufsrecht-patentanwaelte.md) (29 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`berufsrecht-patentanwaelte-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/berufsrecht-patentanwaelte-megaprompt.md) (29 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`berufsrecht-patentanwaelte.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/berufsrecht-patentanwaelte.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/berufsrecht-patentanwaelte.md`](../testakten/megaprompts/berufsrecht-patentanwaelte.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/berufsrecht-steuerberater/README.md
+++ b/berufsrecht-steuerberater/README.md
@@ -264,7 +264,8 @@ Automatisch generierte Komplett-Liste aller 204 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`berufsrecht-steuerberater.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/berufsrecht-steuerberater.md) (32 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`berufsrecht-steuerberater-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/berufsrecht-steuerberater-megaprompt.md) (32 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`berufsrecht-steuerberater.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/berufsrecht-steuerberater.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/berufsrecht-steuerberater.md`](../testakten/megaprompts/berufsrecht-steuerberater.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/berufsrecht-wirtschaftspruefer/README.md
+++ b/berufsrecht-wirtschaftspruefer/README.md
@@ -292,7 +292,8 @@ Automatisch generierte Komplett-Liste aller 232 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`berufsrecht-wirtschaftspruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/berufsrecht-wirtschaftspruefer.md) (28 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`berufsrecht-wirtschaftspruefer-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/berufsrecht-wirtschaftspruefer-megaprompt.md) (28 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`berufsrecht-wirtschaftspruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/berufsrecht-wirtschaftspruefer.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/berufsrecht-wirtschaftspruefer.md`](../testakten/megaprompts/berufsrecht-wirtschaftspruefer.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/betaeubungsmittelrecht/README.md
+++ b/betaeubungsmittelrecht/README.md
@@ -192,7 +192,8 @@ Automatisch generierte Komplett-Liste aller 125 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`betaeubungsmittelrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/betaeubungsmittelrecht.md) (35 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`betaeubungsmittelrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/betaeubungsmittelrecht-megaprompt.md) (28 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`betaeubungsmittelrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/betaeubungsmittelrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/betaeubungsmittelrecht.md`](../testakten/megaprompts/betaeubungsmittelrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/betreuungsrecht/README.md
+++ b/betreuungsrecht/README.md
@@ -220,7 +220,8 @@ Automatisch generierte Komplett-Liste aller 116 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`betreuungsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/betreuungsrecht.md) (80 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`betreuungsrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/betreuungsrecht-megaprompt.md) (81 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`betreuungsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/betreuungsrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/betreuungsrecht.md`](../testakten/megaprompts/betreuungsrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/bgb-at-pruefer/README.md
+++ b/bgb-at-pruefer/README.md
@@ -182,7 +182,8 @@ Automatisch generierte Komplett-Liste aller 95 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`bgb-at-pruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/bgb-at-pruefer.md) (47 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`bgb-at-pruefer-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/bgb-at-pruefer-megaprompt.md) (47 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`bgb-at-pruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/bgb-at-pruefer.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/bgb-at-pruefer.md`](../testakten/megaprompts/bgb-at-pruefer.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/bgb-bt-pruefer/README.md
+++ b/bgb-bt-pruefer/README.md
@@ -181,7 +181,8 @@ Automatisch generierte Komplett-Liste aller 108 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`bgb-bt-pruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/bgb-bt-pruefer.md) (34 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`bgb-bt-pruefer-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/bgb-bt-pruefer-megaprompt.md) (34 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`bgb-bt-pruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/bgb-bt-pruefer.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/bgb-bt-pruefer.md`](../testakten/megaprompts/bgb-bt-pruefer.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/buerokratieversteher-entbuerokratisierer/README.md
+++ b/buerokratieversteher-entbuerokratisierer/README.md
@@ -152,7 +152,8 @@ Automatisch generierte Komplett-Liste aller 100 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`buerokratieversteher-entbuerokratisierer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/buerokratieversteher-entbuerokratisierer.md) (41 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`buerokratieversteher-entbuerokratisierer-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/buerokratieversteher-entbuerokratisierer-megaprompt.md) (41 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`buerokratieversteher-entbuerokratisierer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/buerokratieversteher-entbuerokratisierer.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/buerokratieversteher-entbuerokratisierer.md`](../testakten/megaprompts/buerokratieversteher-entbuerokratisierer.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/bundesnetzagentur-verfahren/README.md
+++ b/bundesnetzagentur-verfahren/README.md
@@ -295,7 +295,8 @@ Automatisch generierte Komplett-Liste aller 221 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`bundesnetzagentur-verfahren.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/bundesnetzagentur-verfahren.md) (63 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`bundesnetzagentur-verfahren-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/bundesnetzagentur-verfahren-megaprompt.md) (63 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`bundesnetzagentur-verfahren.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/bundesnetzagentur-verfahren.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/bundesnetzagentur-verfahren.md`](../testakten/megaprompts/bundesnetzagentur-verfahren.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/bundeswehrrecht-wehrrecht/README.md
+++ b/bundeswehrrecht-wehrrecht/README.md
@@ -179,7 +179,8 @@ Automatisch generierte Komplett-Liste aller 106 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`bundeswehrrecht-wehrrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/bundeswehrrecht-wehrrecht.md) (91 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`bundeswehrrecht-wehrrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/bundeswehrrecht-wehrrecht-megaprompt.md) (76 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`bundeswehrrecht-wehrrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/bundeswehrrecht-wehrrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/bundeswehrrecht-wehrrecht.md`](../testakten/megaprompts/bundeswehrrecht-wehrrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/commercial-courts-deutschland/README.md
+++ b/commercial-courts-deutschland/README.md
@@ -212,7 +212,8 @@ Automatisch generierte Komplett-Liste aller 57 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`commercial-courts-deutschland.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/commercial-courts-deutschland.md) (81 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`commercial-courts-deutschland-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/commercial-courts-deutschland-megaprompt.md) (81 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`commercial-courts-deutschland.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/commercial-courts-deutschland.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/commercial-courts-deutschland.md`](../testakten/megaprompts/commercial-courts-deutschland.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/common-law-kompass/README.md
+++ b/common-law-kompass/README.md
@@ -158,7 +158,8 @@ Automatisch generierte Komplett-Liste aller 58 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`common-law-kompass.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/common-law-kompass.md) (106 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`common-law-kompass-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/common-law-kompass-megaprompt.md) (101 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`common-law-kompass.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/common-law-kompass.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/common-law-kompass.md`](../testakten/megaprompts/common-law-kompass.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/corporate-kanzlei/README.md
+++ b/corporate-kanzlei/README.md
@@ -210,7 +210,8 @@ Automatisch generierte Komplett-Liste aller 87 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`corporate-kanzlei.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/corporate-kanzlei.md) (156 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`corporate-kanzlei-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/corporate-kanzlei-megaprompt.md) (160 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`corporate-kanzlei.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/corporate-kanzlei.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/corporate-kanzlei.md`](../testakten/megaprompts/corporate-kanzlei.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/datenbankrecht/README.md
+++ b/datenbankrecht/README.md
@@ -187,7 +187,8 @@ Automatisch generierte Komplett-Liste aller 129 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`datenbankrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/datenbankrecht.md) (56 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`datenbankrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/datenbankrecht-megaprompt.md) (45 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`datenbankrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/datenbankrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/datenbankrecht.md`](../testakten/megaprompts/datenbankrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/datenschutz-sanktionsverfahren-verteidigung/README.md
+++ b/datenschutz-sanktionsverfahren-verteidigung/README.md
@@ -202,7 +202,8 @@ Automatisch generierte Komplett-Liste aller 100 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`datenschutz-sanktionsverfahren-verteidigung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/datenschutz-sanktionsverfahren-verteidigung.md) (62 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`datenschutz-sanktionsverfahren-verteidigung-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/datenschutz-sanktionsverfahren-verteidigung-megaprompt.md) (52 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`datenschutz-sanktionsverfahren-verteidigung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/datenschutz-sanktionsverfahren-verteidigung.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/datenschutz-sanktionsverfahren-verteidigung.md`](../testakten/megaprompts/datenschutz-sanktionsverfahren-verteidigung.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/datenschutzrecht/README.md
+++ b/datenschutzrecht/README.md
@@ -603,7 +603,8 @@ Automatisch generierte Komplett-Liste aller 365 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`datenschutzrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/datenschutzrecht.md) (63 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`datenschutzrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/datenschutzrecht-megaprompt.md) (71 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`datenschutzrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/datenschutzrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/datenschutzrecht.md`](../testakten/megaprompts/datenschutzrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/designrecht-geschmacksmusterrecht/README.md
+++ b/designrecht-geschmacksmusterrecht/README.md
@@ -118,7 +118,8 @@ Automatisch generierte Komplett-Liste aller 50 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`designrecht-geschmacksmusterrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/designrecht-geschmacksmusterrecht.md) (41 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`designrecht-geschmacksmusterrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/designrecht-geschmacksmusterrecht-megaprompt.md) (41 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`designrecht-geschmacksmusterrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/designrecht-geschmacksmusterrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/designrecht-geschmacksmusterrecht.md`](../testakten/megaprompts/designrecht-geschmacksmusterrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/deutsche-rechtsgeschichte/README.md
+++ b/deutsche-rechtsgeschichte/README.md
@@ -270,7 +270,8 @@ Automatisch generierte Komplett-Liste aller 205 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`deutsche-rechtsgeschichte.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/deutsche-rechtsgeschichte.md) (35 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`deutsche-rechtsgeschichte-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/deutsche-rechtsgeschichte-megaprompt.md) (35 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`deutsche-rechtsgeschichte.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/deutsche-rechtsgeschichte.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/deutsche-rechtsgeschichte.md`](../testakten/megaprompts/deutsche-rechtsgeschichte.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/dfg-foerderantrag/README.md
+++ b/dfg-foerderantrag/README.md
@@ -162,7 +162,8 @@ Automatisch generierte Komplett-Liste aller 84 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`dfg-foerderantrag.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/dfg-foerderantrag.md) (52 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`dfg-foerderantrag-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/dfg-foerderantrag-megaprompt.md) (53 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`dfg-foerderantrag.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/dfg-foerderantrag.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/dfg-foerderantrag.md`](../testakten/megaprompts/dfg-foerderantrag.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/dsa-dma-digitalregulierung/README.md
+++ b/dsa-dma-digitalregulierung/README.md
@@ -131,7 +131,8 @@ Automatisch generierte Komplett-Liste aller 58 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`dsa-dma-digitalregulierung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/dsa-dma-digitalregulierung.md) (112 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`dsa-dma-digitalregulierung-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/dsa-dma-digitalregulierung-megaprompt.md) (115 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`dsa-dma-digitalregulierung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/dsa-dma-digitalregulierung.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/dsa-dma-digitalregulierung.md`](../testakten/megaprompts/dsa-dma-digitalregulierung.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/ecommerce-recht/README.md
+++ b/ecommerce-recht/README.md
@@ -145,7 +145,8 @@ Automatisch generierte Komplett-Liste aller 72 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`ecommerce-recht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/ecommerce-recht.md) (62 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`ecommerce-recht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/ecommerce-recht-megaprompt.md) (62 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`ecommerce-recht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/ecommerce-recht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/ecommerce-recht.md`](../testakten/megaprompts/ecommerce-recht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/einfache-leichte-sprache-jura/README.md
+++ b/einfache-leichte-sprache-jura/README.md
@@ -180,7 +180,8 @@ Automatisch generierte Komplett-Liste aller 87 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`einfache-leichte-sprache-jura.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/einfache-leichte-sprache-jura.md) (45 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`einfache-leichte-sprache-jura-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/einfache-leichte-sprache-jura-megaprompt.md) (46 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`einfache-leichte-sprache-jura.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/einfache-leichte-sprache-jura.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/einfache-leichte-sprache-jura.md`](../testakten/megaprompts/einfache-leichte-sprache-jura.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/einigungsvertrag-vermoegensrecht/README.md
+++ b/einigungsvertrag-vermoegensrecht/README.md
@@ -190,7 +190,8 @@ Automatisch generierte Komplett-Liste aller 123 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`einigungsvertrag-vermoegensrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/einigungsvertrag-vermoegensrecht.md) (30 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`einigungsvertrag-vermoegensrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/einigungsvertrag-vermoegensrecht-megaprompt.md) (24 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`einigungsvertrag-vermoegensrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/einigungsvertrag-vermoegensrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/einigungsvertrag-vermoegensrecht.md`](../testakten/megaprompts/einigungsvertrag-vermoegensrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/email-umformulierer-berufsrecht/README.md
+++ b/email-umformulierer-berufsrecht/README.md
@@ -204,7 +204,8 @@ Automatisch generierte Komplett-Liste aller 82 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`email-umformulierer-berufsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/email-umformulierer-berufsrecht.md) (62 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`email-umformulierer-berufsrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/email-umformulierer-berufsrecht-megaprompt.md) (63 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`email-umformulierer-berufsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/email-umformulierer-berufsrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/email-umformulierer-berufsrecht.md`](../testakten/megaprompts/email-umformulierer-berufsrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/energierecht/README.md
+++ b/energierecht/README.md
@@ -186,7 +186,8 @@ Automatisch generierte Komplett-Liste aller 95 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`energierecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/energierecht.md) (92 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`energierecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/energierecht-megaprompt.md) (92 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`energierecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/energierecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/energierecht.md`](../testakten/megaprompts/energierecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/erbbaurecht-praxis/README.md
+++ b/erbbaurecht-praxis/README.md
@@ -120,7 +120,8 @@ Automatisch generierte Komplett-Liste aller 50 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`erbbaurecht-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/erbbaurecht-praxis.md) (55 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`erbbaurecht-praxis-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/erbbaurecht-praxis-megaprompt.md) (57 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`erbbaurecht-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/erbbaurecht-praxis.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/erbbaurecht-praxis.md`](../testakten/megaprompts/erbbaurecht-praxis.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/europarecht-kompass/README.md
+++ b/europarecht-kompass/README.md
@@ -157,7 +157,8 @@ Automatisch generierte Komplett-Liste aller 57 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`europarecht-kompass.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/europarecht-kompass.md) (86 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`europarecht-kompass-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/europarecht-kompass-megaprompt.md) (91 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`europarecht-kompass.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/europarecht-kompass.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/europarecht-kompass.md`](../testakten/megaprompts/europarecht-kompass.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-agrarrecht/README.md
+++ b/fachanwalt-agrarrecht/README.md
@@ -136,7 +136,8 @@ Automatisch generierte Komplett-Liste aller 78 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-agrarrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-agrarrecht.md) (64 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-agrarrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-agrarrecht-megaprompt.md) (71 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-agrarrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-agrarrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-agrarrecht.md`](../testakten/megaprompts/fachanwalt-agrarrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-arbeitsrecht/README.md
+++ b/fachanwalt-arbeitsrecht/README.md
@@ -200,7 +200,8 @@ Automatisch generierte Komplett-Liste aller 119 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-arbeitsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-arbeitsrecht.md) (90 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-arbeitsrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-arbeitsrecht-megaprompt.md) (74 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-arbeitsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-arbeitsrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-arbeitsrecht.md`](../testakten/megaprompts/fachanwalt-arbeitsrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-bank-kapitalmarktrecht/README.md
+++ b/fachanwalt-bank-kapitalmarktrecht/README.md
@@ -149,7 +149,8 @@ Automatisch generierte Komplett-Liste aller 86 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-bank-kapitalmarktrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-bank-kapitalmarktrecht.md) (55 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-bank-kapitalmarktrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-bank-kapitalmarktrecht-megaprompt.md) (86 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-bank-kapitalmarktrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-bank-kapitalmarktrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-bank-kapitalmarktrecht.md`](../testakten/megaprompts/fachanwalt-bank-kapitalmarktrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-bau-architektenrecht/README.md
+++ b/fachanwalt-bau-architektenrecht/README.md
@@ -174,7 +174,8 @@ Automatisch generierte Komplett-Liste aller 115 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-bau-architektenrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-bau-architektenrecht.md) (40 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-bau-architektenrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-bau-architektenrecht-megaprompt.md) (47 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-bau-architektenrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-bau-architektenrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-bau-architektenrecht.md`](../testakten/megaprompts/fachanwalt-bau-architektenrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-erbrecht/README.md
+++ b/fachanwalt-erbrecht/README.md
@@ -168,7 +168,8 @@ Automatisch generierte Komplett-Liste aller 97 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-erbrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-erbrecht.md) (65 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-erbrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-erbrecht-megaprompt.md) (72 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-erbrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-erbrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-erbrecht.md`](../testakten/megaprompts/fachanwalt-erbrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-familienrecht/README.md
+++ b/fachanwalt-familienrecht/README.md
@@ -221,7 +221,8 @@ Automatisch generierte Komplett-Liste aller 154 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-familienrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-familienrecht.md) (51 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-familienrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-familienrecht-megaprompt.md) (55 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-familienrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-familienrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-familienrecht.md`](../testakten/megaprompts/fachanwalt-familienrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-gewerblicher-rechtsschutz/README.md
+++ b/fachanwalt-gewerblicher-rechtsschutz/README.md
@@ -171,7 +171,8 @@ Automatisch generierte Komplett-Liste aller 107 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-gewerblicher-rechtsschutz.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-gewerblicher-rechtsschutz.md) (79 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-gewerblicher-rechtsschutz-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-gewerblicher-rechtsschutz-megaprompt.md) (88 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-gewerblicher-rechtsschutz.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-gewerblicher-rechtsschutz.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-gewerblicher-rechtsschutz.md`](../testakten/megaprompts/fachanwalt-gewerblicher-rechtsschutz.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-handels-gesellschaftsrecht/README.md
+++ b/fachanwalt-handels-gesellschaftsrecht/README.md
@@ -173,7 +173,8 @@ Automatisch generierte Komplett-Liste aller 94 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-handels-gesellschaftsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-handels-gesellschaftsrecht.md) (57 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-handels-gesellschaftsrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-handels-gesellschaftsrecht-megaprompt.md) (90 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-handels-gesellschaftsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-handels-gesellschaftsrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-handels-gesellschaftsrecht.md`](../testakten/megaprompts/fachanwalt-handels-gesellschaftsrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-insolvenz-sanierungsrecht/README.md
+++ b/fachanwalt-insolvenz-sanierungsrecht/README.md
@@ -600,7 +600,8 @@ Automatisch generierte Komplett-Liste aller 505 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-insolvenz-sanierungsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-insolvenz-sanierungsrecht.md) (56 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-insolvenz-sanierungsrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-insolvenz-sanierungsrecht-megaprompt.md) (72 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-insolvenz-sanierungsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-insolvenz-sanierungsrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-insolvenz-sanierungsrecht.md`](../testakten/megaprompts/fachanwalt-insolvenz-sanierungsrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-internationales-wirtschaftsrecht/README.md
+++ b/fachanwalt-internationales-wirtschaftsrecht/README.md
@@ -135,7 +135,8 @@ Automatisch generierte Komplett-Liste aller 77 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-internationales-wirtschaftsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-internationales-wirtschaftsrecht.md) (50 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-internationales-wirtschaftsrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-internationales-wirtschaftsrecht-megaprompt.md) (88 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-internationales-wirtschaftsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-internationales-wirtschaftsrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-internationales-wirtschaftsrecht.md`](../testakten/megaprompts/fachanwalt-internationales-wirtschaftsrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-it-recht/README.md
+++ b/fachanwalt-it-recht/README.md
@@ -197,7 +197,8 @@ Automatisch generierte Komplett-Liste aller 137 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-it-recht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-it-recht.md) (47 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-it-recht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-it-recht-megaprompt.md) (54 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-it-recht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-it-recht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-it-recht.md`](../testakten/megaprompts/fachanwalt-it-recht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-medizinrecht/README.md
+++ b/fachanwalt-medizinrecht/README.md
@@ -231,7 +231,8 @@ Automatisch generierte Komplett-Liste aller 158 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-medizinrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-medizinrecht.md) (51 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-medizinrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-medizinrecht-megaprompt.md) (62 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-medizinrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-medizinrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-medizinrecht.md`](../testakten/megaprompts/fachanwalt-medizinrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-miet-wohnungseigentumsrecht/README.md
+++ b/fachanwalt-miet-wohnungseigentumsrecht/README.md
@@ -459,7 +459,8 @@ Automatisch generierte Komplett-Liste aller 381 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-miet-wohnungseigentumsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-miet-wohnungseigentumsrecht.md) (50 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-miet-wohnungseigentumsrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-miet-wohnungseigentumsrecht-megaprompt.md) (67 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-miet-wohnungseigentumsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-miet-wohnungseigentumsrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-miet-wohnungseigentumsrecht.md`](../testakten/megaprompts/fachanwalt-miet-wohnungseigentumsrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-migrationsrecht/README.md
+++ b/fachanwalt-migrationsrecht/README.md
@@ -518,7 +518,8 @@ Automatisch generierte Komplett-Liste aller 460 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-migrationsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-migrationsrecht.md) (69 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-migrationsrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-migrationsrecht-megaprompt.md) (62 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-migrationsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-migrationsrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-migrationsrecht.md`](../testakten/megaprompts/fachanwalt-migrationsrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-sozialrecht/README.md
+++ b/fachanwalt-sozialrecht/README.md
@@ -211,7 +211,8 @@ Automatisch generierte Komplett-Liste aller 113 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-sozialrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-sozialrecht.md) (73 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-sozialrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-sozialrecht-megaprompt.md) (77 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-sozialrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-sozialrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-sozialrecht.md`](../testakten/megaprompts/fachanwalt-sozialrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-sportrecht/README.md
+++ b/fachanwalt-sportrecht/README.md
@@ -135,7 +135,8 @@ Automatisch generierte Komplett-Liste aller 77 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-sportrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-sportrecht.md) (50 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-sportrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-sportrecht-megaprompt.md) (57 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-sportrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-sportrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-sportrecht.md`](../testakten/megaprompts/fachanwalt-sportrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-strafrecht/README.md
+++ b/fachanwalt-strafrecht/README.md
@@ -327,7 +327,8 @@ Automatisch generierte Komplett-Liste aller 240 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-strafrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-strafrecht.md) (66 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-strafrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-strafrecht-megaprompt.md) (66 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-strafrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-strafrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-strafrecht.md`](../testakten/megaprompts/fachanwalt-strafrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-transport-speditionsrecht/README.md
+++ b/fachanwalt-transport-speditionsrecht/README.md
@@ -135,7 +135,8 @@ Automatisch generierte Komplett-Liste aller 77 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-transport-speditionsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-transport-speditionsrecht.md) (46 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-transport-speditionsrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-transport-speditionsrecht-megaprompt.md) (70 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-transport-speditionsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-transport-speditionsrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-transport-speditionsrecht.md`](../testakten/megaprompts/fachanwalt-transport-speditionsrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-urheber-medienrecht/README.md
+++ b/fachanwalt-urheber-medienrecht/README.md
@@ -136,7 +136,8 @@ Automatisch generierte Komplett-Liste aller 77 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-urheber-medienrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-urheber-medienrecht.md) (62 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-urheber-medienrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-urheber-medienrecht-megaprompt.md) (82 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-urheber-medienrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-urheber-medienrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-urheber-medienrecht.md`](../testakten/megaprompts/fachanwalt-urheber-medienrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-vergaberecht/README.md
+++ b/fachanwalt-vergaberecht/README.md
@@ -177,7 +177,8 @@ Automatisch generierte Komplett-Liste aller 119 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-vergaberecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-vergaberecht.md) (88 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-vergaberecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-vergaberecht-megaprompt.md) (105 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-vergaberecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-vergaberecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-vergaberecht.md`](../testakten/megaprompts/fachanwalt-vergaberecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-verkehrsrecht/README.md
+++ b/fachanwalt-verkehrsrecht/README.md
@@ -149,7 +149,8 @@ Automatisch generierte Komplett-Liste aller 77 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-verkehrsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-verkehrsrecht.md) (55 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-verkehrsrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-verkehrsrecht-megaprompt.md) (96 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-verkehrsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-verkehrsrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-verkehrsrecht.md`](../testakten/megaprompts/fachanwalt-verkehrsrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-versicherungsrecht/README.md
+++ b/fachanwalt-versicherungsrecht/README.md
@@ -163,7 +163,8 @@ Automatisch generierte Komplett-Liste aller 91 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-versicherungsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-versicherungsrecht.md) (56 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-versicherungsrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-versicherungsrecht-megaprompt.md) (91 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-versicherungsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-versicherungsrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-versicherungsrecht.md`](../testakten/megaprompts/fachanwalt-versicherungsrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fachanwalt-verwaltungsrecht/README.md
+++ b/fachanwalt-verwaltungsrecht/README.md
@@ -164,7 +164,8 @@ Automatisch generierte Komplett-Liste aller 80 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fachanwalt-verwaltungsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-verwaltungsrecht.md) (83 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fachanwalt-verwaltungsrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fachanwalt-verwaltungsrecht-megaprompt.md) (64 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fachanwalt-verwaltungsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fachanwalt-verwaltungsrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fachanwalt-verwaltungsrecht.md`](../testakten/megaprompts/fachanwalt-verwaltungsrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/factoring-recht/README.md
+++ b/factoring-recht/README.md
@@ -131,7 +131,8 @@ Automatisch generierte Komplett-Liste aller 62 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`factoring-recht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/factoring-recht.md) (76 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`factoring-recht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/factoring-recht-megaprompt.md) (76 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`factoring-recht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/factoring-recht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/factoring-recht.md`](../testakten/megaprompts/factoring-recht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fahrgastrechte/README.md
+++ b/fahrgastrechte/README.md
@@ -70,7 +70,8 @@ Automatisch generierte Komplett-Liste aller 13 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fahrgastrechte.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fahrgastrechte.md) (123 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fahrgastrechte-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fahrgastrechte-megaprompt.md) (126 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fahrgastrechte.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fahrgastrechte.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fahrgastrechte.md`](../testakten/megaprompts/fahrgastrechte.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fashion-law-moderecht/README.md
+++ b/fashion-law-moderecht/README.md
@@ -117,7 +117,8 @@ Automatisch generierte Komplett-Liste aller 50 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fashion-law-moderecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fashion-law-moderecht.md) (42 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fashion-law-moderecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fashion-law-moderecht-megaprompt.md) (42 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fashion-law-moderecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fashion-law-moderecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fashion-law-moderecht.md`](../testakten/megaprompts/fashion-law-moderecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/festlandchina-wirtschaftsverkehr/README.md
+++ b/festlandchina-wirtschaftsverkehr/README.md
@@ -257,7 +257,8 @@ Automatisch generierte Komplett-Liste aller 198 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`festlandchina-wirtschaftsverkehr.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/festlandchina-wirtschaftsverkehr.md) (44 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`festlandchina-wirtschaftsverkehr-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/festlandchina-wirtschaftsverkehr-megaprompt.md) (44 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`festlandchina-wirtschaftsverkehr.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/festlandchina-wirtschaftsverkehr.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/festlandchina-wirtschaftsverkehr.md`](../testakten/megaprompts/festlandchina-wirtschaftsverkehr.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fluggastrechte/README.md
+++ b/fluggastrechte/README.md
@@ -157,7 +157,8 @@ Automatisch generierte Komplett-Liste aller 86 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fluggastrechte.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fluggastrechte.md) (52 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fluggastrechte-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fluggastrechte-megaprompt.md) (52 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fluggastrechte.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fluggastrechte.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fluggastrechte.md`](../testakten/megaprompts/fluggastrechte.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/forderungsmanagement-klagewerkstatt/README.md
+++ b/forderungsmanagement-klagewerkstatt/README.md
@@ -218,7 +218,8 @@ Automatisch generierte Komplett-Liste aller 83 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`forderungsmanagement-klagewerkstatt.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/forderungsmanagement-klagewerkstatt.md) (62 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`forderungsmanagement-klagewerkstatt-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/forderungsmanagement-klagewerkstatt-megaprompt.md) (70 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`forderungsmanagement-klagewerkstatt.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/forderungsmanagement-klagewerkstatt.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/forderungsmanagement-klagewerkstatt.md`](../testakten/megaprompts/forderungsmanagement-klagewerkstatt.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/forschungszulage-antragstellung/README.md
+++ b/forschungszulage-antragstellung/README.md
@@ -162,7 +162,8 @@ Automatisch generierte Komplett-Liste aller 84 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`forschungszulage-antragstellung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/forschungszulage-antragstellung.md) (59 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`forschungszulage-antragstellung-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/forschungszulage-antragstellung-megaprompt.md) (59 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`forschungszulage-antragstellung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/forschungszulage-antragstellung.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/forschungszulage-antragstellung.md`](../testakten/megaprompts/forschungszulage-antragstellung.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/fortbestehensprognose/README.md
+++ b/fortbestehensprognose/README.md
@@ -135,7 +135,8 @@ Automatisch generierte Komplett-Liste aller 59 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`fortbestehensprognose.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fortbestehensprognose.md) (118 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`fortbestehensprognose-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/fortbestehensprognose-megaprompt.md) (119 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`fortbestehensprognose.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/fortbestehensprognose.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/fortbestehensprognose.md`](../testakten/megaprompts/fortbestehensprognose.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/franchiserecht-praxis/README.md
+++ b/franchiserecht-praxis/README.md
@@ -186,7 +186,8 @@ Automatisch generierte Komplett-Liste aller 122 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`franchiserecht-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/franchiserecht-praxis.md) (38 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`franchiserecht-praxis-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/franchiserecht-praxis-megaprompt.md) (30 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`franchiserecht-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/franchiserecht-praxis.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/franchiserecht-praxis.md`](../testakten/megaprompts/franchiserecht-praxis.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/gebrauchsmusterrecht/README.md
+++ b/gebrauchsmusterrecht/README.md
@@ -117,7 +117,8 @@ Automatisch generierte Komplett-Liste aller 50 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`gebrauchsmusterrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/gebrauchsmusterrecht.md) (43 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`gebrauchsmusterrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/gebrauchsmusterrecht-megaprompt.md) (43 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`gebrauchsmusterrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/gebrauchsmusterrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/gebrauchsmusterrecht.md`](../testakten/megaprompts/gebrauchsmusterrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/geldwaeschepraevention-aml-kyc/README.md
+++ b/geldwaeschepraevention-aml-kyc/README.md
@@ -181,7 +181,8 @@ Automatisch generierte Komplett-Liste aller 57 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`geldwaeschepraevention-aml-kyc.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/geldwaeschepraevention-aml-kyc.md) (71 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`geldwaeschepraevention-aml-kyc-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/geldwaeschepraevention-aml-kyc-megaprompt.md) (73 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`geldwaeschepraevention-aml-kyc.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/geldwaeschepraevention-aml-kyc.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/geldwaeschepraevention-aml-kyc.md`](../testakten/megaprompts/geldwaeschepraevention-aml-kyc.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/gesellschaftsgruender/README.md
+++ b/gesellschaftsgruender/README.md
@@ -215,7 +215,8 @@ Automatisch generierte Komplett-Liste aller 104 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`gesellschaftsgruender.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/gesellschaftsgruender.md) (109 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`gesellschaftsgruender-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/gesellschaftsgruender-megaprompt.md) (86 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`gesellschaftsgruender.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/gesellschaftsgruender.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/gesellschaftsgruender.md`](../testakten/megaprompts/gesellschaftsgruender.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/gesellschaftsrecht-legal-english/README.md
+++ b/gesellschaftsrecht-legal-english/README.md
@@ -186,7 +186,8 @@ Automatisch generierte Komplett-Liste aller 53 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`gesellschaftsrecht-legal-english.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/gesellschaftsrecht-legal-english.md) (86 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`gesellschaftsrecht-legal-english-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/gesellschaftsrecht-legal-english-megaprompt.md) (86 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`gesellschaftsrecht-legal-english.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/gesellschaftsrecht-legal-english.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/gesellschaftsrecht-legal-english.md`](../testakten/megaprompts/gesellschaftsrecht-legal-english.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/gesellschaftsrecht/README.md
+++ b/gesellschaftsrecht/README.md
@@ -270,7 +270,8 @@ Automatisch generierte Komplett-Liste aller 106 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`gesellschaftsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/gesellschaftsrecht.md) (171 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`gesellschaftsrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/gesellschaftsrecht-megaprompt.md) (125 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`gesellschaftsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/gesellschaftsrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/gesellschaftsrecht.md`](../testakten/megaprompts/gesellschaftsrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/gesellschaftsrechtliche-treuepflicht/README.md
+++ b/gesellschaftsrechtliche-treuepflicht/README.md
@@ -154,7 +154,8 @@ Automatisch generierte Komplett-Liste aller 100 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`gesellschaftsrechtliche-treuepflicht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/gesellschaftsrechtliche-treuepflicht.md) (61 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`gesellschaftsrechtliche-treuepflicht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/gesellschaftsrechtliche-treuepflicht-megaprompt.md) (61 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`gesellschaftsrechtliche-treuepflicht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/gesellschaftsrechtliche-treuepflicht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/gesellschaftsrechtliche-treuepflicht.md`](../testakten/megaprompts/gesellschaftsrechtliche-treuepflicht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/gewerblicher-rechtsschutz/README.md
+++ b/gewerblicher-rechtsschutz/README.md
@@ -305,7 +305,8 @@ Automatisch generierte Komplett-Liste aller 93 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`gewerblicher-rechtsschutz.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/gewerblicher-rechtsschutz.md) (105 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`gewerblicher-rechtsschutz-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/gewerblicher-rechtsschutz-megaprompt.md) (100 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`gewerblicher-rechtsschutz.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/gewerblicher-rechtsschutz.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/gewerblicher-rechtsschutz.md`](../testakten/megaprompts/gewerblicher-rechtsschutz.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/goae-gebuehrenordnung-aerzte/README.md
+++ b/goae-gebuehrenordnung-aerzte/README.md
@@ -134,7 +134,8 @@ Automatisch generierte Komplett-Liste aller 65 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`goae-gebuehrenordnung-aerzte.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/goae-gebuehrenordnung-aerzte.md) (68 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`goae-gebuehrenordnung-aerzte-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/goae-gebuehrenordnung-aerzte-megaprompt.md) (68 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`goae-gebuehrenordnung-aerzte.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/goae-gebuehrenordnung-aerzte.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/goae-gebuehrenordnung-aerzte.md`](../testakten/megaprompts/goae-gebuehrenordnung-aerzte.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/grosskanzlei-corporate-ma/README.md
+++ b/grosskanzlei-corporate-ma/README.md
@@ -423,7 +423,8 @@ Automatisch generierte Komplett-Liste aller 271 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`grosskanzlei-corporate-ma.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/grosskanzlei-corporate-ma.md) (134 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`grosskanzlei-corporate-ma-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/grosskanzlei-corporate-ma-megaprompt.md) (115 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`grosskanzlei-corporate-ma.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/grosskanzlei-corporate-ma.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/grosskanzlei-corporate-ma.md`](../testakten/megaprompts/grosskanzlei-corporate-ma.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/grundbuchamt-praxis/README.md
+++ b/grundbuchamt-praxis/README.md
@@ -135,7 +135,8 @@ Automatisch generierte Komplett-Liste aller 64 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`grundbuchamt-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/grundbuchamt-praxis.md) (36 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`grundbuchamt-praxis-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/grundbuchamt-praxis-megaprompt.md) (37 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`grundbuchamt-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/grundbuchamt-praxis.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/grundbuchamt-praxis.md`](../testakten/megaprompts/grundbuchamt-praxis.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/handelsrecht-hgb/README.md
+++ b/handelsrecht-hgb/README.md
@@ -117,7 +117,8 @@ Automatisch generierte Komplett-Liste aller 56 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`handelsrecht-hgb.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/handelsrecht-hgb.md) (50 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`handelsrecht-hgb-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/handelsrecht-hgb-megaprompt.md) (50 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`handelsrecht-hgb.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/handelsrecht-hgb.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/handelsrecht-hgb.md`](../testakten/megaprompts/handelsrecht-hgb.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/handelsregister-praxis/README.md
+++ b/handelsregister-praxis/README.md
@@ -147,7 +147,8 @@ Automatisch generierte Komplett-Liste aller 77 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`handelsregister-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/handelsregister-praxis.md) (41 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`handelsregister-praxis-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/handelsregister-praxis-megaprompt.md) (42 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`handelsregister-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/handelsregister-praxis.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/handelsregister-praxis.md`](../testakten/megaprompts/handelsregister-praxis.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/handelsvertreterrecht/README.md
+++ b/handelsvertreterrecht/README.md
@@ -195,7 +195,8 @@ Automatisch generierte Komplett-Liste aller 128 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`handelsvertreterrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/handelsvertreterrecht.md) (49 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`handelsvertreterrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/handelsvertreterrecht-megaprompt.md) (49 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`handelsvertreterrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/handelsvertreterrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/handelsvertreterrecht.md`](../testakten/megaprompts/handelsvertreterrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/hausarbeitenmacher/README.md
+++ b/hausarbeitenmacher/README.md
@@ -310,7 +310,8 @@ Automatisch generierte Komplett-Liste aller 59 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`hausarbeitenmacher.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/hausarbeitenmacher.md) (136 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`hausarbeitenmacher-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/hausarbeitenmacher-megaprompt.md) (136 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`hausarbeitenmacher.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/hausarbeitenmacher.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/hausarbeitenmacher.md`](../testakten/megaprompts/hausarbeitenmacher.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/haushaltsrecht-bho-bund-laender/README.md
+++ b/haushaltsrecht-bho-bund-laender/README.md
@@ -412,7 +412,8 @@ Automatisch generierte Komplett-Liste aller 345 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`haushaltsrecht-bho-bund-laender.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/haushaltsrecht-bho-bund-laender.md) (32 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`haushaltsrecht-bho-bund-laender-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/haushaltsrecht-bho-bund-laender-megaprompt.md) (32 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`haushaltsrecht-bho-bund-laender.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/haushaltsrecht-bho-bund-laender.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/haushaltsrecht-bho-bund-laender.md`](../testakten/megaprompts/haushaltsrecht-bho-bund-laender.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/hinweisgeberschutz-compliance/README.md
+++ b/hinweisgeberschutz-compliance/README.md
@@ -169,7 +169,8 @@ Automatisch generierte Komplett-Liste aller 101 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`hinweisgeberschutz-compliance.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/hinweisgeberschutz-compliance.md) (42 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`hinweisgeberschutz-compliance-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/hinweisgeberschutz-compliance-megaprompt.md) (34 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`hinweisgeberschutz-compliance.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/hinweisgeberschutz-compliance.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/hinweisgeberschutz-compliance.md`](../testakten/megaprompts/hinweisgeberschutz-compliance.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/hoai-leistungsphasen-praxis/README.md
+++ b/hoai-leistungsphasen-praxis/README.md
@@ -474,7 +474,8 @@ Automatisch generierte Komplett-Liste aller 388 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`hoai-leistungsphasen-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/hoai-leistungsphasen-praxis.md) (23 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`hoai-leistungsphasen-praxis-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/hoai-leistungsphasen-praxis-megaprompt.md) (23 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`hoai-leistungsphasen-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/hoai-leistungsphasen-praxis.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/hoai-leistungsphasen-praxis.md`](../testakten/megaprompts/hoai-leistungsphasen-praxis.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/hochschulrecht-laender/README.md
+++ b/hochschulrecht-laender/README.md
@@ -169,7 +169,8 @@ Automatisch generierte Komplett-Liste aller 100 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`hochschulrecht-laender.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/hochschulrecht-laender.md) (67 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`hochschulrecht-laender-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/hochschulrecht-laender-megaprompt.md) (67 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`hochschulrecht-laender.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/hochschulrecht-laender.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/hochschulrecht-laender.md`](../testakten/megaprompts/hochschulrecht-laender.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/immobilienrechtspraxis/README.md
+++ b/immobilienrechtspraxis/README.md
@@ -129,7 +129,8 @@ Automatisch generierte Komplett-Liste aller 61 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`immobilienrechtspraxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/immobilienrechtspraxis.md) (86 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`immobilienrechtspraxis-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/immobilienrechtspraxis-megaprompt.md) (68 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`immobilienrechtspraxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/immobilienrechtspraxis.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/immobilienrechtspraxis.md`](../testakten/megaprompts/immobilienrechtspraxis.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/influencer-recht/README.md
+++ b/influencer-recht/README.md
@@ -187,7 +187,8 @@ Automatisch generierte Komplett-Liste aller 129 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`influencer-recht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/influencer-recht.md) (49 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`influencer-recht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/influencer-recht-megaprompt.md) (32 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`influencer-recht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/influencer-recht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/influencer-recht.md`](../testakten/megaprompts/influencer-recht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/informationsfreiheit-presseauskunft/README.md
+++ b/informationsfreiheit-presseauskunft/README.md
@@ -184,7 +184,8 @@ Automatisch generierte Komplett-Liste aller 117 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`informationsfreiheit-presseauskunft.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/informationsfreiheit-presseauskunft.md) (37 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`informationsfreiheit-presseauskunft-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/informationsfreiheit-presseauskunft-megaprompt.md) (30 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`informationsfreiheit-presseauskunft.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/informationsfreiheit-presseauskunft.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/informationsfreiheit-presseauskunft.md`](../testakten/megaprompts/informationsfreiheit-presseauskunft.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/insiderrecht-compliance/README.md
+++ b/insiderrecht-compliance/README.md
@@ -166,7 +166,8 @@ Automatisch generierte Komplett-Liste aller 111 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`insiderrecht-compliance.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/insiderrecht-compliance.md) (65 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`insiderrecht-compliance-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/insiderrecht-compliance-megaprompt.md) (34 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`insiderrecht-compliance.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/insiderrecht-compliance.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/insiderrecht-compliance.md`](../testakten/megaprompts/insiderrecht-compliance.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/insolvenzforderungsanmeldungspruefung/README.md
+++ b/insolvenzforderungsanmeldungspruefung/README.md
@@ -149,7 +149,8 @@ Automatisch generierte Komplett-Liste aller 60 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`insolvenzforderungsanmeldungspruefung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/insolvenzforderungsanmeldungspruefung.md) (100 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`insolvenzforderungsanmeldungspruefung-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/insolvenzforderungsanmeldungspruefung-megaprompt.md) (100 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`insolvenzforderungsanmeldungspruefung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/insolvenzforderungsanmeldungspruefung.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/insolvenzforderungsanmeldungspruefung.md`](../testakten/megaprompts/insolvenzforderungsanmeldungspruefung.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/insolvenzplan-starug-planwerkstatt/README.md
+++ b/insolvenzplan-starug-planwerkstatt/README.md
@@ -151,7 +151,8 @@ Automatisch generierte Komplett-Liste aller 58 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`insolvenzplan-starug-planwerkstatt.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/insolvenzplan-starug-planwerkstatt.md) (126 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`insolvenzplan-starug-planwerkstatt-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/insolvenzplan-starug-planwerkstatt-megaprompt.md) (127 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`insolvenzplan-starug-planwerkstatt.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/insolvenzplan-starug-planwerkstatt.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/insolvenzplan-starug-planwerkstatt.md`](../testakten/megaprompts/insolvenzplan-starug-planwerkstatt.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/insolvenzrecht/README.md
+++ b/insolvenzrecht/README.md
@@ -196,7 +196,8 @@ Automatisch generierte Komplett-Liste aller 97 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`insolvenzrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/insolvenzrecht.md) (146 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`insolvenzrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/insolvenzrecht-megaprompt.md) (145 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`insolvenzrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/insolvenzrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/insolvenzrecht.md`](../testakten/megaprompts/insolvenzrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/insolvenzverwaltung/README.md
+++ b/insolvenzverwaltung/README.md
@@ -238,7 +238,8 @@ Automatisch generierte Komplett-Liste aller 53 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`insolvenzverwaltung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/insolvenzverwaltung.md) (123 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`insolvenzverwaltung-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/insolvenzverwaltung-megaprompt.md) (126 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`insolvenzverwaltung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/insolvenzverwaltung.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/insolvenzverwaltung.md`](../testakten/megaprompts/insolvenzverwaltung.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/internal-investigations-praxis/README.md
+++ b/internal-investigations-praxis/README.md
@@ -162,7 +162,8 @@ Automatisch generierte Komplett-Liste aller 109 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`internal-investigations-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/internal-investigations-praxis.md) (95 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`internal-investigations-praxis-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/internal-investigations-praxis-megaprompt.md) (49 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`internal-investigations-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/internal-investigations-praxis.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/internal-investigations-praxis.md`](../testakten/megaprompts/internal-investigations-praxis.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/internationales-handelsrecht-lex-mercatoria/README.md
+++ b/internationales-handelsrecht-lex-mercatoria/README.md
@@ -252,7 +252,8 @@ Automatisch generierte Komplett-Liste aller 192 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`internationales-handelsrecht-lex-mercatoria.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/internationales-handelsrecht-lex-mercatoria.md) (38 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`internationales-handelsrecht-lex-mercatoria-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/internationales-handelsrecht-lex-mercatoria-megaprompt.md) (30 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`internationales-handelsrecht-lex-mercatoria.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/internationales-handelsrecht-lex-mercatoria.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/internationales-handelsrecht-lex-mercatoria.md`](../testakten/megaprompts/internationales-handelsrecht-lex-mercatoria.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/jurastudium/README.md
+++ b/jurastudium/README.md
@@ -226,7 +226,8 @@ Automatisch generierte Komplett-Liste aller 58 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`jurastudium.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/jurastudium.md) (134 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`jurastudium-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/jurastudium-megaprompt.md) (135 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`jurastudium.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/jurastudium.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/jurastudium.md`](../testakten/megaprompts/jurastudium.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/juristische-sprache-deutsch-als-zweitsprache/README.md
+++ b/juristische-sprache-deutsch-als-zweitsprache/README.md
@@ -114,7 +114,8 @@ Automatisch generierte Komplett-Liste aller 55 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`juristische-sprache-deutsch-als-zweitsprache.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/juristische-sprache-deutsch-als-zweitsprache.md) (40 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`juristische-sprache-deutsch-als-zweitsprache-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/juristische-sprache-deutsch-als-zweitsprache-megaprompt.md) (47 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`juristische-sprache-deutsch-als-zweitsprache.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/juristische-sprache-deutsch-als-zweitsprache.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/juristische-sprache-deutsch-als-zweitsprache.md`](../testakten/megaprompts/juristische-sprache-deutsch-als-zweitsprache.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/jveg-kostenpruefer/README.md
+++ b/jveg-kostenpruefer/README.md
@@ -151,7 +151,8 @@ Automatisch generierte Komplett-Liste aller 60 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`jveg-kostenpruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/jveg-kostenpruefer.md) (92 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`jveg-kostenpruefer-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/jveg-kostenpruefer-megaprompt.md) (96 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`jveg-kostenpruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/jveg-kostenpruefer.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/jveg-kostenpruefer.md`](../testakten/megaprompts/jveg-kostenpruefer.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/kanzlei-allgemein/README.md
+++ b/kanzlei-allgemein/README.md
@@ -294,7 +294,8 @@ Automatisch generierte Komplett-Liste aller 51 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`kanzlei-allgemein.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/kanzlei-allgemein.md) (85 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`kanzlei-allgemein-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/kanzlei-allgemein-megaprompt.md) (88 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`kanzlei-allgemein.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/kanzlei-allgemein.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/kanzlei-allgemein.md`](../testakten/megaprompts/kanzlei-allgemein.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/kanzlei-builder-hub/README.md
+++ b/kanzlei-builder-hub/README.md
@@ -220,7 +220,8 @@ Automatisch generierte Komplett-Liste aller 58 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`kanzlei-builder-hub.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/kanzlei-builder-hub.md) (138 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`kanzlei-builder-hub-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/kanzlei-builder-hub-megaprompt.md) (139 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`kanzlei-builder-hub.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/kanzlei-builder-hub.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/kanzlei-builder-hub.md`](../testakten/megaprompts/kanzlei-builder-hub.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/kanzlei-management/README.md
+++ b/kanzlei-management/README.md
@@ -174,7 +174,8 @@ Automatisch generierte Komplett-Liste aller 100 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`kanzlei-management.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/kanzlei-management.md) (54 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`kanzlei-management-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/kanzlei-management-megaprompt.md) (54 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`kanzlei-management.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/kanzlei-management.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/kanzlei-management.md`](../testakten/megaprompts/kanzlei-management.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/kanzlei-mandant-lifecycle/README.md
+++ b/kanzlei-mandant-lifecycle/README.md
@@ -193,7 +193,8 @@ Automatisch generierte Komplett-Liste aller 115 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`kanzlei-mandant-lifecycle.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/kanzlei-mandant-lifecycle.md) (34 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`kanzlei-mandant-lifecycle-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/kanzlei-mandant-lifecycle-megaprompt.md) (34 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`kanzlei-mandant-lifecycle.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/kanzlei-mandant-lifecycle.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/kanzlei-mandant-lifecycle.md`](../testakten/megaprompts/kanzlei-mandant-lifecycle.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/kartellrecht-marktabgrenzung-pruefung/README.md
+++ b/kartellrecht-marktabgrenzung-pruefung/README.md
@@ -385,7 +385,8 @@ Automatisch generierte Komplett-Liste aller 309 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`kartellrecht-marktabgrenzung-pruefung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/kartellrecht-marktabgrenzung-pruefung.md) (40 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`kartellrecht-marktabgrenzung-pruefung-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/kartellrecht-marktabgrenzung-pruefung-megaprompt.md) (40 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`kartellrecht-marktabgrenzung-pruefung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/kartellrecht-marktabgrenzung-pruefung.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/kartellrecht-marktabgrenzung-pruefung.md`](../testakten/megaprompts/kartellrecht-marktabgrenzung-pruefung.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/ki-governance/README.md
+++ b/ki-governance/README.md
@@ -274,7 +274,8 @@ Automatisch generierte Komplett-Liste aller 59 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`ki-governance.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/ki-governance.md) (154 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`ki-governance-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/ki-governance-megaprompt.md) (160 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`ki-governance.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/ki-governance.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/ki-governance.md`](../testakten/megaprompts/ki-governance.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/ki-richtlinie-kanzleien/README.md
+++ b/ki-richtlinie-kanzleien/README.md
@@ -174,7 +174,8 @@ Automatisch generierte Komplett-Liste aller 59 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`ki-richtlinie-kanzleien.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/ki-richtlinie-kanzleien.md) (114 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`ki-richtlinie-kanzleien-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/ki-richtlinie-kanzleien-megaprompt.md) (121 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`ki-richtlinie-kanzleien.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/ki-richtlinie-kanzleien.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/ki-richtlinie-kanzleien.md`](../testakten/megaprompts/ki-richtlinie-kanzleien.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/ki-vo-ai-act-pruefer/README.md
+++ b/ki-vo-ai-act-pruefer/README.md
@@ -316,7 +316,8 @@ Automatisch generierte Komplett-Liste aller 122 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`ki-vo-ai-act-pruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/ki-vo-ai-act-pruefer.md) (73 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`ki-vo-ai-act-pruefer-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/ki-vo-ai-act-pruefer-megaprompt.md) (74 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`ki-vo-ai-act-pruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/ki-vo-ai-act-pruefer.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/ki-vo-ai-act-pruefer.md`](../testakten/megaprompts/ki-vo-ai-act-pruefer.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/kommunalrecht-laender/README.md
+++ b/kommunalrecht-laender/README.md
@@ -243,7 +243,8 @@ Automatisch generierte Komplett-Liste aller 176 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`kommunalrecht-laender.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/kommunalrecht-laender.md) (30 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`kommunalrecht-laender-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/kommunalrecht-laender-megaprompt.md) (30 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`kommunalrecht-laender.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/kommunalrecht-laender.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/kommunalrecht-laender.md`](../testakten/megaprompts/kommunalrecht-laender.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/krankenhausrecht/README.md
+++ b/krankenhausrecht/README.md
@@ -137,7 +137,8 @@ Automatisch generierte Komplett-Liste aller 68 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`krankenhausrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/krankenhausrecht.md) (61 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`krankenhausrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/krankenhausrecht-megaprompt.md) (61 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`krankenhausrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/krankenhausrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/krankenhausrecht.md`](../testakten/megaprompts/krankenhausrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/krankenkassenrecht-krankenversicherung/README.md
+++ b/krankenkassenrecht-krankenversicherung/README.md
@@ -218,7 +218,8 @@ Automatisch generierte Komplett-Liste aller 160 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`krankenkassenrecht-krankenversicherung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/krankenkassenrecht-krankenversicherung.md) (56 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`krankenkassenrecht-krankenversicherung-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/krankenkassenrecht-krankenversicherung-megaprompt.md) (45 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`krankenkassenrecht-krankenversicherung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/krankenkassenrecht-krankenversicherung.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/krankenkassenrecht-krankenversicherung.md`](../testakten/megaprompts/krankenkassenrecht-krankenversicherung.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/kriegsdienstverweigerung-wehrdienst/README.md
+++ b/kriegsdienstverweigerung-wehrdienst/README.md
@@ -220,7 +220,8 @@ Automatisch generierte Komplett-Liste aller 136 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`kriegsdienstverweigerung-wehrdienst.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/kriegsdienstverweigerung-wehrdienst.md) (48 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`kriegsdienstverweigerung-wehrdienst-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/kriegsdienstverweigerung-wehrdienst-megaprompt.md) (48 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`kriegsdienstverweigerung-wehrdienst.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/kriegsdienstverweigerung-wehrdienst.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/kriegsdienstverweigerung-wehrdienst.md`](../testakten/megaprompts/kriegsdienstverweigerung-wehrdienst.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/krisenfrueherkennung-starug/README.md
+++ b/krisenfrueherkennung-starug/README.md
@@ -196,7 +196,8 @@ Automatisch generierte Komplett-Liste aller 58 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`krisenfrueherkennung-starug.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/krisenfrueherkennung-starug.md) (150 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`krisenfrueherkennung-starug-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/krisenfrueherkennung-starug-megaprompt.md) (150 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`krisenfrueherkennung-starug.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/krisenfrueherkennung-starug.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/krisenfrueherkennung-starug.md`](../testakten/megaprompts/krisenfrueherkennung-starug.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/leasingrecht-praxis/README.md
+++ b/leasingrecht-praxis/README.md
@@ -174,7 +174,8 @@ Automatisch generierte Komplett-Liste aller 117 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`leasingrecht-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/leasingrecht-praxis.md) (86 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`leasingrecht-praxis-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/leasingrecht-praxis-megaprompt.md) (45 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`leasingrecht-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/leasingrecht-praxis.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/leasingrecht-praxis.md`](../testakten/megaprompts/leasingrecht-praxis.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/legistik-werkstatt/README.md
+++ b/legistik-werkstatt/README.md
@@ -395,7 +395,8 @@ Automatisch generierte Komplett-Liste aller 254 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`legistik-werkstatt.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/legistik-werkstatt.md) (57 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`legistik-werkstatt-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/legistik-werkstatt-megaprompt.md) (58 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`legistik-werkstatt.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/legistik-werkstatt.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/legistik-werkstatt.md`](../testakten/megaprompts/legistik-werkstatt.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/liquiditaetsplanung/README.md
+++ b/liquiditaetsplanung/README.md
@@ -181,7 +181,8 @@ Automatisch generierte Komplett-Liste aller 73 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`liquiditaetsplanung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/liquiditaetsplanung.md) (43 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`liquiditaetsplanung-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/liquiditaetsplanung-megaprompt.md) (43 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`liquiditaetsplanung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/liquiditaetsplanung.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/liquiditaetsplanung.md`](../testakten/megaprompts/liquiditaetsplanung.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/lizenzvertragsersteller/README.md
+++ b/lizenzvertragsersteller/README.md
@@ -149,7 +149,8 @@ Automatisch generierte Komplett-Liste aller 32 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`lizenzvertragsersteller.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/lizenzvertragsersteller.md) (50 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`lizenzvertragsersteller-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/lizenzvertragsersteller-megaprompt.md) (50 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`lizenzvertragsersteller.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/lizenzvertragsersteller.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/lizenzvertragsersteller.md`](../testakten/megaprompts/lizenzvertragsersteller.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/lobbyregister-bundestag/README.md
+++ b/lobbyregister-bundestag/README.md
@@ -224,7 +224,8 @@ Automatisch generierte Komplett-Liste aller 52 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`lobbyregister-bundestag.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/lobbyregister-bundestag.md) (84 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`lobbyregister-bundestag-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/lobbyregister-bundestag-megaprompt.md) (84 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`lobbyregister-bundestag.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/lobbyregister-bundestag.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/lobbyregister-bundestag.md`](../testakten/megaprompts/lobbyregister-bundestag.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/luftrecht-flughafenrecht/README.md
+++ b/luftrecht-flughafenrecht/README.md
@@ -306,7 +306,8 @@ Automatisch generierte Komplett-Liste aller 239 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`luftrecht-flughafenrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/luftrecht-flughafenrecht.md) (47 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`luftrecht-flughafenrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/luftrecht-flughafenrecht-megaprompt.md) (47 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`luftrecht-flughafenrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/luftrecht-flughafenrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/luftrecht-flughafenrecht.md`](../testakten/megaprompts/luftrecht-flughafenrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/mandantenanfragen-assistent/README.md
+++ b/mandantenanfragen-assistent/README.md
@@ -207,7 +207,8 @@ Automatisch generierte Komplett-Liste aller 58 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`mandantenanfragen-assistent.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/mandantenanfragen-assistent.md) (113 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`mandantenanfragen-assistent-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/mandantenanfragen-assistent-megaprompt.md) (113 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`mandantenanfragen-assistent.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/mandantenanfragen-assistent.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/mandantenanfragen-assistent.md`](../testakten/megaprompts/mandantenanfragen-assistent.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/markenrecht-fashion-luxus/README.md
+++ b/markenrecht-fashion-luxus/README.md
@@ -192,7 +192,8 @@ Automatisch generierte Komplett-Liste aller 82 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`markenrecht-fashion-luxus.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/markenrecht-fashion-luxus.md) (105 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`markenrecht-fashion-luxus-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/markenrecht-fashion-luxus-megaprompt.md) (105 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`markenrecht-fashion-luxus.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/markenrecht-fashion-luxus.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/markenrecht-fashion-luxus.md`](../testakten/megaprompts/markenrecht-fashion-luxus.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/meinungspruefer/README.md
+++ b/meinungspruefer/README.md
@@ -147,7 +147,8 @@ Automatisch generierte Komplett-Liste aller 53 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`meinungspruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/meinungspruefer.md) (55 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`meinungspruefer-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/meinungspruefer-megaprompt.md) (55 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`meinungspruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/meinungspruefer.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/meinungspruefer.md`](../testakten/megaprompts/meinungspruefer.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/memorandums-ersteller/README.md
+++ b/memorandums-ersteller/README.md
@@ -116,7 +116,8 @@ Automatisch generierte Komplett-Liste aller 58 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`memorandums-ersteller.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/memorandums-ersteller.md) (69 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`memorandums-ersteller-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/memorandums-ersteller-megaprompt.md) (75 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`memorandums-ersteller.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/memorandums-ersteller.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/memorandums-ersteller.md`](../testakten/megaprompts/memorandums-ersteller.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/methodenlehre-buergerliches-recht/README.md
+++ b/methodenlehre-buergerliches-recht/README.md
@@ -304,7 +304,8 @@ Automatisch generierte Komplett-Liste aller 158 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`methodenlehre-buergerliches-recht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/methodenlehre-buergerliches-recht.md) (66 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`methodenlehre-buergerliches-recht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/methodenlehre-buergerliches-recht-megaprompt.md) (62 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`methodenlehre-buergerliches-recht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/methodenlehre-buergerliches-recht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/methodenlehre-buergerliches-recht.md`](../testakten/megaprompts/methodenlehre-buergerliches-recht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/mietrecht/README.md
+++ b/mietrecht/README.md
@@ -148,7 +148,8 @@ Automatisch generierte Komplett-Liste aller 64 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`mietrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/mietrecht.md) (142 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`mietrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/mietrecht-megaprompt.md) (79 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`mietrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/mietrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/mietrecht.md`](../testakten/megaprompts/mietrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/mittelstand-corporate-ma/README.md
+++ b/mittelstand-corporate-ma/README.md
@@ -241,7 +241,8 @@ Automatisch generierte Komplett-Liste aller 100 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`mittelstand-corporate-ma.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/mittelstand-corporate-ma.md) (182 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`mittelstand-corporate-ma-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/mittelstand-corporate-ma-megaprompt.md) (185 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`mittelstand-corporate-ma.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/mittelstand-corporate-ma.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/mittelstand-corporate-ma.md`](../testakten/megaprompts/mittelstand-corporate-ma.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/nachbarschaftsstreit-pruefer/README.md
+++ b/nachbarschaftsstreit-pruefer/README.md
@@ -138,7 +138,8 @@ Automatisch generierte Komplett-Liste aller 59 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`nachbarschaftsstreit-pruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/nachbarschaftsstreit-pruefer.md) (48 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`nachbarschaftsstreit-pruefer-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/nachbarschaftsstreit-pruefer-megaprompt.md) (48 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`nachbarschaftsstreit-pruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/nachbarschaftsstreit-pruefer.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/nachbarschaftsstreit-pruefer.md`](../testakten/megaprompts/nachbarschaftsstreit-pruefer.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/nda-abgleich/README.md
+++ b/nda-abgleich/README.md
@@ -154,7 +154,8 @@ Automatisch generierte Komplett-Liste aller 91 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`nda-abgleich.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/nda-abgleich.md) (36 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`nda-abgleich-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/nda-abgleich-megaprompt.md) (36 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`nda-abgleich.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/nda-abgleich.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/nda-abgleich.md`](../testakten/megaprompts/nda-abgleich.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/nda-verschwiegenheit-generator-checker/README.md
+++ b/nda-verschwiegenheit-generator-checker/README.md
@@ -156,7 +156,8 @@ Automatisch generierte Komplett-Liste aller 101 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`nda-verschwiegenheit-generator-checker.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/nda-verschwiegenheit-generator-checker.md) (41 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`nda-verschwiegenheit-generator-checker-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/nda-verschwiegenheit-generator-checker-megaprompt.md) (33 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`nda-verschwiegenheit-generator-checker.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/nda-verschwiegenheit-generator-checker.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/nda-verschwiegenheit-generator-checker.md`](../testakten/megaprompts/nda-verschwiegenheit-generator-checker.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/nis2-cybersecurity-compliance/README.md
+++ b/nis2-cybersecurity-compliance/README.md
@@ -169,7 +169,8 @@ Automatisch generierte Komplett-Liste aller 102 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`nis2-cybersecurity-compliance.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/nis2-cybersecurity-compliance.md) (32 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`nis2-cybersecurity-compliance-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/nis2-cybersecurity-compliance-megaprompt.md) (32 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`nis2-cybersecurity-compliance.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/nis2-cybersecurity-compliance.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/nis2-cybersecurity-compliance.md`](../testakten/megaprompts/nis2-cybersecurity-compliance.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/normenkontrolle-bauleitplanung/README.md
+++ b/normenkontrolle-bauleitplanung/README.md
@@ -232,7 +232,8 @@ Automatisch generierte Komplett-Liste aller 94 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`normenkontrolle-bauleitplanung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/normenkontrolle-bauleitplanung.md) (75 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`normenkontrolle-bauleitplanung-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/normenkontrolle-bauleitplanung-megaprompt.md) (73 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`normenkontrolle-bauleitplanung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/normenkontrolle-bauleitplanung.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/normenkontrolle-bauleitplanung.md`](../testakten/megaprompts/normenkontrolle-bauleitplanung.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/normenkontrollrat-nkr/README.md
+++ b/normenkontrollrat-nkr/README.md
@@ -207,7 +207,8 @@ Automatisch generierte Komplett-Liste aller 63 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`normenkontrollrat-nkr.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/normenkontrollrat-nkr.md) (81 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`normenkontrollrat-nkr-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/normenkontrollrat-nkr-megaprompt.md) (55 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`normenkontrollrat-nkr.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/normenkontrollrat-nkr.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/normenkontrollrat-nkr.md`](../testakten/megaprompts/normenkontrollrat-nkr.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/notariat-alltag/README.md
+++ b/notariat-alltag/README.md
@@ -186,7 +186,8 @@ Automatisch generierte Komplett-Liste aller 129 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`notariat-alltag.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/notariat-alltag.md) (60 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`notariat-alltag-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/notariat-alltag-megaprompt.md) (48 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`notariat-alltag.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/notariat-alltag.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/notariat-alltag.md`](../testakten/megaprompts/notariat-alltag.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/oeffentliches-wirtschaftsrecht/README.md
+++ b/oeffentliches-wirtschaftsrecht/README.md
@@ -186,7 +186,8 @@ Automatisch generierte Komplett-Liste aller 119 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`oeffentliches-wirtschaftsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/oeffentliches-wirtschaftsrecht.md) (29 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`oeffentliches-wirtschaftsrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/oeffentliches-wirtschaftsrecht-megaprompt.md) (23 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`oeffentliches-wirtschaftsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/oeffentliches-wirtschaftsrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/oeffentliches-wirtschaftsrecht.md`](../testakten/megaprompts/oeffentliches-wirtschaftsrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/ordnungswidrigkeitenrecht/README.md
+++ b/ordnungswidrigkeitenrecht/README.md
@@ -200,7 +200,8 @@ Automatisch generierte Komplett-Liste aller 133 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`ordnungswidrigkeitenrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/ordnungswidrigkeitenrecht.md) (35 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`ordnungswidrigkeitenrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/ordnungswidrigkeitenrecht-megaprompt.md) (29 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`ordnungswidrigkeitenrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/ordnungswidrigkeitenrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/ordnungswidrigkeitenrecht.md`](../testakten/megaprompts/ordnungswidrigkeitenrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/parteienrecht-parteiorganisation/README.md
+++ b/parteienrecht-parteiorganisation/README.md
@@ -163,7 +163,8 @@ Automatisch generierte Komplett-Liste aller 110 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`parteienrecht-parteiorganisation.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/parteienrecht-parteiorganisation.md) (28 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`parteienrecht-parteiorganisation-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/parteienrecht-parteiorganisation-megaprompt.md) (28 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`parteienrecht-parteiorganisation.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/parteienrecht-parteiorganisation.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/parteienrecht-parteiorganisation.md`](../testakten/megaprompts/parteienrecht-parteiorganisation.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/patentrecherche/README.md
+++ b/patentrecherche/README.md
@@ -148,7 +148,8 @@ Automatisch generierte Komplett-Liste aller 57 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`patentrecherche.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/patentrecherche.md) (128 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`patentrecherche-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/patentrecherche-megaprompt.md) (128 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`patentrecherche.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/patentrecherche.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/patentrecherche.md`](../testakten/megaprompts/patentrecherche.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/patentrecht/README.md
+++ b/patentrecht/README.md
@@ -182,7 +182,8 @@ Automatisch generierte Komplett-Liste aller 60 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`patentrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/patentrecht.md) (56 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`patentrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/patentrecht-megaprompt.md) (56 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`patentrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/patentrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/patentrecht.md`](../testakten/megaprompts/patentrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/phishing-vorfall-pruefer/README.md
+++ b/phishing-vorfall-pruefer/README.md
@@ -127,7 +127,8 @@ Automatisch generierte Komplett-Liste aller 60 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`phishing-vorfall-pruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/phishing-vorfall-pruefer.md) (70 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`phishing-vorfall-pruefer-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/phishing-vorfall-pruefer-megaprompt.md) (74 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`phishing-vorfall-pruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/phishing-vorfall-pruefer.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/phishing-vorfall-pruefer.md`](../testakten/megaprompts/phishing-vorfall-pruefer.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/preussisches-allgemeines-landrecht-pralr/README.md
+++ b/preussisches-allgemeines-landrecht-pralr/README.md
@@ -536,7 +536,8 @@ Automatisch generierte Komplett-Liste aller 462 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`preussisches-allgemeines-landrecht-pralr.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/preussisches-allgemeines-landrecht-pralr.md) (27 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`preussisches-allgemeines-landrecht-pralr-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/preussisches-allgemeines-landrecht-pralr-megaprompt.md) (27 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`preussisches-allgemeines-landrecht-pralr.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/preussisches-allgemeines-landrecht-pralr.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/preussisches-allgemeines-landrecht-pralr.md`](../testakten/megaprompts/preussisches-allgemeines-landrecht-pralr.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/private-equity-praxis/README.md
+++ b/private-equity-praxis/README.md
@@ -165,7 +165,8 @@ Automatisch generierte Komplett-Liste aller 108 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`private-equity-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/private-equity-praxis.md) (46 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`private-equity-praxis-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/private-equity-praxis-megaprompt.md) (47 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`private-equity-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/private-equity-praxis.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/private-equity-praxis.md`](../testakten/megaprompts/private-equity-praxis.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/produktrecht/README.md
+++ b/produktrecht/README.md
@@ -239,7 +239,8 @@ Automatisch generierte Komplett-Liste aller 69 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`produktrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/produktrecht.md) (109 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`produktrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/produktrecht-megaprompt.md) (112 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`produktrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/produktrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/produktrecht.md`](../testakten/megaprompts/produktrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/prozessrecht/README.md
+++ b/prozessrecht/README.md
@@ -188,7 +188,8 @@ Automatisch generierte Komplett-Liste aller 62 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`prozessrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/prozessrecht.md) (109 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`prozessrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/prozessrecht-megaprompt.md) (78 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`prozessrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/prozessrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/prozessrecht.md`](../testakten/megaprompts/prozessrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/pruefungsrecht-hochschule/README.md
+++ b/pruefungsrecht-hochschule/README.md
@@ -176,7 +176,8 @@ Automatisch generierte Komplett-Liste aller 108 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`pruefungsrecht-hochschule.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/pruefungsrecht-hochschule.md) (68 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`pruefungsrecht-hochschule-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/pruefungsrecht-hochschule-megaprompt.md) (54 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`pruefungsrecht-hochschule.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/pruefungsrecht-hochschule.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/pruefungsrecht-hochschule.md`](../testakten/megaprompts/pruefungsrecht-hochschule.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/rechtsberatungsstelle/README.md
+++ b/rechtsberatungsstelle/README.md
@@ -234,7 +234,8 @@ Automatisch generierte Komplett-Liste aller 59 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`rechtsberatungsstelle.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/rechtsberatungsstelle.md) (136 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`rechtsberatungsstelle-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/rechtsberatungsstelle-megaprompt.md) (136 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`rechtsberatungsstelle.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/rechtsberatungsstelle.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/rechtsberatungsstelle.md`](../testakten/megaprompts/rechtsberatungsstelle.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/rechtstheorie-rechtsphilosophie/README.md
+++ b/rechtstheorie-rechtsphilosophie/README.md
@@ -128,7 +128,8 @@ Automatisch generierte Komplett-Liste aller 64 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`rechtstheorie-rechtsphilosophie.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/rechtstheorie-rechtsphilosophie.md) (61 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`rechtstheorie-rechtsphilosophie-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/rechtstheorie-rechtsphilosophie-megaprompt.md) (61 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`rechtstheorie-rechtsphilosophie.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/rechtstheorie-rechtsphilosophie.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/rechtstheorie-rechtsphilosophie.md`](../testakten/megaprompts/rechtstheorie-rechtsphilosophie.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/regulatorisches-recht/README.md
+++ b/regulatorisches-recht/README.md
@@ -185,7 +185,8 @@ Automatisch generierte Komplett-Liste aller 61 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`regulatorisches-recht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/regulatorisches-recht.md) (121 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`regulatorisches-recht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/regulatorisches-recht-megaprompt.md) (81 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`regulatorisches-recht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/regulatorisches-recht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/regulatorisches-recht.md`](../testakten/megaprompts/regulatorisches-recht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/rentenpruefer/README.md
+++ b/rentenpruefer/README.md
@@ -114,7 +114,8 @@ Automatisch generierte Komplett-Liste aller 51 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`rentenpruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/rentenpruefer.md) (56 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`rentenpruefer-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/rentenpruefer-megaprompt.md) (56 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`rentenpruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/rentenpruefer.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/rentenpruefer.md`](../testakten/megaprompts/rentenpruefer.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/robotik-recht/README.md
+++ b/robotik-recht/README.md
@@ -309,7 +309,8 @@ Automatisch generierte Komplett-Liste aller 212 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`robotik-recht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/robotik-recht.md) (41 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`robotik-recht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/robotik-recht-megaprompt.md) (41 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`robotik-recht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/robotik-recht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/robotik-recht.md`](../testakten/megaprompts/robotik-recht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/roemisch-katholisches-kirchenrecht/README.md
+++ b/roemisch-katholisches-kirchenrecht/README.md
@@ -1959,7 +1959,8 @@ Automatisch generierte Komplett-Liste aller 1876 Skills in diesem Plugin. Beschr
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`roemisch-katholisches-kirchenrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/roemisch-katholisches-kirchenrecht.md) (63 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`roemisch-katholisches-kirchenrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/roemisch-katholisches-kirchenrecht-megaprompt.md) (52 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`roemisch-katholisches-kirchenrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/roemisch-katholisches-kirchenrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/roemisch-katholisches-kirchenrecht.md`](../testakten/megaprompts/roemisch-katholisches-kirchenrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/roemisches-recht/README.md
+++ b/roemisches-recht/README.md
@@ -353,7 +353,8 @@ Automatisch generierte Komplett-Liste aller 283 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`roemisches-recht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/roemisches-recht.md) (22 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`roemisches-recht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/roemisches-recht-megaprompt.md) (21 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`roemisches-recht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/roemisches-recht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/roemisches-recht.md`](../testakten/megaprompts/roemisches-recht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/schoeffen-handelsrichter-praxis/README.md
+++ b/schoeffen-handelsrichter-praxis/README.md
@@ -140,7 +140,8 @@ Automatisch generierte Komplett-Liste aller 80 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`schoeffen-handelsrichter-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/schoeffen-handelsrichter-praxis.md) (43 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`schoeffen-handelsrichter-praxis-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/schoeffen-handelsrichter-praxis-megaprompt.md) (43 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`schoeffen-handelsrichter-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/schoeffen-handelsrichter-praxis.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/schoeffen-handelsrichter-praxis.md`](../testakten/megaprompts/schoeffen-handelsrichter-praxis.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/schriftform-und-textform-bgb/README.md
+++ b/schriftform-und-textform-bgb/README.md
@@ -172,7 +172,8 @@ Automatisch generierte Komplett-Liste aller 59 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`schriftform-und-textform-bgb.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/schriftform-und-textform-bgb.md) (146 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`schriftform-und-textform-bgb-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/schriftform-und-textform-bgb-megaprompt.md) (146 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`schriftform-und-textform-bgb.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/schriftform-und-textform-bgb.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/schriftform-und-textform-bgb.md`](../testakten/megaprompts/schriftform-und-textform-bgb.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/schulrecht-laender/README.md
+++ b/schulrecht-laender/README.md
@@ -169,7 +169,8 @@ Automatisch generierte Komplett-Liste aller 100 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`schulrecht-laender.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/schulrecht-laender.md) (58 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`schulrecht-laender-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/schulrecht-laender-megaprompt.md) (58 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`schulrecht-laender.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/schulrecht-laender.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/schulrecht-laender.md`](../testakten/megaprompts/schulrecht-laender.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/scripts/inject-megaprompt-section.py
+++ b/scripts/inject-megaprompt-section.py
@@ -18,6 +18,7 @@ BEGIN = "<!-- BEGIN megaprompt-und-vorlagen (autogen) -->"
 END = "<!-- END megaprompt-und-vorlagen (autogen) -->"
 
 RAW_BASE = "https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts"
+RELEASE_BASE = "https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download"
 
 
 def block_for(plugin: str, kb: int) -> str:
@@ -28,7 +29,8 @@ def block_for(plugin: str, kb: int) -> str:
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`{plugin}.md`]({RAW_BASE}/{plugin}.md) ({kb} KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`{plugin}-megaprompt.md`]({RELEASE_BASE}/{plugin}-megaprompt.md) ({kb} KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`{plugin}.md`]({RAW_BASE}/{plugin}.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/{plugin}.md`](../testakten/megaprompts/{plugin}.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/seerecht-schifffahrtsrecht/README.md
+++ b/seerecht-schifffahrtsrecht/README.md
@@ -305,7 +305,8 @@ Automatisch generierte Komplett-Liste aller 238 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`seerecht-schifffahrtsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/seerecht-schifffahrtsrecht.md) (53 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`seerecht-schifffahrtsrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/seerecht-schifffahrtsrecht-megaprompt.md) (53 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`seerecht-schifffahrtsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/seerecht-schifffahrtsrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/seerecht-schifffahrtsrecht.md`](../testakten/megaprompts/seerecht-schifffahrtsrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/selbstvertreter-amtsgericht/README.md
+++ b/selbstvertreter-amtsgericht/README.md
@@ -171,7 +171,8 @@ Automatisch generierte Komplett-Liste aller 89 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`selbstvertreter-amtsgericht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/selbstvertreter-amtsgericht.md) (88 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`selbstvertreter-amtsgericht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/selbstvertreter-amtsgericht-megaprompt.md) (88 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`selbstvertreter-amtsgericht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/selbstvertreter-amtsgericht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/selbstvertreter-amtsgericht.md`](../testakten/megaprompts/selbstvertreter-amtsgericht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/selbstvertreter-sozialgericht/README.md
+++ b/selbstvertreter-sozialgericht/README.md
@@ -231,7 +231,8 @@ Automatisch generierte Komplett-Liste aller 138 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`selbstvertreter-sozialgericht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/selbstvertreter-sozialgericht.md) (50 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`selbstvertreter-sozialgericht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/selbstvertreter-sozialgericht-megaprompt.md) (50 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`selbstvertreter-sozialgericht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/selbstvertreter-sozialgericht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/selbstvertreter-sozialgericht.md`](../testakten/megaprompts/selbstvertreter-sozialgericht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/softwarerecht-de-eu-us/README.md
+++ b/softwarerecht-de-eu-us/README.md
@@ -167,7 +167,8 @@ Automatisch generierte Komplett-Liste aller 105 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`softwarerecht-de-eu-us.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/softwarerecht-de-eu-us.md) (32 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`softwarerecht-de-eu-us-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/softwarerecht-de-eu-us-megaprompt.md) (33 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`softwarerecht-de-eu-us.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/softwarerecht-de-eu-us.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/softwarerecht-de-eu-us.md`](../testakten/megaprompts/softwarerecht-de-eu-us.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/solo-selbststaendige-praxis/README.md
+++ b/solo-selbststaendige-praxis/README.md
@@ -272,7 +272,8 @@ Automatisch generierte Komplett-Liste aller 201 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`solo-selbststaendige-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/solo-selbststaendige-praxis.md) (21 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`solo-selbststaendige-praxis-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/solo-selbststaendige-praxis-megaprompt.md) (21 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`solo-selbststaendige-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/solo-selbststaendige-praxis.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/solo-selbststaendige-praxis.md`](../testakten/megaprompts/solo-selbststaendige-praxis.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/sozialversicherungsstatus-pruefer/README.md
+++ b/sozialversicherungsstatus-pruefer/README.md
@@ -163,7 +163,8 @@ Automatisch generierte Komplett-Liste aller 101 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`sozialversicherungsstatus-pruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/sozialversicherungsstatus-pruefer.md) (40 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`sozialversicherungsstatus-pruefer-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/sozialversicherungsstatus-pruefer-megaprompt.md) (40 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`sozialversicherungsstatus-pruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/sozialversicherungsstatus-pruefer.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/sozialversicherungsstatus-pruefer.md`](../testakten/megaprompts/sozialversicherungsstatus-pruefer.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/staatsanwaltschaft-praxis-einstieg/README.md
+++ b/staatsanwaltschaft-praxis-einstieg/README.md
@@ -206,7 +206,8 @@ Automatisch generierte Komplett-Liste aller 142 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`staatsanwaltschaft-praxis-einstieg.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/staatsanwaltschaft-praxis-einstieg.md) (32 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`staatsanwaltschaft-praxis-einstieg-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/staatsanwaltschaft-praxis-einstieg-megaprompt.md) (32 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`staatsanwaltschaft-praxis-einstieg.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/staatsanwaltschaft-praxis-einstieg.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/staatsanwaltschaft-praxis-einstieg.md`](../testakten/megaprompts/staatsanwaltschaft-praxis-einstieg.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/startup-hr-personalabteilung-berlin/README.md
+++ b/startup-hr-personalabteilung-berlin/README.md
@@ -196,7 +196,8 @@ Automatisch generierte Komplett-Liste aller 111 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`startup-hr-personalabteilung-berlin.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/startup-hr-personalabteilung-berlin.md) (35 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`startup-hr-personalabteilung-berlin-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/startup-hr-personalabteilung-berlin-megaprompt.md) (35 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`startup-hr-personalabteilung-berlin.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/startup-hr-personalabteilung-berlin.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/startup-hr-personalabteilung-berlin.md`](../testakten/megaprompts/startup-hr-personalabteilung-berlin.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/status-navigator-step-plan/README.md
+++ b/status-navigator-step-plan/README.md
@@ -187,7 +187,8 @@ Automatisch generierte Komplett-Liste aller 35 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`status-navigator-step-plan.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/status-navigator-step-plan.md) (24 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`status-navigator-step-plan-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/status-navigator-step-plan-megaprompt.md) (28 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`status-navigator-step-plan.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/status-navigator-step-plan.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/status-navigator-step-plan.md`](../testakten/megaprompts/status-navigator-step-plan.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/steuerrecht-anwalt-und-berater/README.md
+++ b/steuerrecht-anwalt-und-berater/README.md
@@ -612,7 +612,8 @@ Automatisch generierte Komplett-Liste aller 381 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`steuerrecht-anwalt-und-berater.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/steuerrecht-anwalt-und-berater.md) (125 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`steuerrecht-anwalt-und-berater-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/steuerrecht-anwalt-und-berater-megaprompt.md) (96 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`steuerrecht-anwalt-und-berater.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/steuerrecht-anwalt-und-berater.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/steuerrecht-anwalt-und-berater.md`](../testakten/megaprompts/steuerrecht-anwalt-und-berater.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/strafanzeige-vorbereiter/README.md
+++ b/strafanzeige-vorbereiter/README.md
@@ -110,7 +110,8 @@ Automatisch generierte Komplett-Liste aller 56 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`strafanzeige-vorbereiter.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/strafanzeige-vorbereiter.md) (34 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`strafanzeige-vorbereiter-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/strafanzeige-vorbereiter-megaprompt.md) (34 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`strafanzeige-vorbereiter.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/strafanzeige-vorbereiter.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/strafanzeige-vorbereiter.md`](../testakten/megaprompts/strafanzeige-vorbereiter.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/strafbefehl-verteidiger/README.md
+++ b/strafbefehl-verteidiger/README.md
@@ -162,7 +162,8 @@ Automatisch generierte Komplett-Liste aller 60 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`strafbefehl-verteidiger.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/strafbefehl-verteidiger.md) (113 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`strafbefehl-verteidiger-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/strafbefehl-verteidiger-megaprompt.md) (116 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`strafbefehl-verteidiger.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/strafbefehl-verteidiger.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/strafbefehl-verteidiger.md`](../testakten/megaprompts/strafbefehl-verteidiger.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/strafzumessung/README.md
+++ b/strafzumessung/README.md
@@ -183,7 +183,8 @@ Automatisch generierte Komplett-Liste aller 60 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`strafzumessung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/strafzumessung.md) (116 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`strafzumessung-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/strafzumessung-megaprompt.md) (111 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`strafzumessung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/strafzumessung.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/strafzumessung.md`](../testakten/megaprompts/strafzumessung.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/strassenrecht-infrastruktur/README.md
+++ b/strassenrecht-infrastruktur/README.md
@@ -193,7 +193,8 @@ Automatisch generierte Komplett-Liste aller 126 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`strassenrecht-infrastruktur.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/strassenrecht-infrastruktur.md) (37 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`strassenrecht-infrastruktur-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/strassenrecht-infrastruktur-megaprompt.md) (30 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`strassenrecht-infrastruktur.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/strassenrecht-infrastruktur.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/strassenrecht-infrastruktur.md`](../testakten/megaprompts/strassenrecht-infrastruktur.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/strassenverkehrsrecht-stvo/README.md
+++ b/strassenverkehrsrecht-stvo/README.md
@@ -184,7 +184,8 @@ Automatisch generierte Komplett-Liste aller 117 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`strassenverkehrsrecht-stvo.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/strassenverkehrsrecht-stvo.md) (36 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`strassenverkehrsrecht-stvo-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/strassenverkehrsrecht-stvo-megaprompt.md) (29 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`strassenverkehrsrecht-stvo.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/strassenverkehrsrecht-stvo.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/strassenverkehrsrecht-stvo.md`](../testakten/megaprompts/strassenverkehrsrecht-stvo.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/subsumtions-pruefer/README.md
+++ b/subsumtions-pruefer/README.md
@@ -243,7 +243,8 @@ Automatisch generierte Komplett-Liste aller 61 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`subsumtions-pruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/subsumtions-pruefer.md) (103 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`subsumtions-pruefer-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/subsumtions-pruefer-megaprompt.md) (75 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`subsumtions-pruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/subsumtions-pruefer.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/subsumtions-pruefer.md`](../testakten/megaprompts/subsumtions-pruefer.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/tabellenreview-3d/README.md
+++ b/tabellenreview-3d/README.md
@@ -160,7 +160,8 @@ Automatisch generierte Komplett-Liste aller 83 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`tabellenreview-3d.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/tabellenreview-3d.md) (69 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`tabellenreview-3d-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/tabellenreview-3d-megaprompt.md) (71 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`tabellenreview-3d.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/tabellenreview-3d.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/tabellenreview-3d.md`](../testakten/megaprompts/tabellenreview-3d.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/telekommunikationsrecht/README.md
+++ b/telekommunikationsrecht/README.md
@@ -111,7 +111,8 @@ Automatisch generierte Komplett-Liste aller 57 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`telekommunikationsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/telekommunikationsrecht.md) (34 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`telekommunikationsrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/telekommunikationsrecht-megaprompt.md) (34 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`telekommunikationsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/telekommunikationsrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/telekommunikationsrecht.md`](../testakten/megaprompts/telekommunikationsrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/tierschutzrecht/README.md
+++ b/tierschutzrecht/README.md
@@ -195,7 +195,8 @@ Automatisch generierte Komplett-Liste aller 128 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`tierschutzrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/tierschutzrecht.md) (37 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`tierschutzrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/tierschutzrecht-megaprompt.md) (30 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`tierschutzrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/tierschutzrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/tierschutzrecht.md`](../testakten/megaprompts/tierschutzrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/umweltrecht/README.md
+++ b/umweltrecht/README.md
@@ -152,7 +152,8 @@ Automatisch generierte Komplett-Liste aller 58 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`umweltrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/umweltrecht.md) (130 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`umweltrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/umweltrecht-megaprompt.md) (133 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`umweltrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/umweltrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/umweltrecht.md`](../testakten/megaprompts/umweltrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/umweltschutzverband-verbandsklage/README.md
+++ b/umweltschutzverband-verbandsklage/README.md
@@ -179,7 +179,8 @@ Automatisch generierte Komplett-Liste aller 112 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`umweltschutzverband-verbandsklage.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/umweltschutzverband-verbandsklage.md) (35 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`umweltschutzverband-verbandsklage-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/umweltschutzverband-verbandsklage-megaprompt.md) (29 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`umweltschutzverband-verbandsklage.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/umweltschutzverband-verbandsklage.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/umweltschutzverband-verbandsklage.md`](../testakten/megaprompts/umweltschutzverband-verbandsklage.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/urheberrecht-de-eu/README.md
+++ b/urheberrecht-de-eu/README.md
@@ -209,7 +209,8 @@ Automatisch generierte Komplett-Liste aller 64 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`urheberrecht-de-eu.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/urheberrecht-de-eu.md) (54 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`urheberrecht-de-eu-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/urheberrecht-de-eu-megaprompt.md) (54 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`urheberrecht-de-eu.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/urheberrecht-de-eu.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/urheberrecht-de-eu.md`](../testakten/megaprompts/urheberrecht-de-eu.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/urteilsbauer-relationsmacher/README.md
+++ b/urteilsbauer-relationsmacher/README.md
@@ -181,7 +181,8 @@ Automatisch generierte Komplett-Liste aller 83 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`urteilsbauer-relationsmacher.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/urteilsbauer-relationsmacher.md) (71 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`urteilsbauer-relationsmacher-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/urteilsbauer-relationsmacher-megaprompt.md) (72 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`urteilsbauer-relationsmacher.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/urteilsbauer-relationsmacher.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/urteilsbauer-relationsmacher.md`](../testakten/megaprompts/urteilsbauer-relationsmacher.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/us-bankruptcy-code/README.md
+++ b/us-bankruptcy-code/README.md
@@ -272,7 +272,8 @@ Automatisch generierte Komplett-Liste aller 100 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`us-bankruptcy-code.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/us-bankruptcy-code.md) (45 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`us-bankruptcy-code-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/us-bankruptcy-code-megaprompt.md) (45 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`us-bankruptcy-code.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/us-bankruptcy-code.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/us-bankruptcy-code.md`](../testakten/megaprompts/us-bankruptcy-code.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/us-copyright-registrierung-verlag/README.md
+++ b/us-copyright-registrierung-verlag/README.md
@@ -179,7 +179,8 @@ Automatisch generierte Komplett-Liste aller 100 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`us-copyright-registrierung-verlag.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/us-copyright-registrierung-verlag.md) (38 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`us-copyright-registrierung-verlag-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/us-copyright-registrierung-verlag-megaprompt.md) (38 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`us-copyright-registrierung-verlag.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/us-copyright-registrierung-verlag.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/us-copyright-registrierung-verlag.md`](../testakten/megaprompts/us-copyright-registrierung-verlag.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/venture-capital-geber/README.md
+++ b/venture-capital-geber/README.md
@@ -183,7 +183,8 @@ Automatisch generierte Komplett-Liste aller 105 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`venture-capital-geber.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/venture-capital-geber.md) (28 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`venture-capital-geber-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/venture-capital-geber-megaprompt.md) (28 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`venture-capital-geber.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/venture-capital-geber.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/venture-capital-geber.md`](../testakten/megaprompts/venture-capital-geber.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/verbraucher-rechtsstaat-alltag/README.md
+++ b/verbraucher-rechtsstaat-alltag/README.md
@@ -126,7 +126,8 @@ Automatisch generierte Komplett-Liste aller 66 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`verbraucher-rechtsstaat-alltag.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/verbraucher-rechtsstaat-alltag.md) (46 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`verbraucher-rechtsstaat-alltag-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/verbraucher-rechtsstaat-alltag-megaprompt.md) (46 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`verbraucher-rechtsstaat-alltag.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/verbraucher-rechtsstaat-alltag.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/verbraucher-rechtsstaat-alltag.md`](../testakten/megaprompts/verbraucher-rechtsstaat-alltag.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/verbraucherinsolvenz-schuldenbereinigung/README.md
+++ b/verbraucherinsolvenz-schuldenbereinigung/README.md
@@ -184,7 +184,8 @@ Automatisch generierte Komplett-Liste aller 69 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`verbraucherinsolvenz-schuldenbereinigung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/verbraucherinsolvenz-schuldenbereinigung.md) (26 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`verbraucherinsolvenz-schuldenbereinigung-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/verbraucherinsolvenz-schuldenbereinigung-megaprompt.md) (26 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`verbraucherinsolvenz-schuldenbereinigung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/verbraucherinsolvenz-schuldenbereinigung.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/verbraucherinsolvenz-schuldenbereinigung.md`](../testakten/megaprompts/verbraucherinsolvenz-schuldenbereinigung.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/verbraucherschutzrecht-pruefer/README.md
+++ b/verbraucherschutzrecht-pruefer/README.md
@@ -214,7 +214,8 @@ Automatisch generierte Komplett-Liste aller 147 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`verbraucherschutzrecht-pruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/verbraucherschutzrecht-pruefer.md) (29 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`verbraucherschutzrecht-pruefer-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/verbraucherschutzrecht-pruefer-megaprompt.md) (29 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`verbraucherschutzrecht-pruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/verbraucherschutzrecht-pruefer.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/verbraucherschutzrecht-pruefer.md`](../testakten/megaprompts/verbraucherschutzrecht-pruefer.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/verbraucherschutzverband-durchsetzung/README.md
+++ b/verbraucherschutzverband-durchsetzung/README.md
@@ -187,7 +187,8 @@ Automatisch generierte Komplett-Liste aller 120 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`verbraucherschutzverband-durchsetzung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/verbraucherschutzverband-durchsetzung.md) (28 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`verbraucherschutzverband-durchsetzung-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/verbraucherschutzverband-durchsetzung-megaprompt.md) (28 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`verbraucherschutzverband-durchsetzung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/verbraucherschutzverband-durchsetzung.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/verbraucherschutzverband-durchsetzung.md`](../testakten/megaprompts/verbraucherschutzverband-durchsetzung.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/vereinsrecht-vereinsmanager/README.md
+++ b/vereinsrecht-vereinsmanager/README.md
@@ -110,7 +110,8 @@ Automatisch generierte Komplett-Liste aller 58 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`vereinsrecht-vereinsmanager.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/vereinsrecht-vereinsmanager.md) (56 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`vereinsrecht-vereinsmanager-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/vereinsrecht-vereinsmanager-megaprompt.md) (56 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`vereinsrecht-vereinsmanager.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/vereinsrecht-vereinsmanager.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/vereinsrecht-vereinsmanager.md`](../testakten/megaprompts/vereinsrecht-vereinsmanager.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/verfassungsrecht/README.md
+++ b/verfassungsrecht/README.md
@@ -144,7 +144,8 @@ Automatisch generierte Komplett-Liste aller 59 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`verfassungsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/verfassungsrecht.md) (116 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`verfassungsrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/verfassungsrecht-megaprompt.md) (119 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`verfassungsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/verfassungsrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/verfassungsrecht.md`](../testakten/megaprompts/verfassungsrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/verhaeltnismaessigkeitspruefer/README.md
+++ b/verhaeltnismaessigkeitspruefer/README.md
@@ -235,7 +235,8 @@ Automatisch generierte Komplett-Liste aller 85 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`verhaeltnismaessigkeitspruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/verhaeltnismaessigkeitspruefer.md) (51 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`verhaeltnismaessigkeitspruefer-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/verhaeltnismaessigkeitspruefer-megaprompt.md) (51 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`verhaeltnismaessigkeitspruefer.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/verhaeltnismaessigkeitspruefer.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/verhaeltnismaessigkeitspruefer.md`](../testakten/megaprompts/verhaeltnismaessigkeitspruefer.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/verkehr-infrastrukturrecht/README.md
+++ b/verkehr-infrastrukturrecht/README.md
@@ -149,7 +149,8 @@ Automatisch generierte Komplett-Liste aller 59 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`verkehr-infrastrukturrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/verkehr-infrastrukturrecht.md) (95 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`verkehr-infrastrukturrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/verkehr-infrastrukturrecht-megaprompt.md) (92 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`verkehr-infrastrukturrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/verkehr-infrastrukturrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/verkehr-infrastrukturrecht.md`](../testakten/megaprompts/verkehr-infrastrukturrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/verkehrsowi-verteidiger/README.md
+++ b/verkehrsowi-verteidiger/README.md
@@ -165,7 +165,8 @@ Automatisch generierte Komplett-Liste aller 60 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`verkehrsowi-verteidiger.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/verkehrsowi-verteidiger.md) (98 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`verkehrsowi-verteidiger-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/verkehrsowi-verteidiger-megaprompt.md) (100 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`verkehrsowi-verteidiger.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/verkehrsowi-verteidiger.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/verkehrsowi-verteidiger.md`](../testakten/megaprompts/verkehrsowi-verteidiger.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/verlagsrecht-buchpreisbindung/README.md
+++ b/verlagsrecht-buchpreisbindung/README.md
@@ -158,7 +158,8 @@ Automatisch generierte Komplett-Liste aller 100 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`verlagsrecht-buchpreisbindung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/verlagsrecht-buchpreisbindung.md) (122 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`verlagsrecht-buchpreisbindung-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/verlagsrecht-buchpreisbindung-megaprompt.md) (82 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`verlagsrecht-buchpreisbindung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/verlagsrecht-buchpreisbindung.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/verlagsrecht-buchpreisbindung.md`](../testakten/megaprompts/verlagsrecht-buchpreisbindung.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/verlagsredaktion/README.md
+++ b/verlagsredaktion/README.md
@@ -224,7 +224,8 @@ Automatisch generierte Komplett-Liste aller 117 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`verlagsredaktion.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/verlagsredaktion.md) (26 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`verlagsredaktion-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/verlagsredaktion-megaprompt.md) (26 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`verlagsredaktion.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/verlagsredaktion.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/verlagsredaktion.md`](../testakten/megaprompts/verlagsredaktion.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/versammlungsrecht/README.md
+++ b/versammlungsrecht/README.md
@@ -141,7 +141,8 @@ Automatisch generierte Komplett-Liste aller 55 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`versammlungsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/versammlungsrecht.md) (58 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`versammlungsrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/versammlungsrecht-megaprompt.md) (58 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`versammlungsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/versammlungsrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/versammlungsrecht.md`](../testakten/megaprompts/versammlungsrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/versicherungsrecht/README.md
+++ b/versicherungsrecht/README.md
@@ -122,7 +122,8 @@ Automatisch generierte Komplett-Liste aller 64 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`versicherungsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/versicherungsrecht.md) (36 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`versicherungsrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/versicherungsrecht-megaprompt.md) (36 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`versicherungsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/versicherungsrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/versicherungsrecht.md`](../testakten/megaprompts/versicherungsrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/vertragsausfueller/README.md
+++ b/vertragsausfueller/README.md
@@ -154,7 +154,8 @@ Automatisch generierte Komplett-Liste aller 60 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`vertragsausfueller.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/vertragsausfueller.md) (74 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`vertragsausfueller-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/vertragsausfueller-megaprompt.md) (79 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`vertragsausfueller.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/vertragsausfueller.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/vertragsausfueller.md`](../testakten/megaprompts/vertragsausfueller.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/vertragsrecht/README.md
+++ b/vertragsrecht/README.md
@@ -243,7 +243,8 @@ Automatisch generierte Komplett-Liste aller 59 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`vertragsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/vertragsrecht.md) (177 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`vertragsrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/vertragsrecht-megaprompt.md) (174 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`vertragsrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/vertragsrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/vertragsrecht.md`](../testakten/megaprompts/vertragsrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/wahlkampfrecht-praxis/README.md
+++ b/wahlkampfrecht-praxis/README.md
@@ -217,7 +217,8 @@ Automatisch generierte Komplett-Liste aller 120 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`wahlkampfrecht-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/wahlkampfrecht-praxis.md) (51 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`wahlkampfrecht-praxis-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/wahlkampfrecht-praxis-megaprompt.md) (52 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`wahlkampfrecht-praxis.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/wahlkampfrecht-praxis.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/wahlkampfrecht-praxis.md`](../testakten/megaprompts/wahlkampfrecht-praxis.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/wandeldarlehen-lebenszyklus/README.md
+++ b/wandeldarlehen-lebenszyklus/README.md
@@ -205,7 +205,8 @@ Automatisch generierte Komplett-Liste aller 53 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`wandeldarlehen-lebenszyklus.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/wandeldarlehen-lebenszyklus.md) (115 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`wandeldarlehen-lebenszyklus-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/wandeldarlehen-lebenszyklus-megaprompt.md) (115 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`wandeldarlehen-lebenszyklus.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/wandeldarlehen-lebenszyklus.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/wandeldarlehen-lebenszyklus.md`](../testakten/megaprompts/wandeldarlehen-lebenszyklus.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/weg-hausverwaltung/README.md
+++ b/weg-hausverwaltung/README.md
@@ -195,7 +195,8 @@ Automatisch generierte Komplett-Liste aller 92 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`weg-hausverwaltung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/weg-hausverwaltung.md) (54 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`weg-hausverwaltung-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/weg-hausverwaltung-megaprompt.md) (54 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`weg-hausverwaltung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/weg-hausverwaltung.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/weg-hausverwaltung.md`](../testakten/megaprompts/weg-hausverwaltung.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/weltraumrecht/README.md
+++ b/weltraumrecht/README.md
@@ -237,7 +237,8 @@ Automatisch generierte Komplett-Liste aller 180 Skills in diesem Plugin. Beschre
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`weltraumrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/weltraumrecht.md) (43 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`weltraumrecht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/weltraumrecht-megaprompt.md) (34 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`weltraumrecht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/weltraumrecht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/weltraumrecht.md`](../testakten/megaprompts/weltraumrecht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/word-legal-ai-plugin-and-skill-for-german-lawyers/README.md
+++ b/word-legal-ai-plugin-and-skill-for-german-lawyers/README.md
@@ -225,7 +225,8 @@ Automatisch generierte Komplett-Liste aller 52 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`word-legal-ai-plugin-and-skill-for-german-lawyers.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/word-legal-ai-plugin-and-skill-for-german-lawyers.md) (103 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`word-legal-ai-plugin-and-skill-for-german-lawyers-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/word-legal-ai-plugin-and-skill-for-german-lawyers-megaprompt.md) (103 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`word-legal-ai-plugin-and-skill-for-german-lawyers.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/word-legal-ai-plugin-and-skill-for-german-lawyers.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/word-legal-ai-plugin-and-skill-for-german-lawyers.md`](../testakten/megaprompts/word-legal-ai-plugin-and-skill-for-german-lawyers.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/zitierweise-deutsches-recht/README.md
+++ b/zitierweise-deutsches-recht/README.md
@@ -155,7 +155,8 @@ Automatisch generierte Komplett-Liste aller 83 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`zitierweise-deutsches-recht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/zitierweise-deutsches-recht.md) (50 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`zitierweise-deutsches-recht-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/zitierweise-deutsches-recht-megaprompt.md) (50 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`zitierweise-deutsches-recht.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/zitierweise-deutsches-recht.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/zitierweise-deutsches-recht.md`](../testakten/megaprompts/zitierweise-deutsches-recht.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/zwangsverwaltung-zvg/README.md
+++ b/zwangsverwaltung-zvg/README.md
@@ -195,7 +195,8 @@ Automatisch generierte Komplett-Liste aller 58 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`zwangsverwaltung-zvg.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/zwangsverwaltung-zvg.md) (70 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`zwangsverwaltung-zvg-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/zwangsverwaltung-zvg-megaprompt.md) (73 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`zwangsverwaltung-zvg.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/zwangsverwaltung-zvg.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/zwangsverwaltung-zvg.md`](../testakten/megaprompts/zwangsverwaltung-zvg.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*

--- a/zwangsvollstreckung/README.md
+++ b/zwangsvollstreckung/README.md
@@ -164,7 +164,8 @@ Automatisch generierte Komplett-Liste aller 59 Skills in diesem Plugin. Beschrei
 
 Das Plugin gibt es zusaetzlich als **single-file Megaprompt** — ein experimentelles Markdown, das die wichtigsten Skills in einer einzigen Datei buendelt. Drop das in einen Chat ohne Claude-Code-Integration; der Agent erhaelt damit die gebuendelten Skill-Anweisungen.
 
-- **Direkt-Download**: [`zwangsvollstreckung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/zwangsvollstreckung.md) (120 KB)
+- **Direkt als Datei herunterladen** (empfohlen): [`zwangsvollstreckung-megaprompt.md`](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest/download/zwangsvollstreckung-megaprompt.md) (122 KB) — Release-Asset, wird vom Browser als Datei gespeichert.
+- Im Browser ansehen: [`zwangsvollstreckung.md`](https://raw.githubusercontent.com/Klotzkette/claude-fuer-deutsches-recht/main/testakten/megaprompts/zwangsvollstreckung.md) — wird als Text gerendert, nicht heruntergeladen.
 - Im Repo: [`testakten/megaprompts/zwangsvollstreckung.md`](../testakten/megaprompts/zwangsvollstreckung.md)
 
 *Keine Haftung, keine Gewaehr — Megaprompts sind eine Best-Effort-Kompression, kein vollwertiger Plugin-Ersatz.*


### PR DESCRIPTION
## Megaprompts als Direkt-Download-Datei statt Browser-Anzeige

### Problem

Plugin-READMEs verlinkten den Megaprompt bisher über `raw.githubusercontent.com/.../megaprompts/<plugin>.md`. GitHub liefert dort `.md` mit `Content-Type: text/plain` — der Browser **zeigt** den Megaprompt als Text **an**, statt ihn als Datei herunterzuladen. Wer den Megaprompt in einen anderen Chat hochladen will, muss erst Rechtsklick → „Speichern unter" oder Copy-Paste.

### Lösung

Megaprompts werden zusätzlich als **eigenes Release-Asset** veröffentlicht. Release-Assets liefert GitHub mit `Content-Disposition: attachment`, der Browser lädt also als Datei.

### Änderungen

1. **`.github/workflows/release-plugin-zips.yml`** — neuer Step kopiert jeden Megaprompt als `<plugin>-megaprompt.md` ins `dist/`-Verzeichnis. Upload-Filter und SHA256-Checksumdatei-Filter ergänzt.

2. **`scripts/inject-megaprompt-section.py`** — README-Block hat jetzt drei Optionen statt einer:
   - **Direkt als Datei herunterladen** (empfohlen): Release-Asset, wird vom Browser gespeichert.
   - **Im Browser ansehen**: raw.github-Link, plain-text-render.
   - **Im Repo**: relativer Pfad.

3. **213 Plugin-READMEs** auf das neue 3-Optionen-Schema aktualisiert.

### Wirksam nach dem nächsten Release

Solange noch kein Release v327+ rausgegangen ist, gibt der Direkt-Download-Link einen 404. Sobald der Release-Workflow läuft (manuell oder per Tag), sind die 213 `<plugin>-megaprompt.md`-Assets auf dem `latest`-Release verfügbar.

### Sanity

- `validate-plugin-structure.mjs` OK
- `validate-yaml-frontmatter.py` 0 Fehler

---
_Generated by [Claude Code](https://claude.ai/code/session_011vwdNGtbxBSrb7x7Duo3BL)_