### PR TITLE
Skill-Benennungs-Bugs und Lizenz-Inkonsistenz behoben

### DIFF
--- a/arbeitszeugnisgenerator/README.md
+++ b/arbeitszeugnisgenerator/README.md
@@ -36,7 +36,7 @@ Drei Modi zur Wahl:
 
 - **Wohlwollensgrundsatz versus Wahrheitspflicht**: Beides muss eingehalten werden, kein Schoenschreiben um den Preis der Wahrheit.
 - **Geheimcodes**: Versehentlich eingebaute Negativcodes ("bemueht sich", "im Grossen und Ganzen", "lernte schnell kennen und schaetzen") kippen die Note. Der Generator vermeidet sie aktiv.
-- **Zeugnisklarheit nach BAG 9 AZR 227.11**: Keine doppelten Boeden, keine widerspruechlichen Aussagen.
+- **Zeugnisklarheit (objektiver Empfaengerhorizont, BAG 9 AZR 352.04)**: Keine doppelten Boeden, keine widerspruechlichen Aussagen.
 - **Aussere Form**: Briefkopf, Datum, Unterschrift, kein Knick, keine Streichungen.
 - **Schlussformel-Wirkung**: Schlussformeln wirken oft staerker als die Bewertungssaetze. Eine schwache Schlussformel zieht die Gesamtnote.
 

--- a/arbeitszeugnisgenerator/arbeitszeugnisgenerator-werkstatt.md
+++ b/arbeitszeugnisgenerator/arbeitszeugnisgenerator-werkstatt.md
@@ -93,8 +93,8 @@ Arbeitsprodukt: Liefere am Ende dieser Station den vollstaendigen, druckfertigen
 - BAG, Urteil vom 14.10.2003 - 9 AZR 12.03: Zeugnisklarheit. Aussagen muessen so formuliert sein, dass sie von Dritten zutreffend verstanden werden koennen; Geheimcodes sind unzulaessig.
 - BAG, Urteil vom 12.08.2008 - 9 AZR 632.07: Anspruch auf qualifiziertes Zeugnis umfasst Leistung und Verhalten in ausformuliertem Text, nicht in Stichworten.
 - BAG, Urteil vom 27.04.2021 - 9 AZR 262.20: Kein durchsetzbarer Anspruch auf Dank, Bedauern und gute Zukunftswuensche; gleichwohl ueblicher Bestandteil bei guten und sehr guten Zeugnissen.
-- BAG, Urteil vom 21.06.2005 - 9 AZR 352.04: Anspruch auf Zwischenzeugnis bei berechtigtem Interesse, etwa Vorgesetztenwechsel, Umstrukturierung oder bevorstehender Bewerbung.
-- BAG, Urteil vom 11.12.2012 - 9 AZR 227.11: Anforderungen an die Zeugnissprache; Auslassungen typischer Beurteilungspunkte koennen als negative Aussage gewertet werden.
+- BAG, Urteil vom 21.06.2005 - 9 AZR 352.04: Selbstbindung des Arbeitgebers an ein Zwischenzeugnis und Massregelungsverbot; das Endzeugnis darf ohne veraenderte Tatsachengrundlage nicht zum Nachteil des Arbeitnehmers abweichen; massgeblich ist der objektive Empfaengerhorizont.
+- BAG, Urteil vom 11.12.2012 - 9 AZR 227.11: Kein gesetzlicher Anspruch auf eine Schlussformel mit Dank und guten Wuenschen; bei Unzufriedenheit mit einer erteilten Schlussformel besteht nur Anspruch auf ein Zeugnis ohne Schlussformel, nicht auf eine bestimmte Umformulierung.
 - BAG, Urteil vom 15.11.2011 - 9 AZR 386.10: Notenstufen im Arbeitszeugnis und ihre sprachliche Entsprechung; durchschnittliche Bewertung entspricht der Note befriedigend.
 
 ## 6. Notenformel-Katalog fuer Zusammenfassungsformeln

--- a/arbeitszeugnisgenerator/skills/zeugnisklarheit-objektiver-empfaengerhorizont/SKILL.md
+++ b/arbeitszeugnisgenerator/skills/zeugnisklarheit-objektiver-empfaengerhorizont/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: zeugnisklarheit-bag-9-azr-227-11
-description: "Das Gebot der Zeugnisklarheit aus Paragraf 109 Abs. 2 GewO und der BAG-Rechtsprechung (9 AZR 352/04; 9 AZR 386/10; 9 AZR 227/11). Maßgeblich ist der objektive Empfängerhorizont. Formulierungen müssen das ausdrücken, was ihr Wortlaut besagt — nicht mehr, nicht weniger. Enthält Regeln zur Abgrenzung zulässiger Formulierungsspielräume von unzulässigen Codes."
+name: zeugnisklarheit-objektiver-empfaengerhorizont
+description: "Das Gebot der Zeugnisklarheit aus Paragraf 109 Abs. 2 GewO und der BAG-Rechtsprechung (9 AZR 352/04; 9 AZR 386/10). Maßgeblich ist der objektive Empfängerhorizont. Formulierungen müssen das ausdrücken, was ihr Wortlaut besagt — nicht mehr, nicht weniger. Enthält Regeln zur Abgrenzung zulässiger Formulierungsspielräume von unzulässigen Codes."
 ---
 
-# Zeugnisklarheit — BAG 9 AZR 227/11
+# Zeugnisklarheit — objektiver Empfängerhorizont (BAG 9 AZR 352/04; 9 AZR 386/10)
 
 ## Ziel
 

--- a/arbeitszeugnispruefer/arbeitszeugnispruefer-werkstatt.md
+++ b/arbeitszeugnispruefer/arbeitszeugnispruefer-werkstatt.md
@@ -98,7 +98,7 @@ Arbeitsprodukt: Liefere am Ende dieser Station das Aufforderungsschreiben mit Fr
 - BAG, Urteil vom 12.08.2008 - 9 AZR 632.07: Anspruch auf qualifiziertes Zeugnis verlangt ausformulierten Text, nicht Stichworte.
 - BAG, Urteil vom 27.04.2021 - 9 AZR 262.20: kein durchsetzbarer Anspruch auf Schlussformel; sie ist aber bei guten Zeugnissen ueblicher Bestandteil.
 - BAG, Urteil vom 21.06.2005 - 9 AZR 352.04: Selbstbindung des Arbeitgebers an ein Zwischenzeugnis und Massregelungsverbot; das Endzeugnis darf ohne veraenderte Tatsachengrundlage nicht zum Nachteil des Arbeitnehmers abweichen; objektiver Empfaengerhorizont.
-- BAG, Urteil vom 11.12.2012 - 9 AZR 227.11: Anforderungen an die Zeugnissprache; Auslassungen typischer Beurteilungspunkte koennen als negative Aussage gewertet werden.
+- BAG, Urteil vom 11.12.2012 - 9 AZR 227.11: Kein gesetzlicher Anspruch auf eine Schlussformel mit Dank und guten Wuenschen; bei Unzufriedenheit mit einer erteilten Schlussformel besteht nur Anspruch auf ein Zeugnis ohne Schlussformel, nicht auf eine bestimmte Umformulierung.
 - BAG, Urteil vom 15.11.2011 - 9 AZR 386.10: Notenstufen und ihre sprachliche Entsprechung; durchschnittlich entspricht befriedigend.
 
 ## 6. Geheimcode-Katalog (Pruefliste)

--- a/arbeitszeugnispruefer/skills/zeugnisklarheit-objektiver-empfaengerhorizont/SKILL.md
+++ b/arbeitszeugnispruefer/skills/zeugnisklarheit-objektiver-empfaengerhorizont/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: zeugnisklarheit-bag-9-azr-227-11
-description: Pruefung eines Arbeitszeugnisses auf das Gebot der Zeugnisklarheit nach Paragraf 109 Absatz 2 GewO mit Anwendung des objektiven Empfaengerhorizonts als Massstab gemaess BAG-Urteil 9 AZR 227.11 und ergaenzender Rechtsprechung.
+name: zeugnisklarheit-objektiver-empfaengerhorizont
+description: Pruefung eines Arbeitszeugnisses auf das Gebot der Zeugnisklarheit nach Paragraf 109 Absatz 2 GewO mit Anwendung des objektiven Empfaengerhorizonts als Massstab gemaess der BAG-Rechtsprechung (9 AZR 352.04; 9 AZR 386.10).
 ---
 
-# Zeugnisklarheit nach BAG 9 AZR 227.11
+# Zeugnisklarheit nach dem objektiven Empfaengerhorizont (BAG 9 AZR 352.04; 9 AZR 386.10)
 
 Das Gebot der Zeugnisklarheit verlangt, dass jede Formulierung im Zeugnis dem objektiven Leser dasselbe vermittelt, was sie wortwortlich sagt. Mehrdeutigkeiten, verklausulierte Negativaussagen und ironisch ueberzogenes Lob verstoossen gegen dieses Gebot. Massgeblich ist nicht die Absicht des Arbeitgebers, sondern der objektive Empfaengerhorizont (BAG 21.6.2005 - 9 AZR 352.04).
 

--- a/bautraegervertragspruefer/skills/paragraf-308-nr-4-bgb-leistungsaenderung/SKILL.md
+++ b/bautraegervertragspruefer/skills/paragraf-308-nr-4-bgb-leistungsaenderung/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: paragraf-308-nr-1-bgb-leistungsaenderung
+name: paragraf-308-nr-4-bgb-leistungsaenderung
 description: "Prueft Leistungsaenderungsvorbehalte des Bautraegers nach Paragraf 308 Nummer 4 BGB. Klauseln die dem Bautraeger pauschale Aenderungen an Bausoll, Grundriss, Ausstattung, Energiestandard oder Teilungserklaerung erlauben sind unwirksam wenn keine konkret benannten triftigen Gruende erkennbar sind."
 ---
 

--- a/gerichtsplugins/relationstechnik-zivilrecht/.claude-plugin/plugin.json
+++ b/gerichtsplugins/relationstechnik-zivilrecht/.claude-plugin/plugin.json
@@ -12,5 +12,5 @@
     "revisionssicher",
     "relationstechnik"
   ],
-  "license": "Apache-2.0"
+  "license": "Apache-2.0 OR MIT"
 }

--- a/gerichtsplugins/richter-amtsgericht-handelsregister/.claude-plugin/plugin.json
+++ b/gerichtsplugins/richter-amtsgericht-handelsregister/.claude-plugin/plugin.json
@@ -12,5 +12,5 @@
     "revisionssicher",
     "richter"
   ],
-  "license": "Apache-2.0"
+  "license": "Apache-2.0 OR MIT"
 }

--- a/gerichtsplugins/richter-amtsgericht-insolvenz-restrukturierung/.claude-plugin/plugin.json
+++ b/gerichtsplugins/richter-amtsgericht-insolvenz-restrukturierung/.claude-plugin/plugin.json
@@ -12,5 +12,5 @@
     "revisionssicher",
     "richter"
   ],
-  "license": "Apache-2.0"
+  "license": "Apache-2.0 OR MIT"
 }

--- a/gerichtsplugins/richter-amtsgericht-straf/.claude-plugin/plugin.json
+++ b/gerichtsplugins/richter-amtsgericht-straf/.claude-plugin/plugin.json
@@ -12,5 +12,5 @@
     "revisionssicher",
     "richter"
   ],
-  "license": "Apache-2.0"
+  "license": "Apache-2.0 OR MIT"
 }

--- a/gerichtsplugins/richter-amtsgericht-zivil/.claude-plugin/plugin.json
+++ b/gerichtsplugins/richter-amtsgericht-zivil/.claude-plugin/plugin.json
@@ -12,5 +12,5 @@
     "revisionssicher",
     "richter"
   ],
-  "license": "Apache-2.0"
+  "license": "Apache-2.0 OR MIT"
 }

--- a/gerichtsplugins/richter-arbeitsgericht/.claude-plugin/plugin.json
+++ b/gerichtsplugins/richter-arbeitsgericht/.claude-plugin/plugin.json
@@ -12,5 +12,5 @@
     "revisionssicher",
     "richter"
   ],
-  "license": "Apache-2.0"
+  "license": "Apache-2.0 OR MIT"
 }

--- a/gerichtsplugins/richter-bverfg-verfassungsbeschwerden/.claude-plugin/plugin.json
+++ b/gerichtsplugins/richter-bverfg-verfassungsbeschwerden/.claude-plugin/plugin.json
@@ -12,5 +12,5 @@
     "revisionssicher",
     "richter"
   ],
-  "license": "Apache-2.0"
+  "license": "Apache-2.0 OR MIT"
 }

--- a/gerichtsplugins/richter-familiengericht/.claude-plugin/plugin.json
+++ b/gerichtsplugins/richter-familiengericht/.claude-plugin/plugin.json
@@ -12,5 +12,5 @@
     "revisionssicher",
     "richter"
   ],
-  "license": "Apache-2.0"
+  "license": "Apache-2.0 OR MIT"
 }

--- a/gerichtsplugins/richter-finanzgericht/.claude-plugin/plugin.json
+++ b/gerichtsplugins/richter-finanzgericht/.claude-plugin/plugin.json
@@ -12,5 +12,5 @@
     "revisionssicher",
     "richter"
   ],
-  "license": "Apache-2.0"
+  "license": "Apache-2.0 OR MIT"
 }

--- a/gerichtsplugins/richter-landgericht-strafkammer/.claude-plugin/plugin.json
+++ b/gerichtsplugins/richter-landgericht-strafkammer/.claude-plugin/plugin.json
@@ -12,5 +12,5 @@
     "revisionssicher",
     "richter"
   ],
-  "license": "Apache-2.0"
+  "license": "Apache-2.0 OR MIT"
 }

--- a/gerichtsplugins/richter-landgericht-zivilkammer/.claude-plugin/plugin.json
+++ b/gerichtsplugins/richter-landgericht-zivilkammer/.claude-plugin/plugin.json
@@ -12,5 +12,5 @@
     "revisionssicher",
     "richter"
   ],
-  "license": "Apache-2.0"
+  "license": "Apache-2.0 OR MIT"
 }

--- a/gerichtsplugins/richter-sozialgericht/.claude-plugin/plugin.json
+++ b/gerichtsplugins/richter-sozialgericht/.claude-plugin/plugin.json
@@ -12,5 +12,5 @@
     "revisionssicher",
     "richter"
   ],
-  "license": "Apache-2.0"
+  "license": "Apache-2.0 OR MIT"
 }

--- a/gerichtsplugins/richter-verwaltungsgericht/.claude-plugin/plugin.json
+++ b/gerichtsplugins/richter-verwaltungsgericht/.claude-plugin/plugin.json
@@ -12,5 +12,5 @@
     "revisionssicher",
     "richter"
   ],
-  "license": "Apache-2.0"
+  "license": "Apache-2.0 OR MIT"
 }

--- a/gerichtsplugins/staatsanwaltschaft-amtsanwaltschaft/.claude-plugin/plugin.json
+++ b/gerichtsplugins/staatsanwaltschaft-amtsanwaltschaft/.claude-plugin/plugin.json
@@ -12,5 +12,5 @@
     "aktengeheimnis",
     "revisionssicher"
   ],
-  "license": "Apache-2.0"
+  "license": "Apache-2.0 OR MIT"
 }


### PR DESCRIPTION
Folge-PR zu #313 — setzt die drei dort gemeldeten offenen Punkte um.

## 1. Skill-Benennungs-Bug Bauträger
`bautraegervertragspruefer/skills/paragraf-308-nr-1-bgb-leistungsaenderung` → `…-nr-4-…`. Inhalt, Überschrift und Description behandeln durchgängig § 308 **Nr. 4** BGB (Änderungsvorbehalt) — nur der Slug/`name` sagte fälschlich „Nr. 1".

## 2. Skill-Benennungs-Bug Zeugnisklarheit (Generator + Prüfer)
`zeugnisklarheit-bag-9-azr-227-11` → `zeugnisklarheit-objektiver-empfaengerhorizont` in **beiden** Plugins. `9 AZR 227/11` (BAG 11.12.2012) ist extern verifiziert die **Schlussformel**-Entscheidung (kein Anspruch auf Dank/gute Wünsche), **keine** Zeugnisklarheits-Leitentscheidung. Tragende Anker der Zeugnisklarheit sind `9 AZR 352/04` (objektiver Empfängerhorizont) und `9 AZR 386/10`.

Mitkorrigierte Verweise:
- `arbeitszeugnisgenerator/README.md`: Zeugnisklarheits-Bullet vom falschen AZ gelöst.
- Beide Werkstatt-Prompts: `227/11` war fälschlich als „Anforderungen an die Zeugnissprache" beschrieben → korrektes Schlussformel-Holding.
- Generator-Werkstatt zusätzlich: `352/04` war fälschlich als „Anspruch auf Zwischenzeugnis" beschrieben → korrekt Selbstbindung/Maßregelungsverbot + objektiver Empfängerhorizont (so wie im Prüfer-Werkstatt bereits richtig).

## 3. Lizenz-Inkonsistenz
Die 14 Gerichts-Sub-Plugins standen auf `Apache-2.0`, der Repo-Standard ist dual `Apache-2.0 OR MIT` (213 von 227 Plugins, so auch in der Wurzel-README). Angeglichen.

Alle drei umbenannten Skills: Frontmatter-`name` = Ordnername verifiziert; keine verwaisten Slug-Verweise; alle 14 `plugin.json` valides JSON. Keine erfundenen Fundstellen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXnmkjavncPDoNYycYaC5G)_