### PR TITLE
README-Hauptverzeichnis alphabetisch vervollständigen

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,25 @@ Ziel ist es, zu zeigen, wie sich Plugins und Skills für Arbeitsrecht, Gesellsch
 
 > **Cowork mit eigenem Modellzugang:** Wenn du die Plugins in einer Cowork-Oberfläche über eine eigene Schnittstelle, einen Gateway-Anbieter oder einen Enterprise-Proxy nutzen willst, spring direkt zu [Eigene Schnittstelle oder Zwischenanbieter anbinden](#eigene-schnittstelle-oder-zwischenanbieter-anbinden-stand-juli-2026).
 
-## Direktnavigation
+## Alle vollständigen Listen von A bis Z
 
-| Gesucht | Direkter Weg |
-| --- | --- |
-| Alle Plugins von A bis Z | [Plugin-Katalog](#was-ist-drin) · [Download-Index mit Einzel-ZIPs](./ASSET_INDEX.md) · [Rechtsgebietsübersicht](./references/rechtsgebiete-uebersicht.md) |
-| Alle Skills, nach Plugin und Name sortiert | [Skill-Gesamtübersicht](./SKILLS.md) · [Detailseiten je Plugin](./skills-index/) |
-| Alle ausführlichen Werkstatt-Prompts | [Werkstatt-Liste mit Markdown-Direktdownloads](./docs/werkstatt-und-schnellstart-coverage.md#werkstatt-prompts) · [kuratierte Promptliste](./PROMPTLISTE.md) |
-| Alle kompakten Schnellstart-Prompts | [Schnellstart-Liste mit Markdown-Direktdownloads](./docs/werkstatt-und-schnellstart-coverage.md#schnellstart-prompts) |
-| Alle Testakten von A bis Z | [Testakten-Übersicht mit drei Downloadformaten](./testakten/README.md) · [Qualitätsstandard](./testakten/QUALITAETSSTANDARD.md) |
-| Installation und Fehlersuche | [Schnellstart](#schnellstart) · [einfache Installationshilfe](./INSTALLATION_EINFACH.md) · [Kurzanleitung](./QUICKSTART.md) |
-| Sämtliche Release-Dateien und Prüfsummen | [aktueller Release](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest) · [vollständiger Asset-Index](./ASSET_INDEX.md) |
-| English explanation | [English quick guide](#english-quick-guide) |
+<!-- BEGIN HAUPTVERZEICHNIS (auto-generated) -->
+Die fünf vollständigen Register sind alphabetisch sortiert und werden bei jedem Release gegen Marketplace und Dateibestand geprüft. Jede Liste nennt zu jedem Eintrag eine Kurzbeschreibung und führt von dort unmittelbar zur Datei, zum Download oder zur passenden Detailseite.
+
+| Bestand | Umfang | Kurzbeschreibung | Vollständige alphabetische Liste |
+| --- | ---: | --- | --- |
+| **Plugins** | 235 | Installierbare Pakete für Rechtsgebiete und Arbeitsbereiche; jede Zeile beschreibt Zweck und fachlichen Zuschnitt. | [Plugin-Katalog mit Kurzbeschreibungen](#was-ist-drin) · [ZIPs und Einzeldateien](./ASSET_INDEX.md) |
+| **Skills** | 26461 | Eng abgegrenzte Arbeitsabläufe; die Detailseiten führen jeden Skill mit Kurzbeschreibung und einzelnem Markdown-Download auf. | [Skill-Gesamtübersicht](./SKILLS.md) · [Detailseiten je Plugin](./skills-index/) |
+| **Werkstatt-Prompts** | 235 | Ausführliche eigenständige Arbeitsmodi für komplexe Vorgänge; je Plugin mit Kurzbeschreibung und direktem Markdown-Download. | [Werkstatt-Prompts von A bis Z](./docs/werkstatt-und-schnellstart-coverage.md#werkstatt-prompts) |
+| **Schnellstart-/Mini-Prompts** | 235 | Kompakte eigenständige Einstiege für den Kernworkflow und ein erstes belastbares Arbeitsprodukt. | [Schnellstart-Prompts von A bis Z](./docs/werkstatt-und-schnellstart-coverage.md#schnellstart-prompts) |
+| **Testakten** | 302 zentral / 305 gesamt | Praxisnahe Dokumentensammlungen; jede Zeile skizziert den Fall, nennt passende Plugins und bietet drei Downloadformen. Drei weitere Akten liegen unmittelbar bei ihren Plugins. | [Zentrale Testakten mit Kurzbeschreibungen von A bis Z](./testakten/README.md#verfügbare-akten) · [pluginlokale Akten über den Plugin-Katalog](#was-ist-drin) |
+
+Sortierlogik: Plugins, Werkstatt- und Schnellstart-Prompts folgen dem Plugin-Slug; Skills sind zuerst nach Plugin und dort nach Skill-Slug sortiert; Testakten folgen dem Aktenordner. Die großen Bestände bleiben auf eigenen, schnell ladenden Registerseiten, damit der Haupt-README trotz 26461 Skills benutzbar bleibt.
+
+Plugin-Schnellwahl: [A](#a) · [B](#b) · [C](#c) · [D](#d) · [E](#e) · [F](#f) · [G](#g) · [H](#h) · [I](#i) · [J](#j) · [K](#k) · [L](#l) · [M](#m) · [N](#n) · [O](#o) · [P](#p) · [R](#r) · [S](#s) · [T](#t) · [U](#u) · [V](#v) · [W](#w) · [Z](#z)
+<!-- END HAUPTVERZEICHNIS (auto-generated) -->
+
+Weitere direkte Wege: [Schnellstart](#schnellstart) · [einfache Installationshilfe](./INSTALLATION_EINFACH.md) · [Kurzanleitung](./QUICKSTART.md) · [kuratierte Promptliste](./PROMPTLISTE.md) · [Rechtsgebietsübersicht](./references/rechtsgebiete-uebersicht.md) · [aktueller Release](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest) · [English quick guide](#english-quick-guide)
 
 ### Bitte mit-testen und Feedback geben
 
@@ -767,6 +774,6 @@ This repository provides a large German-law plugin and skill collection for prac
 
 **Click behaviour:** README, index and overview links remain normal GitHub navigation pages. Links labelled **Download MD** save the unchanged Markdown work file instead of opening a source preview. Individual skills receive a unique plugin-and-skill filename so that multiple downloads do not overwrite one another.
 
-Start with the [plugin catalogue](#was-ist-drin), the [complete skill index](./SKILLS.md), the [workshop and quick-start index](./docs/werkstatt-und-schnellstart-coverage.md), or the [latest release](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest).
+All five complete indexes are alphabetically sorted and provide a short description for every plugin, skill, workshop prompt, quick-start prompt or practice file. Start with the [five A-to-Z indexes](#alle-vollständigen-listen-von-a-bis-z), the [plugin catalogue](#was-ist-drin), the [complete skill index](./SKILLS.md), the [workshop and quick-start index](./docs/werkstatt-und-schnellstart-coverage.md), the [practice-file index](./testakten/README.md), or the [latest release](https://github.com/Klotzkette/claude-fuer-deutsches-recht/releases/latest).
 
 The material is experimental and does not replace legal advice. Every output must be checked by a qualified human against current statutes, official materials and independently verifiable court decisions. Do not upload confidential client data unless the technical setup, professional duties and data-protection framework permit it.

--- a/scripts/generate-root-plugin-catalog.py
+++ b/scripts/generate-root-plugin-catalog.py
@@ -8,13 +8,17 @@ import re
 from pathlib import Path
 
 from readme_display import display_prose
+from testakte_zip_common import working_dump_flat_pairs
 
 
 REPO = Path(__file__).resolve().parent.parent
 MARKETPLACE = REPO / ".claude-plugin" / "marketplace.json"
 README = REPO / "README.md"
+DIRECTORY_BEGIN = "<!-- BEGIN HAUPTVERZEICHNIS (auto-generated) -->"
+DIRECTORY_END = "<!-- END HAUPTVERZEICHNIS (auto-generated) -->"
 BEGIN = "<!-- BEGIN PLUGIN-KATALOG (auto-generated) -->"
 END = "<!-- END PLUGIN-KATALOG (auto-generated) -->"
+SKIP_TESTAKTEN = {"formatvorlagen-paradebeispiele", "megaprompts"}
 
 
 def source_rel(plugin: dict) -> str:
@@ -41,6 +45,77 @@ def display_description(plugin: dict) -> str:
 def group_label(name: str) -> str:
     first = name[:1].upper()
     return first if first.isalpha() else "0-9"
+
+
+def inventory_counts(plugins: list[dict]) -> dict[str, int]:
+    skills = 0
+    werkstatt = 0
+    schnellstart = 0
+    pluginlocal_testakten = 0
+    for plugin in plugins:
+        directory = REPO / source_rel(plugin)
+        skills += sum(1 for _ in (directory / "skills").glob("*/SKILL.md"))
+        name = plugin["name"]
+        werkstatt += int((directory / f"{name}-werkstatt.md").is_file())
+        schnellstart += int((directory / f"{name}-schnellstart.md").is_file())
+        testakte = directory / "testakte"
+        if testakte.is_dir() and working_dump_flat_pairs(
+            testakte,
+            include_gesamt_pdf=False,
+        ):
+            pluginlocal_testakten += 1
+
+    central_testakten = sum(
+        1
+        for child in (REPO / "testakten").iterdir()
+        if child.is_dir() and child.name not in SKIP_TESTAKTEN
+    )
+    return {
+        "plugins": len(plugins),
+        "skills": skills,
+        "werkstatt": werkstatt,
+        "schnellstart": schnellstart,
+        "central_testakten": central_testakten,
+        "testakten": central_testakten + pluginlocal_testakten,
+    }
+
+
+def build_directory(plugins: list[dict]) -> str:
+    counts = inventory_counts(plugins)
+    labels = sorted({group_label(plugin["name"]) for plugin in plugins})
+    plugin_navigation = " · ".join(
+        f"[{label}](#{label.lower()})" for label in labels
+    )
+    return "\n".join(
+        [
+            DIRECTORY_BEGIN,
+            "Die fünf vollständigen Register sind alphabetisch sortiert und werden bei jedem Release gegen Marketplace und Dateibestand geprüft. Jede Liste nennt zu jedem Eintrag eine Kurzbeschreibung und führt von dort unmittelbar zur Datei, zum Download oder zur passenden Detailseite.",
+            "",
+            "| Bestand | Umfang | Kurzbeschreibung | Vollständige alphabetische Liste |",
+            "| --- | ---: | --- | --- |",
+            f"| **Plugins** | {counts['plugins']} | Installierbare Pakete für Rechtsgebiete und Arbeitsbereiche; jede Zeile beschreibt Zweck und fachlichen Zuschnitt. | [Plugin-Katalog mit Kurzbeschreibungen](#was-ist-drin) · [ZIPs und Einzeldateien](./ASSET_INDEX.md) |",
+            f"| **Skills** | {counts['skills']} | Eng abgegrenzte Arbeitsabläufe; die Detailseiten führen jeden Skill mit Kurzbeschreibung und einzelnem Markdown-Download auf. | [Skill-Gesamtübersicht](./SKILLS.md) · [Detailseiten je Plugin](./skills-index/) |",
+            f"| **Werkstatt-Prompts** | {counts['werkstatt']} | Ausführliche eigenständige Arbeitsmodi für komplexe Vorgänge; je Plugin mit Kurzbeschreibung und direktem Markdown-Download. | [Werkstatt-Prompts von A bis Z](./docs/werkstatt-und-schnellstart-coverage.md#werkstatt-prompts) |",
+            f"| **Schnellstart-/Mini-Prompts** | {counts['schnellstart']} | Kompakte eigenständige Einstiege für den Kernworkflow und ein erstes belastbares Arbeitsprodukt. | [Schnellstart-Prompts von A bis Z](./docs/werkstatt-und-schnellstart-coverage.md#schnellstart-prompts) |",
+            f"| **Testakten** | {counts['central_testakten']} zentral / {counts['testakten']} gesamt | Praxisnahe Dokumentensammlungen; jede Zeile skizziert den Fall, nennt passende Plugins und bietet drei Downloadformen. Drei weitere Akten liegen unmittelbar bei ihren Plugins. | [Zentrale Testakten mit Kurzbeschreibungen von A bis Z](./testakten/README.md#verfügbare-akten) · [pluginlokale Akten über den Plugin-Katalog](#was-ist-drin) |",
+            "",
+            f"Sortierlogik: Plugins, Werkstatt- und Schnellstart-Prompts folgen dem Plugin-Slug; Skills sind zuerst nach Plugin und dort nach Skill-Slug sortiert; Testakten folgen dem Aktenordner. Die großen Bestände bleiben auf eigenen, schnell ladenden Registerseiten, damit der Haupt-README trotz {counts['skills']} Skills benutzbar bleibt.",
+            "",
+            f"Plugin-Schnellwahl: {plugin_navigation}",
+            DIRECTORY_END,
+        ]
+    )
+
+
+def replace_directory(text: str, directory: str) -> str:
+    if DIRECTORY_BEGIN not in text or DIRECTORY_END not in text:
+        raise RuntimeError("Hauptverzeichnis-Markierungen in README.md fehlen")
+    pattern = re.compile(
+        re.escape(DIRECTORY_BEGIN)
+        + r"[\s\S]*?"
+        + re.escape(DIRECTORY_END)
+    )
+    return pattern.sub(directory, text, count=1)
 
 
 def build_catalog(plugins: list[dict]) -> str:
@@ -94,9 +169,13 @@ def main() -> int:
     marketplace = json.loads(MARKETPLACE.read_text(encoding="utf-8"))
     plugins = marketplace["plugins"]
     original = README.read_text(encoding="utf-8")
-    updated = replace_catalog(original, build_catalog(plugins))
+    updated = replace_directory(original, build_directory(plugins))
+    updated = replace_catalog(updated, build_catalog(plugins))
     README.write_text(updated, encoding="utf-8")
-    print(f"README.md: vollständiger A-Z-Katalog mit {len(plugins)} Plugins.")
+    print(
+        "README.md: Hauptverzeichnis und vollständiger A-Z-Katalog "
+        f"mit {len(plugins)} Plugins."
+    )
     return 0
 
 

--- a/scripts/validate-root-readme-overview.py
+++ b/scripts/validate-root-readme-overview.py
@@ -16,6 +16,8 @@ MARKETPLACE = REPO / PLUGIN_META_DIR / "marketplace.json"
 SKIP_TESTAKTEN = {"formatvorlagen-paradebeispiele", "megaprompts"}
 CATALOG_BEGIN = "<!-- BEGIN PLUGIN-KATALOG (auto-generated) -->"
 CATALOG_END = "<!-- END PLUGIN-KATALOG (auto-generated) -->"
+DIRECTORY_BEGIN = "<!-- BEGIN HAUPTVERZEICHNIS (auto-generated) -->"
+DIRECTORY_END = "<!-- END HAUPTVERZEICHNIS (auto-generated) -->"
 DOWNLOAD_BASE = "https://klotzkette.github.io/claude-fuer-deutsches-recht/download.html?path="
 
 
@@ -32,9 +34,14 @@ def count_values(marketplace: dict) -> dict[str, int | str]:
     plugins = marketplace["plugins"]
     skill_files = []
     pluginlocal_testakten = []
+    werkstatt = 0
+    schnellstart = 0
     for plugin in plugins:
         directory = plugin_source(plugin)
         skill_files.extend((directory / "skills").glob("*/SKILL.md"))
+        name = plugin["name"]
+        werkstatt += int((directory / f"{name}-werkstatt.md").is_file())
+        schnellstart += int((directory / f"{name}-schnellstart.md").is_file())
         testakte = directory / "testakte"
         if testakte.is_dir() and working_dump_flat_pairs(testakte, include_gesamt_pdf=False):
             pluginlocal_testakten.append(testakte)
@@ -51,6 +58,8 @@ def count_values(marketplace: dict) -> dict[str, int | str]:
     return {
         "plugins": len(plugins),
         "skills": len(skill_files),
+        "werkstatt": werkstatt,
+        "schnellstart": schnellstart,
         "central_testakten": len(central_testakten),
         "testakten": len(central_testakten) + len(pluginlocal_testakten),
         "version": f"v{marketplace['version']}",
@@ -206,6 +215,67 @@ def check_root_readme(values: dict[str, int | str]) -> list[str]:
     return errors
 
 
+def check_root_directory(values: dict[str, int | str]) -> list[str]:
+    readme = (REPO / "README.md").read_text(encoding="utf-8")
+    errors: list[str] = []
+    if DIRECTORY_BEGIN not in readme or DIRECTORY_END not in readme:
+        return ["README Hauptverzeichnis: Generator-Markierungen fehlen"]
+    directory = readme.split(DIRECTORY_BEGIN, 1)[1].split(DIRECTORY_END, 1)[0]
+
+    if "| Bestand | Umfang | Kurzbeschreibung | Vollständige alphabetische Liste |" not in directory:
+        errors.append("README Hauptverzeichnis: erklärende Tabellenspalten fehlen")
+
+    expected_counts = {
+        "Plugins": int(values["plugins"]),
+        "Skills": int(values["skills"]),
+        "Werkstatt-Prompts": int(values["werkstatt"]),
+        "Schnellstart-/Mini-Prompts": int(values["schnellstart"]),
+    }
+    for label, expected in expected_counts.items():
+        match = re.search(
+            rf"^\| \*\*{re.escape(label)}\*\* \| (\d+) \|",
+            directory,
+            re.MULTILINE,
+        )
+        if not match:
+            errors.append(f"README Hauptverzeichnis: {label} fehlt")
+        elif int(match.group(1)) != expected:
+            errors.append(
+                f"README Hauptverzeichnis: {label} {match.group(1)} statt {expected}"
+            )
+
+    testakten = re.search(
+        r"^\| \*\*Testakten\*\* \| (\d+) zentral / (\d+) gesamt \|",
+        directory,
+        re.MULTILINE,
+    )
+    if not testakten:
+        errors.append("README Hauptverzeichnis: Testakten fehlen")
+    elif (
+        int(testakten.group(1)) != values["central_testakten"]
+        or int(testakten.group(2)) != values["testakten"]
+    ):
+        errors.append("README Hauptverzeichnis: Testakten-Zählung ist veraltet")
+
+    required_links = [
+        "#was-ist-drin",
+        "./ASSET_INDEX.md",
+        "./SKILLS.md",
+        "./skills-index/",
+        "./docs/werkstatt-und-schnellstart-coverage.md#werkstatt-prompts",
+        "./docs/werkstatt-und-schnellstart-coverage.md#schnellstart-prompts",
+        "./testakten/README.md#verfügbare-akten",
+    ]
+    for target in required_links:
+        if f"]({target})" not in directory:
+            errors.append(f"README Hauptverzeichnis: Link fehlt: {target}")
+
+    rows = re.findall(r"^\| \*\*[^|]+\*\* \|", directory, re.MULTILINE)
+    if len(rows) != 5:
+        errors.append(f"README Hauptverzeichnis: {len(rows)} statt 5 Registerzeilen")
+    return errors
+
+
 def check_generated_overviews(values: dict[str, int | str]) -> list[str]:
     errors: list[str] = []
 
@@ -255,6 +325,7 @@ def main() -> int:
     values = count_values(marketplace)
     errors = (
         check_root_readme(values)
+        + check_root_directory(values)
         + check_generated_overviews(values)
         + check_sorted_inventories(marketplace)
     )
@@ -265,7 +336,10 @@ def main() -> int:
     print(
         "validate-root-readme-overview OK "
         f"({values['plugins']} Plugins, {values['skills']} Skills, "
-        f"{values['central_testakten']} zentrale Testakten, Stand {values['version']})"
+        f"{values['werkstatt']} Werkstatt-Prompts, "
+        f"{values['schnellstart']} Schnellstart-Prompts, "
+        f"{values['central_testakten']} zentrale / {values['testakten']} Testakten gesamt, "
+        f"Stand {values['version']})"
     )
     return 0
 


### PR DESCRIPTION
## Änderungen

- prominentes Hauptverzeichnis für Plugins, Skills, Werkstatt-, Schnellstart- und Testaktenregister
- aktuelle Bestandszahlen, Kurzbeschreibungen, Sortierlogik und direkte A–Z-Ziele
- automatische Aktualisierung über den vorhandenen README-Generator
- Validator prüft künftig Zähler, Registerzeilen und sämtliche Zielverweise
- englischer Kurzführer verweist ebenfalls auf alle fünf Register

## Prüfung

- Root-Übersicht und alphabetische Vollständigkeit grün
- README-Links und Anker grün
- Plugin-Struktur und Marketplace-Import grün
- Markdown-Struktur, Frontmatter und Release-Bereitschaft grün
- Generator idempotent