### PR TITLE
Normanker in W&I und Umwandlung korrigieren

### DIFF
--- a/gesellschaftsrecht/skills/umwandlung-formwechsel-verschmelzung-spaltung/SKILL.md
+++ b/gesellschaftsrecht/skills/umwandlung-formwechsel-verschmelzung-spaltung/SKILL.md
@@ -35,7 +35,9 @@ Nutze diesen Skill, wenn eine Gesellschaft umstrukturiert werden soll und Formwe
 ## Rechtsprechungs- und Normanker
 
 - Umwandlungsgesetz: Verschmelzung, Spaltung, Vermögensübertragung und Formwechsel.
-- Paragraf 13 und 16 UmwG: Beschluss und Registerwirkung als zentrale Arbeitsschritte.
+- Paragraf 13 und Paragraf 16 UmwG: Beschluss und Anmeldung der Verschmelzung als getrennte Arbeitsschritte.
+- Paragraf 20 UmwG: Wirkungen der Eintragung der Verschmelzung, insbesondere Vollzug, Vermögensübergang und Erlöschen des übertragenden Rechtsträgers.
+- Paragraf 131 UmwG: Wirkungen der Eintragung bei Spaltungen und Ausgliederungen.
 - Paragraf 22 UmwG: Gläubigerschutz.
 - Paragraf 613a BGB: Betriebsübergang prüfen, wenn Arbeitnehmer betroffen sind.
 

--- a/grosskanzlei-corporate-ma/skills/w-i-insurance-underwriting-bridge/SKILL.md
+++ b/grosskanzlei-corporate-ma/skills/w-i-insurance-underwriting-bridge/SKILL.md
@@ -33,7 +33,7 @@ Nutze diesen Skill, wenn eine W&I-Versicherung in den Deal einbezogen wird und d
 
 ## Rechtsprechungs- und Normanker
 
-- Paragraf 43 VVG: Zurechnung und Vertreterwissen bei Versicherungsverträgen als Prüfhinweis.
+- Paragraf 69 und Paragraf 70 VVG: gesetzliche Vollmacht und Kenntnis des Versicherungsvertreters; bei Broker-, Makler- und Deal-Team-Wissen zusätzlich Vertreterstellung, Knowledge-Definition und Disclosure Letter getrennt prüfen.
 - Paragraf 19 VVG: vorvertragliche Anzeigeobliegenheit als Leitplanke für saubere Underwriting-Antworten.
 - Paragraf 133 und 157 BGB: Auslegung von SPA- und Police-Begriffen im Zusammenspiel.
 - BGH, 21.04.1997 - II ZR 175/95: dokumentierte Informationsgrundlage für Deal-Entscheidungen.


### PR DESCRIPTION
## Änderung

- W&I-Underwriting: falschen VVG-43-Anker durch VVG 69 und 70 ersetzt.
- Umwandlung: Registerwirkung der Verschmelzung auf UmwG 20 gelegt und Spaltungswirkung über UmwG 131 ergänzt.

## Prüfung

- Zielsuche nach den alten falschen Ankern ohne Treffer
- `git diff --check` ohne Beanstandung