### PR TITLE
Produktrecht-Profilmigration im Direktstart wiederherstellen

### DIFF
--- a/produktrecht/skills/kaltstart-interview/SKILL.md
+++ b/produktrecht/skills/kaltstart-interview/SKILL.md
@@ -18,6 +18,18 @@ Frage höchstens zwei Punkte nach, und nur wenn ohne diese Antwort der nächste 
 
 Starte mit einem Arbeitsprodukt, nicht mit einer Inventarliste: Kurzvermerk, Fristenblatt, Prüfmatrix, Entwurf, Fragenliste oder Entscheidungsvorschlag. Routing ist nur Mittel zum Zweck. Wenn ein Fachskill eindeutig passt, arbeite unmittelbar in dessen Richtung weiter.
 
+## Produktrecht-Setup zuerst sichern
+
+Vor dem allgemeinen Kaltstart immer zuerst das Produktrecht-Profil sichern:
+
+1. Zustand von `~/.claude/plugins/config/claude-fuer-deutsches-recht/produktrecht/CLAUDE.md` prüfen.
+2. Wenn dort bereits ein ausgefülltes Profil ohne `[PLATZHALTER]`-Marker liegt, kein neues Interview starten; Profil lesen und mit der laufenden Aufgabe arbeiten.
+3. Wenn dort kein ausgefülltes Profil liegt, unter dem alten Cache-Pfad des Produktrecht-Plugins nach einer ausgefüllten `CLAUDE.md` ohne `[PLATZHALTER]`-Marker suchen.
+4. Wenn ein solches Altprofil existiert, es nach `~/.claude/plugins/config/claude-fuer-deutsches-recht/produktrecht/CLAUDE.md` kopieren; übergeordnete Verzeichnisse bei Bedarf erstellen und dem Nutzer knapp zeigen, was migriert wurde.
+5. Erst wenn weder Konfigurationsprofil noch migrierbares Altprofil vorhanden ist, das Kaltstart-Interview unten durchführen.
+6. Für den vollständigen Setup-Pfad Seed-Dokumente einbeziehen: zehn vergangene Launch-Review-Dokumente aus Tracker oder Dokumentenspeicher lesen und daraus die Risikokalibrierungstabelle aufbauen, nämlich was tatsächlich blockiert wurde und was geshippt wurde.
+7. Beim Schreiben von `~/.claude/plugins/config/claude-fuer-deutsches-recht/produktrecht/CLAUDE.md` die Kalibrierungstabelle zur Bestätigung zeigen.
+
 ## `--check-integrations`
 
 Führt die Integrations-Verfügbarkeitsprüfung erneut durch (Launch-Tracker, Dokumentenspeicher, Slack) und aktualisiert `## Verfügbare Integrationen` in der Konfiguration. Führt kein neues Interview durch. Verwenden wenn ein MCP verbunden oder getrennt wurde.


### PR DESCRIPTION
## Inhalt

- Produktrecht-Kaltstart sichert vor dem allgemeinen Direktstart wieder das vorhandene Profil.
- Migrierbares Altprofil wird vor einem neuen Interview in den Konfigurationspfad übernommen.
- Seed-Reviews und Kalibrierungstabelle bleiben Teil des vollständigen Setup-Pfads.

## Prüfungen

- `git diff --check`
- `node scripts/validate-plugin-structure.mjs`
- `python3 scripts/validate-yaml-frontmatter.py`