### PR TITLE
Verbindliche dezimale Gliederungsregel für alle Vorlagen und Verträge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS.md – Repository-Regeln für alle Agenten
+
+Dieses Repository enthält Plugins für deutsche Kanzleien. Diese Datei gilt für **jedes** Werkzeug, das hier arbeitet – Codex, Perplexity, Cloud, Claude und jedes weitere Modell. Der vollständige Leitfaden steht in [`CLAUDE.md`](./CLAUDE.md); halte dich an beide.
+
+## Gliederung und Nummerierung (verbindlich für alle Vorlagen und Verträge)
+
+Diese Regel gilt **dauerhaft und für jedes Werkzeug**. Sie ist nicht verhandelbar.
+
+- **Ausschließlich dezimale Gliederung:** `1`, dann `1.1`, dann `1.1.1`, dann `1.1.1.1` und so weiter, beliebig tief.
+- **Niemals** römische Ziffern (`I`, `II`), Großbuchstaben (`A`, `B`, `C`), Kleinbuchstaben (`a`, `b`) oder gemischte Verlags-Gliederungen (`A. I. 1. a) aa)`). Genau diese Schemata sind verboten, weil man sich darin nicht zurechtfindet.
+- **Leerzeile zwischen Gliederungspunkt und seinem Inhalt sowie zwischen Gliederungsebenen.** Überschrift bzw. Nummer und der folgende Text/Unterpunkt werden durch eine Leerzeile getrennt, sonst ist es nicht lesbar.
+- **Einrückung sparsam.** Nur leicht einrücken, gerade so viel, dass die Hierarchie sichtbar bleibt und es gut aussieht – nie so tief, dass das Dokument zerfleddert wirkt.
+
+Gilt für alle Vorlagen, Verträge, Memos, Schriftsätze und sonstigen Dokumente in diesem Repository.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,17 @@ Dieses Repository enthält Plugins für deutsche Kanzleien. Wenn du in diesem Re
 - Keine Kommentar-, Handbuch- oder Aufsatzfundstellen aus Modellwissen zitieren. Literatur nur nutzen, wenn der Nutzer die Quelle bereitstellt oder ein lizenzierter Live-Zugriff sie verifiziert.
 - **Leitentscheidungs-Anker:** [`references/leitentscheidungen-anker.md`](./references/leitentscheidungen-anker.md) ist die kuratierte Themen-Anker-Liste je Rechtsgebiet. Sie ersetzt nicht die Live-Verifikation, aber sie liefert sichere Sucheinstiege ohne Modellwissens-Halluzination.
 
+## Gliederung und Nummerierung (verbindlich für alle Vorlagen und Verträge)
+
+Diese Regel gilt **dauerhaft und für jedes Werkzeug**, das in diesem Repository arbeitet – Claude, Codex, Perplexity, Cloud und jedes weitere Modell. Sie ist nicht verhandelbar.
+
+- **Ausschließlich dezimale Gliederung:** `1`, dann `1.1`, dann `1.1.1`, dann `1.1.1.1` und so weiter, beliebig tief.
+- **Niemals** römische Ziffern (`I`, `II`), Großbuchstaben (`A`, `B`, `C`), Kleinbuchstaben (`a`, `b`) oder gemischte Verlags-Gliederungen (`A. I. 1. a) aa)`). Genau diese Schemata sind verboten, weil man sich darin nicht zurechtfindet.
+- **Leerzeile zwischen Gliederungspunkt und seinem Inhalt sowie zwischen Gliederungsebenen.** Überschrift bzw. Nummer und der folgende Text/Unterpunkt werden durch eine Leerzeile getrennt, sonst ist es nicht lesbar.
+- **Einrückung sparsam.** Nur leicht einrücken, gerade so viel, dass die Hierarchie sichtbar bleibt und es gut aussieht – nie so tief, dass das Dokument zerfleddert wirkt.
+
+Gilt für alle Vorlagen, Verträge, Memos, Schriftsätze und sonstigen Dokumente in diesem Repository.
+
 ## Verboten
 
 - Präjudizienbindungs-Argumente. In Deutschland gibt es keine Präjudizienbindung (außer § 31 BVerfGG).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ Viele Skills in diesem Repo sind im Kern strukturierte **Mega-Prompts** — also
 
 Für diesen Anwendungsfall gibt es eine kuratierte, nach Fachanwaltschaften sortierte Liste: **[Klotzkettes Juristische Promptliste](./PROMPTLISTE.md)** — alle Angaben ohne Gewähr, mit großem Disclaimer auf der Seite. Workflow-Eingangs-Skills, generische Router und ausgesprochen historisch-exotische Inhalte (Preußisches Landrecht, Römisches Recht, Kanonisches Recht, Weltraumrecht) bleiben dort bewusst ausgespart.
 
+## Verbindliche Gliederungsregel für alle Vorlagen und Verträge
+
+Diese Regel gilt **dauerhaft und für jedes Werkzeug**, das in diesem Repository arbeitet – Claude, Codex, Perplexity, Cloud und jedes weitere Modell. Sie ist auch in [`CLAUDE.md`](./CLAUDE.md) und [`AGENTS.md`](./AGENTS.md) festgehalten.
+
+- **Ausschließlich dezimale Gliederung:** `1`, dann `1.1`, dann `1.1.1`, dann `1.1.1.1` und so weiter, beliebig tief.
+
+- **Niemals** römische Ziffern (`I`, `II`), Großbuchstaben (`A`, `B`, `C`), Kleinbuchstaben (`a`, `b`) oder gemischte Verlags-Gliederungen (`A. I. 1. a) aa)`) – genau diese Schemata sind verboten, weil man sich darin nicht zurechtfindet.
+
+- **Leerzeile** zwischen Gliederungspunkt und seinem Inhalt sowie zwischen den Gliederungsebenen, sonst ist es nicht lesbar.
+
+- **Einrückung sparsam** – nur leicht einrücken, gerade so viel, dass die Hierarchie sichtbar bleibt und es gut aussieht, nie so tief, dass das Dokument zerfleddert wirkt.
+
+Gilt für alle Vorlagen, Verträge, Memos, Schriftsätze und sonstigen Dokumente in diesem Repository.
+
 ## Überblick
 
 | Kennzahl | Wert |


### PR DESCRIPTION
Hält die vom Repository-Inhaber als sehr wichtig bezeichnete Gliederungsregel dauerhaft fest – gültig für alle Werkzeuge, die in diesem Repo arbeiten (Claude, Codex, Perplexity, Cloud u. a.):

- Ausschließlich dezimale Gliederung: `1`, `1.1`, `1.1.1`, `1.1.1.1`, beliebig tief.
- Niemals römische Ziffern, Groß-/Kleinbuchstaben oder gemischte Verlags-Gliederungen (`A. I. 1. a) aa)`).
- Leerzeile zwischen Gliederungspunkt und Inhalt sowie zwischen den Ebenen.
- Einrückung sparsam, damit Dokumente nicht zerfleddert wirken.

Verankert an drei Stellen:

- `CLAUDE.md` – neuer Abschnitt vor „Verboten".
- `AGENTS.md` – neu angelegt, für Codex und andere Agenten.
- `README.md` – sichtbarer Abschnitt vor dem „Überblick".

🤖 Generated with [Claude Code](https://claude.com/claude-code)