### PR TITLE
chore: add missing READMEs and fix testakte PDF link

### DIFF
--- a/recherche/README.md
+++ b/recherche/README.md
@@ -1,0 +1,11 @@
+# Recherche
+
+Dieses Verzeichnis sammelt Plugins und Hilfsmittel für juristische Recherchearbeiten.
+
+## Inhalt
+
+- `beamtenrecht-und-richterrecht/` — Recherche-Skills und Quellen für Beamtenrecht und Richterrecht.
+
+## Zweck
+
+Die Plugins in diesem Bereich unterstützen gezielte Rechercheaufgaben, etwa das Zusammentragen von Rechtsprechung, Gesetzestexten und Fachliteratur für spezielle Berufsgruppen.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,15 @@
+# Tests
+
+Dieses Verzeichnis enthält Test- und Qualitätssicherungsdateien für das Repository.
+
+## Inhalt
+
+- `smoke-tests.md` — Smoke-Tests zur schnellen Prüfung wichtiger Repository-Strukturen und Invarianten.
+
+## Zweck
+
+Die Smoke-Tests helfen, nach Änderungen schnell zu erkennen, ob grundlegende Annahmen des Repositories noch gelten (z. B. vollständige Frontmatter, korrekte Verzeichnisstruktur).
+
+## Ausführung
+
+Die Tests werden manuell oder über die vorhandenen Validator-Scripts im `scripts/`-Verzeichnis ausgeführt.

--- a/uebersicht-fachanwaltschaften/README.md
+++ b/uebersicht-fachanwaltschaften/README.md
@@ -1,0 +1,16 @@
+# Fachanwaltschafts-Plugins
+
+Dieses Verzeichnis enthält eine übersichtliche Darstellung aller Plugins für anerkannte Fachanwaltschaften im Repository.
+
+## Inhalt
+
+- `index.html` — Statische Übersichtsseite mit Filter- und Kachelansicht aller Fachanwaltschafts-Plugins.
+- `.nojekyll` — Deaktiviert die Jekyll-Verarbeitung für GitHub Pages.
+
+## Nutzung
+
+Die `index.html` kann lokal im Browser geöffnet oder über GitHub Pages bereitgestellt werden. Sie dient als schneller Einstieg, um das passende Fachanwaltschafts-Plugin zu finden.
+
+## Struktur
+
+Die Liste der Fachanwaltschaften entspricht den offiziellen Fachanwaltsbezeichnungen nach BRAO. Jedes verlinkte Plugin enthält Skills, Referenzen und Testakten für den jeweiligen Rechtsbereich.


### PR DESCRIPTION
**Quick-Win-PR für das Repo.**\n\nÄnderungen:\n- README.md für ,  und  ergänzt, damit diese Verzeichnisse im Repo direkt erklärt sind.\n- : kaputter PDF-Link auf die korrekte Unterstrich-Version des Antrags korrigiert.\n\nKeine rechtlichen Inhalte verändert, reine Qualitäts-/Strukturarbeit.\n\nDer Branch kommt aus dem DEVDORADO-Fork.