### PR TITLE
Codex-Feedback aus #340: clean() erhält Grenzwörter und wirft hängende Funktionswörter ab

### DIFF
--- a/scripts/generate-werkstatt-und-schnellstart-prompts.py
+++ b/scripts/generate-werkstatt-und-schnellstart-prompts.py
@@ -138,9 +138,28 @@ def clean(text: str, limit: int | None = None) -> str:
     text = re.sub(r"\s+", " ", text).strip()
     if limit and len(text) > limit:
         cut = text[: limit - 1]
-        # Nie mitten im Wort schneiden: auf die letzte Wortgrenze zurueckgehen.
-        if " " in cut:
-            cut = cut[: cut.rfind(" ")]
+        # Nur zurueckschneiden, wenn der Schnitt mitten in einem Wort endet.
+        # Endet der Schnitt genau auf einer Wortgrenze (letztes Zeichen oder
+        # naechstes Zeichen im Originaltext ist ein Leerzeichen), bleibt das
+        # vollstaendige Grenzwort erhalten.
+        if cut and not cut[-1].isspace() and not text[len(cut)].isspace():
+            if " " in cut:
+                cut = cut[: cut.rfind(" ")]
+        # Kein haengendes Funktionswort am Satzende ("Risiken und." o. ae.):
+        # nachklappernde Konjunktionen, Praepositionen und Artikel abwerfen,
+        # damit der gekuerzte Satz auf einem Inhaltswort endet.
+        dangling = {
+            "und", "oder", "sowie", "mit", "ohne", "zum", "zur", "zu",
+            "der", "die", "das", "des", "dem", "den",
+            "ein", "eine", "einer", "eines", "einem", "einen",
+            "bei", "nach", "fuer", "für", "auf", "als", "im", "in", "an",
+            "am", "von", "vom", "aus", "ueber", "über", "unter", "gegen",
+            "je", "pro", "statt", "ist", "sind", "wird", "werden",
+        }
+        words = cut.split(" ")
+        while len(words) > 1 and words[-1].lower().strip(" ,.;:") in dangling:
+            words.pop()
+        cut = " ".join(words)
         return cut.rstrip(" ,.;:") + "."
     return text
 


### PR DESCRIPTION
## Zweck

Setzt das Codex-Feedback aus PR #340 um (P2: „Preserve boundary words when truncating"). Codex selbst kann in diesem Repo nicht agieren (Connector-Bot: keine Codex-Umgebung konfiguriert), daher liefere ich den Fix direkt.

## Problem

Der Wortgrenzen-Schnitt in `clean()` (`scripts/generate-werkstatt-und-schnellstart-prompts.py`) hatte zwei Randfälle:
1. Endete der Schnitt **genau auf** einer Wortgrenze, wurde trotzdem auf das vorletzte Wort zurückgeschnitten — vollständige Grenzwörter gingen verloren.
2. Endete der Schnitt mitten in einem Wort, konnte das Zurückschneiden eine **hängende Konjunktion** hinterlassen („…Prüfpunkten, Risiken **und**. Output:") — genau die von Codex per `build_werkstatt('common-law-kompass')` belegte Regression, die ein künftiger Generatorlauf in die Prompts geschrieben hätte.

## Fix

- Zurückschneiden nur noch bei echtem Mid-Word-Schnitt (letztes Zeichen des Schnitts **und** Folgezeichen im Original sind Nicht-Leerzeichen).
- Danach werden nachklappernde Funktionswörter (und, mit, der, zur, für, …) abgeworfen, sodass der gekürzte Satz auf einem Inhaltswort endet.

## Regressionstest (ausgeführt, alle grün)

- Unit: Mid-Word-Schnitt → „…Risiken." | Schnitt exakt vor Leerzeichen → „…und naechstem." | Schnitt auf Leerzeichen → „…und naechstem."
- Real: `build_werkstatt()` für **common-law-kompass** und **sozialversicherungsstatus-pruefer** (Codex' Beispiele) — keine Mid-Word-Schnitte, keine hängenden Funktionswörter.

Nur Skript-Änderung; keine generierten Artefakte betroffen, daher kein Versions-Bump (Errata wie #339).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXnmkjavncPDoNYycYaC5G)_