### PR TITLE
v434.1.0: Rubric der Oldenburger Erbrechtsakte auf das Eval-Schema umgestellt

### DIFF
--- a/testakten/erbrecht-vertragserbe-schenkungen-erbvertrag-oldenburg/rubric.yaml
+++ b/testakten/erbrecht-vertragserbe-schenkungen-erbvertrag-oldenburg/rubric.yaml
@@ -1,77 +1,100 @@
 name: erbrecht-vertragserbe-schenkungen-erbvertrag-oldenburg
-beschreibung: >
-  Berufungsverfahren vor dem OLG Oldenburg (8 U 63/26) nach teilweise
-  stattgebendem Urteil des LG Oldenburg (5 O 458/25): Der Sohn ist
-  vertragsmaessig eingesetzter Schlusserbe aus einem Erbvertrag mit nie
-  ausgeuebtem Ruecktrittsvorbehalt; der Erblasser wandte der Tochter
-  lebzeitig die Hofstelle (gegen Wohnungsrecht und Pflegeversprechen),
-  ein Baugrundstueck und Geldbetraege zu. Waehrend des Berufungsverfahrens
-  veroeffentlicht der BGH die Entscheidungsgruende IV ZR 256/25 zum
-  Ruecktrittsvorbehalt; der Senat weist darauf hin und setzt eine
-  Stellungnahmefrist. Zu fertigen sind Stellungnahme, Berufungserwiderung
-  und Begruendung der Anschlussberufung.
-pruefpunkte:
+plugin: "fachanwalt-erbrecht"
+description: 'Berufungsverfahren vor dem OLG Oldenburg (8 U 63/26) nach teilweise stattgebendem Urteil des
+  LG Oldenburg (5 O 458/25): Der Sohn ist vertragsmaessig eingesetzter Schlusserbe aus einem Erbvertrag mit
+  nie ausgeuebtem Ruecktrittsvorbehalt; der Erblasser wandte der Tochter lebzeitig die Hofstelle (gegen
+  Wohnungsrecht und Pflegeversprechen), ein Baugrundstueck und Geldbetraege zu. Waehrend des
+  Berufungsverfahrens veroeffentlicht der BGH die Entscheidungsgruende IV ZR 256/25 zum
+  Ruecktrittsvorbehalt; der Senat weist darauf hin und setzt eine Stellungnahmefrist. Zu fertigen sind
+  Stellungnahme, Berufungserwiderung und Begruendung der Anschlussberufung.'
+checks:
+  - id: datei-01-mandatsnotiz
+    check_type: file_exists
+    description: Die Mandatsnotiz mit Beteiligten, Verfahrensstand und Fristen ist vorhanden.
+    path: 01_mandatsnotiz_berufung.docx
+  - id: datei-02-erbvertrag
+    check_type: file_exists
+    description: Der vollstaendige Erbvertrag von 2008 mit Ruecktrittsvorbehalt ist vorhanden.
+    path: 02_erbvertrag_2008.docx
+  - id: datei-03-uebergabevertrag
+    check_type: file_exists
+    description: Der vollstaendige Uebergabevertrag ueber die Hofstelle ist vorhanden.
+    path: 03_uebergabevertrag_hofstelle_2021.docx
+  - id: datei-05-lg-urteil
+    check_type: file_exists
+    description: Das Urteil des LG Oldenburg 5 O 458/25 ist vorhanden.
+    path: 05_lg_oldenburg_urteil_2026-03-12.docx
+  - id: datei-06-berufungsbegruendung
+    check_type: file_exists
+    description: Die Berufungsbegruendung der Beklagten ist vorhanden.
+    path: 06_berufungsbegruendung_beklagte_2026-05-18.docx
+  - id: datei-10-olg-hinweis
+    check_type: file_exists
+    description: Die Hinweisverfuegung des OLG Oldenburg 8 U 63/26 ist vorhanden.
+    path: 10_olg_hinweisverfuegung_2026-07-16.docx
+  - id: datenkern-autokauf-buchung
+    check_type: text_contains
+    description: Der Datenkern enthaelt die als Darlehen reklamierte Buchung vom 14.02.2022 ueber 20000 EUR.
+    path: 07_geldzuwendungen_konto_2020_2023.csv
+    contains: "2022-02-14,20000.00,Autokauf Silke"
+  - id: datenkern-pflegedienst-lastschrift
+    check_type: text_contains
+    description: Die Pflegedienst-Rechnungen weisen die Lastschrift vom Konto des Erblassers aus.
+    path: 08_pflegedienst_rechnungen_2022_2024.csv
+    contains: "Lastschrift,Heinrich Terborg"
+  - id: newsletter-bgh-aktenzeichen
+    check_type: text_contains
+    description: Der Newsletter fuehrt die BGH-Entscheidung IV ZR 256/25 in das Verfahren ein.
+    path: eml/01_newsletter_bgh_vertragserbe_2026-07-08.eml
+    contains: "IV ZR 256/25"
+  - id: mindestbestand-arbeitsdateien
+    check_type: working_file_count
+    description: Die Akte enthaelt mindestens zwoelf exportierbare Arbeitsdateien.
+    min: 12
   - id: p1-datenkern-geldzuwendungen
-    beschreibung: >
-      Datenauswertungs-Kern - Aus 07_geldzuwendungen_konto_2020_2023.csv ist
-      der Umfang der Geldzuwendungen selbststaendig zu ermitteln und dem
-      Hilfsvorbringen der Beklagten (Berufungsbegruendung Ziffer 4,
-      E-Mail der Gegenanwaeltin vom 17.07.2026) gegenueberzustellen.
-    erwartung: >
-      Der Bearbeiter errechnet aus den zwoelf Buchungen die Gesamtsumme von
-      152.000 EUR, erkennt, dass die als Darlehen reklamierten Positionen
-      (14.02.2022 ueber 20.000 EUR und 30.06.2022 ueber 15.000 EUR) im
-      Verwendungszweck nicht als Darlehen bezeichnet sind und weder Zins-
-      noch Rueckzahlungsspur haben, und dass die behaupteten 22.000 EUR
-      Anlassgeschenke mit den tatsaechlich als Weihnachten bezeichneten
-      Buchungen (dreimal 12.000 EUR, zusammen 36.000 EUR) nicht
-      zusammenpassen; die Gegenrechnung 152.000 minus 35.000 minus 22.000
-      gleich 95.000 wird als rechnerisch stimmig, aber tatsaechlich
-      unbelegt eingeordnet.
+    check_type: human_review
+    description: Datenauswertungs-Kern - Aus 07_geldzuwendungen_konto_2020_2023.csv ist der Umfang der
+      Geldzuwendungen selbststaendig zu ermitteln und dem Hilfsvorbringen der Beklagten
+      (Berufungsbegruendung Ziffer 4, E-Mail der Gegenanwaeltin vom 17.07.2026) gegenueberzustellen.
+    note: Der Bearbeiter errechnet aus den zwoelf Buchungen die Gesamtsumme von 152.000 EUR, erkennt, dass
+      die als Darlehen reklamierten Positionen (14.02.2022 ueber 20.000 EUR und 30.06.2022 ueber 15.000 EUR)
+      im Verwendungszweck nicht als Darlehen bezeichnet sind und weder Zins- noch Rueckzahlungsspur haben,
+      und dass die behaupteten 22.000 EUR Anlassgeschenke mit den tatsaechlich als Weihnachten bezeichneten
+      Buchungen (dreimal 12.000 EUR, zusammen 36.000 EUR) nicht zusammenpassen; die Gegenrechnung 152.000
+      minus 35.000 minus 22.000 gleich 95.000 wird als rechnerisch stimmig, aber tatsaechlich unbelegt
+      eingeordnet.
   - id: p2-ruecktrittsvorbehalt-bgh
-    beschreibung: >
-      Das zentrale Berufungsargument (bereits der nicht ausgeuebte
-      Ruecktrittsvorbehalt lasse die schutzwuerdige Erberwartung entfallen)
-      ist anhand der ueber den Newsletter eingefuehrten BGH-Entscheidung
-      IV ZR 256/25 zu behandeln.
-    erwartung: >
-      Der Bearbeiter arbeitet heraus, dass nach der neuen BGH-Linie die
-      erbvertragliche Bindung trotz vorbehaltenen Ruecktrittsrechts
-      grundsaetzlich bestehen bleibt, solange der Ruecktritt nicht wirksam
-      erklaert wurde, und wendet dies auf Ziffer 6 des Erbvertrags an
-      (kein Ruecktritt bis zum Erbfall). Er zitiert die Entscheidung nur
-      nach der bereitgestellten Quelle, empfiehlt die Verifikation des
-      Volltexts in der Entscheidungsdatenbank des Bundesgerichtshofs und
-      erfindet keine weiteren Fundstellen.
+    check_type: human_review
+    description: Das zentrale Berufungsargument (bereits der nicht ausgeuebte Ruecktrittsvorbehalt lasse
+      die schutzwuerdige Erberwartung entfallen) ist anhand der ueber den Newsletter eingefuehrten
+      BGH-Entscheidung IV ZR 256/25 zu behandeln.
+    note: Der Bearbeiter arbeitet heraus, dass nach der neuen BGH-Linie die erbvertragliche Bindung trotz
+      vorbehaltenen Ruecktrittsrechts grundsaetzlich bestehen bleibt, solange der Ruecktritt nicht wirksam
+      erklaert wurde, und wendet dies auf Ziffer 6 des Erbvertrags an (kein Ruecktritt bis zum Erbfall).
+      Er zitiert die Entscheidung nur nach der bereitgestellten Quelle, empfiehlt die Verifikation des
+      Volltexts in der Entscheidungsdatenbank des Bundesgerichtshofs und erfindet keine weiteren
+      Fundstellen.
   - id: p3-hofstelle-eigeninteresse
-    beschreibung: >
-      Fuer die Anschlussberufung ist das lebzeitige Eigeninteresse bei der
-      Hofstellen-Uebertragung anhand der tatsaechlichen Durchfuehrung zu
-      pruefen (Uebergabevertrag Ziffer 4, Pflegedienst-Rechnungen,
-      Chatverlauf, Kurzgutachten).
-    erwartung: >
-      Der Bearbeiter stellt dem Pflegeversprechen der Beklagten die
-      Rechnungen des Pflegedienstes Huntetal gegenueber (Grundpflege ab
-      Maerz 2022, bezahlt per Lastschrift vom Konto des Erblassers, mit
-      steigendem Umfang bis 2024), wertet die Chataeusserungen vom
-      19.04.2021 und 28.03.2022 als Indizien und setzt die Wertrelation
-      aus dem Kurzgutachten (Verkehrswert 468.000 EUR gegen kapitalisiertes
-      Wohnungsrecht 61.000 EUR und Pflegewert 34.000 EUR) in Beziehung,
-      ohne dem Gericht eine sichere Tatsachenwuerdigung vorwegzunehmen.
+    check_type: human_review
+    description: Fuer die Anschlussberufung ist das lebzeitige Eigeninteresse bei der
+      Hofstellen-Uebertragung anhand der tatsaechlichen Durchfuehrung zu pruefen (Uebergabevertrag
+      Ziffer 4, Pflegedienst-Rechnungen, Chatverlauf, Kurzgutachten).
+    note: Der Bearbeiter stellt dem Pflegeversprechen der Beklagten die Rechnungen des Pflegedienstes
+      Huntetal gegenueber (Grundpflege ab Maerz 2022, bezahlt per Lastschrift vom Konto des Erblassers,
+      mit steigendem Umfang bis 2024), wertet die Chataeusserungen vom 19.04.2021 und 28.03.2022 als
+      Indizien und setzt die Wertrelation aus dem Kurzgutachten (Verkehrswert 468.000 EUR gegen
+      kapitalisiertes Wohnungsrecht 61.000 EUR und Pflegewert 34.000 EUR) in Beziehung, ohne dem Gericht
+      eine sichere Tatsachenwuerdigung vorwegzunehmen.
   - id: p4-frist-und-verfahrensrecht
-    beschreibung: >
-      Fristen und verfahrensrechtliche Lage sind korrekt zu erfassen.
-    erwartung: >
-      Der Bearbeiter notiert die Stellungnahmefrist zum 14.08.2026 und den
-      Termin am 29.09.2026, prueft die Dreijahresfrist des Paragrafen 2287
-      Absatz 2 BGB (Erbfall 05.09.2024, Klageerhebung 27.02.2025) und
-      behandelt die Anschlussberufung sowie den Beweisantritt der
-      Gegenseite (Zeugin Lammers) verfahrensgerecht.
+    check_type: human_review
+    description: Fristen und verfahrensrechtliche Lage sind korrekt zu erfassen.
+    note: Der Bearbeiter notiert die Stellungnahmefrist zum 14.08.2026 und den Termin am 29.09.2026,
+      prueft die Dreijahresfrist des Paragrafen 2287 Absatz 2 BGB (Erbfall 05.09.2024, Klageerhebung
+      27.02.2025) und behandelt die Anschlussberufung sowie den Beweisantritt der Gegenseite
+      (Zeugin Lammers) verfahrensgerecht.
   - id: p5-formalien-und-ausformulierung
-    beschreibung: >
-      Formale Anforderungen an die Arbeitsprodukte.
-    erwartung: >
-      Stellungnahme, Berufungserwiderung und Anschlussberufungsbegruendung
-      werden vollstaendig ausformuliert in ganzen Saetzen mit dezimaler
-      Gliederung geliefert; Aktenzeichen und Fundstellen stammen
-      ausschliesslich aus der Akte, Unsicherheiten werden gekennzeichnet.
+    check_type: human_review
+    description: Formale Anforderungen an die Arbeitsprodukte.
+    note: Stellungnahme, Berufungserwiderung und Anschlussberufungsbegruendung werden vollstaendig
+      ausformuliert in ganzen Saetzen mit dezimaler Gliederung geliefert; Aktenzeichen und Fundstellen
+      stammen ausschliesslich aus der Akte, Unsicherheiten werden gekennzeichnet.


### PR DESCRIPTION
## Ziel

Folge-Fix zu #357: Der Release-Lauf für v434.1.0 scheiterte am Eval-Harness (`run-eval.py`), weil die `rubric.yaml` der neuen Oldenburger Erbrechtsakte noch das alte Prosa-Format nutzte (`[FAIL] erbrecht-vertragserbe-schenkungen-erbvertrag-oldenburg (0/2 pass)` — fehlendes `plugin`-Feld und fehlende `checks`-Liste).

## Änderung

Die Rubric ist auf das maschinenprüfbare v434-Schema umgestellt: `plugin: fachanwalt-erbrecht` plus 15 `checks` — sechs `file_exists` für die Kernaktenstücke, drei `text_contains` (Darlehens-Buchung im Datenkern, Lastschrift vom Erblasserkonto in den Pflegedienst-Rechnungen, BGH-Aktenzeichen im Newsletter), ein `working_file_count` (min 12) und fünf `human_review`-Prüfpunkte mit den inhaltlichen Erwartungen (Datenkern-Nachrechnung, BGH-Anwendung, Eigeninteresse Hofstelle, Fristen, Ausformulierungspflicht).

## Qualitätssicherung

- `run-eval.py` für die Akte: **10/10 pass, 5 human_review-Skips**.
- Gesamtlauf wie im CI (`run-eval.py --quiet`): **304 Testakten, 302 mit Rubric, All-Pass 302, Fail 0**.

Nach dem Merge wird das Release mit Tag v434.1.0 erneut angestoßen (der fehlgeschlagene Lauf hatte noch keinen Tag erzeugt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXnmkjavncPDoNYycYaC5G

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXnmkjavncPDoNYycYaC5G)_