### PR TITLE
Sichtbare Download-URLs zuverlässig prüfen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1. Links, Anker und Metadaten
 
-Links und Anker werden nun aus derselben Markdown-Struktur gelesen. Beispiele in Codeblöcken, Inline-Code und Kommentaren sowie YAML-Metadaten erzeugen weder Sprungziele noch Linkfehler. Referenzlinks, formatierte Beschriftungen und leere echte Links bleiben prüfbar. Auch die Downloadprüfung unterscheidet Beispiele von tatsächlich angebotenen Dateien. Zusätzliche Regressionen sichern beide Grenzfälle aus der Nachprüfung. Die fachlichen AML-Inhalte und Akten bleiben unverändert.
+Links und Anker werden nun aus derselben Markdown-Struktur gelesen. Beispiele in Codeblöcken, Inline-Code und Kommentaren sowie YAML-Metadaten erzeugen weder Sprungziele noch Linkfehler. Referenzlinks, formatierte Beschriftungen und leere echte Links bleiben prüfbar. Auch die Downloadprüfung unterscheidet Beispiele von tatsächlich angebotenen Dateien und erfasst ausgeschriebene URLs im Fließtext nach GitHub-Markdown-Regeln. Zusätzliche Regressionen sichern diese Grenzfälle sowie gültige, fehlende und unzulässige Downloadziele. Die fachlichen AML-Inhalte und Akten bleiben unverändert.
 
 # v444.0.2 - Echte Sprungziele statt Codebeispiele
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ reportlab>=4.0
 pypdf>=4.0
 odfpy>=1.4
 markdown-it-py>=3.0,<5
+linkify-it-py>=2.0,<3

--- a/scripts/test-readme-navigation.py
+++ b/scripts/test-readme-navigation.py
@@ -341,6 +341,44 @@ class NavigationTests(unittest.TestCase):
         self.assertEqual(NAV.markdown_links(tokens), [])
         self.assertEqual(NAV.explicit_html(tokens).destinations, ['README.md'])
 
+    def test_bare_download_urls_are_checked_in_rendered_prose(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            (root / 'uebersicht-fachanwaltschaften').mkdir()
+            (root / 'uebersicht-fachanwaltschaften/download.html').write_text(
+                'downloads/${encodedPath}; download.click()', encoding='utf-8'
+            )
+            (root / '.github/workflows').mkdir(parents=True)
+            (root / '.github/workflows/pages.yml').write_text(
+                "-name '*.md'\n_site/downloads\npath: ./_site\n", encoding='utf-8'
+            )
+            (root / 'quellen.md').write_text('# Quellen\n', encoding='utf-8')
+            readme = root / 'README.md'
+            with patch.object(NAV, 'REPO', root), patch.object(
+                NAV, 'user_facing_download_docs', return_value=[readme]
+            ):
+                for target, message in (
+                    ('quellen.md', None), ('fehlt.md', 'Downloadziel fehlt'),
+                    ('../README.md', 'unzulässiges Markdown-Downloadziel'),
+                ):
+                    with self.subTest(target=target):
+                        readme.write_text('# Downloads\n\nDirekt: ' + NAV.DOWNLOAD_BASE + target + '\n', encoding='utf-8')
+                        errors = []
+                        self.assertEqual(NAV.validate_markdown_downloads(errors), 1)
+                        if message:
+                            self.assertEqual(len(errors), 1)
+                            self.assertIn(message, errors[0])
+                        else:
+                            self.assertEqual(errors, [])
+                url = NAV.DOWNLOAD_BASE + 'fehlt.md'
+                readme.write_text(
+                    f'---\ndescription: "{url}"\n---\n# Downloads\n\n'
+                    f'```text\n{url}\n```\n\n`{url}`\n\n<!-- {url} -->\n', encoding='utf-8'
+                )
+                errors = []
+                self.assertEqual(NAV.validate_markdown_downloads(errors), 0)
+                self.assertEqual(errors, [])
+
     def test_download_targets_include_reference_markdown(self):
         for target in (
             "notariat-alltag/references/mitarbeiter-formwege.md",

--- a/scripts/validate-readme-navigation.py
+++ b/scripts/validate-readme-navigation.py
@@ -19,7 +19,7 @@ import yaml
 REPO = Path(__file__).resolve().parent.parent
 MARKETPLACE = REPO / ".claude-plugin" / "marketplace.json"
 DOWNLOAD_BASE = "https://klotzkette.github.io/claude-fuer-deutsches-recht/download.html?path="
-MARKDOWN = MarkdownIt("commonmark").enable(["table", "strikethrough"])
+MARKDOWN = MarkdownIt("gfm-like")
 
 
 class ExplicitAnchors(HTMLParser):


### PR DESCRIPTION
# 1. Sichtbare Download-URLs prüfen

## 1.1. Korrektur

Die gemeinsame Markdown-Auswertung verwendet den GitHub-nahen Modus einschließlich automatischer Verlinkung ausgeschriebener URLs. Dadurch wird auch ein im Fließtext angebotener Download auf Existenz und zulässigen Repository-Pfad geprüft. Codebeispiele, Kommentare und Metadaten bleiben ausgeschlossen.

## 1.2. Prüfung und Umfang

Eine zusätzliche End-to-End-Regression prüft gültige, fehlende und unzulässige ausgeschriebene Downloadziele sowie deren Ausschluss in Beispielen. Die Navigationstestgruppe enthält 31 Tests. Der vollständige Prüflauf umfasst weiterhin 52 Kommandos. Fachinhalte, Akten und Version 444.0.3 bleiben unverändert; der Release-Tag ist noch nicht veröffentlicht.
